### PR TITLE
Add encryption support for flow extensions

### DIFF
--- a/.changeset/flow-extension-encryption.md
+++ b/.changeset/flow-extension-encryption.md
@@ -1,0 +1,9 @@
+---
+"@wso2is/console": patch
+"@wso2is/admin.flow-extensions.v1": patch
+"@wso2is/admin.connections.v1": patch
+"@wso2is/admin.core.v1": patch
+"@wso2is/i18n": patch
+---
+
+Add encryption support for flow extensions

--- a/features/admin.connections.v1/hooks/use-get-combined-connection-list.ts
+++ b/features/admin.connections.v1/hooks/use-get-combined-connection-list.ts
@@ -19,7 +19,7 @@
 import { RequestErrorInterface, RequestResultInterface } from "@wso2is/admin.core.v1/hooks/use-request";
 import { AuthenticatorExtensionsConfigInterface } from "@wso2is/admin.extensions.v1/configs/models";
 import useGetFlowExtension from "@wso2is/admin.flow-extensions.v1/api/use-get-flow-extension";
-import { FlowExtensionListResponseInterface } from "@wso2is/admin.flow-extensions.v1/models/flow-extension";
+import { FlowExtensionListResponseInterface, FlowExtensionTags } from "@wso2is/admin.flow-extensions.v1/models/flow-extension";
 import {
     useGetIdentityVerificationProviderList
 } from "@wso2is/admin.identity-verification-providers.v1/api/use-get-idvp-list";
@@ -108,6 +108,9 @@ export const useGetCombinedConnectionList = <Data = ConnectionInterface[], Error
         shouldFetchIdVPs && shouldFilterIdVPs()
     );
 
+    const shouldIncludeFlowExtensions: boolean = !searchInputs?.filterTags || searchInputs.filterTags.length === 0
+        || searchInputs.filterTags.includes(FlowExtensionTags.FLOW_EXTENSION);
+
     const {
         data: fetchedFlowExtensionList,
         isLoading: isFlowExtensionListFetchRequestLoading,
@@ -115,7 +118,7 @@ export const useGetCombinedConnectionList = <Data = ConnectionInterface[], Error
         error: flowExtensionListFetchRequestError,
         mutate: mutateFlowExtensionListFetchRequest
     } = useGetFlowExtension<FlowExtensionListResponseInterface[], RequestErrorInterface>(
-        shouldFetchFlowExtensions
+        shouldFetchFlowExtensions && shouldIncludeFlowExtensions
     );
 
     const combinedData: ConnectionInterface[] = [];
@@ -190,6 +193,7 @@ export const useGetCombinedConnectionList = <Data = ConnectionInterface[], Error
                     id: flowExtension.id,
                     image: flowExtension.iconUrl,
                     name: flowExtension.name,
+                    tags: [ FlowExtensionTags.FLOW_EXTENSION ],
                     type: ConnectionTypes.FLOW_EXTENSION
                 } as ConnectionInterface);
             }

--- a/features/admin.connections.v1/pages/connections.tsx
+++ b/features/admin.connections.v1/pages/connections.tsx
@@ -24,6 +24,7 @@ import { history } from "@wso2is/admin.core.v1/helpers/history";
 import { FeatureConfigInterface } from "@wso2is/admin.core.v1/models/config";
 import { AppState } from "@wso2is/admin.core.v1/store";
 import { EventPublisher } from "@wso2is/admin.core.v1/utils/event-publisher";
+import { FlowExtensionTags } from "@wso2is/admin.flow-extensions.v1/models/flow-extension";
 import {
     IdVPTemplateTags
 } from "@wso2is/admin.identity-verification-providers.v1/models/identity-verification-providers";
@@ -188,8 +189,12 @@ const ConnectionsPage: FC<ConnectionsPropsInterface> = (props: ConnectionsPropsI
             return AuthenticatorMeta.getAllowedFilterTags().includes(tag);
         });
 
+        if (hasFlowExtensionReadPermissions) {
+            _filteredTags.push(FlowExtensionTags.FLOW_EXTENSION);
+        }
+
         return _filteredTags;
-    }, [ isAuthenticatorTagsFetchRequestLoading ]);
+    }, [ isAuthenticatorTagsFetchRequestLoading, hasFlowExtensionReadPermissions ]);
 
     /**
      * Handles the `onSearchQueryClear` callback action.

--- a/features/admin.core.v1/components/add-certificate-form.tsx
+++ b/features/admin.core.v1/components/add-certificate-form.tsx
@@ -35,7 +35,7 @@ interface AddCertificateFormProps extends IdentifiableComponentInterface {
     /**
      * Flag to trigger the form submission.
      */
-    triggerSubmit: boolean;
+    triggerSubmit?: boolean;
     /**
      * Callback to handle form submission.
      *

--- a/features/admin.flow-extensions.v1/components/create/flow-extension-create-wizard.tsx
+++ b/features/admin.flow-extensions.v1/components/create/flow-extension-create-wizard.tsx
@@ -16,18 +16,24 @@
  * under the License.
  */
 
+import Alert from "@oxygen-ui/react/Alert";
+import Box from "@oxygen-ui/react/Box";
+import Divider from "@oxygen-ui/react/Divider";
+import Typography from "@oxygen-ui/react/Typography";
 import ActionEndpointConfigForm from "@wso2is/admin.actions.v1/components/action-endpoint-config-form";
 import {
     AuthenticationType,
     EndpointConfigFormPropertyInterface
 } from "@wso2is/admin.actions.v1/models/actions";
 import { validateActionEndpointFields } from "@wso2is/admin.actions.v1/util/form-field-util";
+import { AddCertificateFormComponent } from "@wso2is/admin.core.v1/components/add-certificate-form";
 import { ModalWithSidePanel } from "@wso2is/admin.core.v1/components/modals/modal-with-side-panel";
 import { AppConstants } from "@wso2is/admin.core.v1/constants/app-constants";
 import { history } from "@wso2is/admin.core.v1/helpers/history";
 import { AlertLevels, HttpErrorResponseDataInterface, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { Field, Wizard, WizardPage } from "@wso2is/forms";
+import { useTrigger } from "@wso2is/forms/legacy";
 import {
     GenericIcon,
     Heading,
@@ -40,7 +46,7 @@ import {
 import { FormValidation } from "@wso2is/validation";
 import { AxiosError } from "axios";
 import React, { FunctionComponent, MutableRefObject, ReactElement, SVGProps, useEffect, useRef, useState } from "react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { Dispatch } from "redux";
 import { Icon, Grid as SemanticGrid } from "semantic-ui-react";
@@ -116,6 +122,18 @@ const FlowExtensionCreateWizard: FunctionComponent<FlowExtensionCreateWizardProp
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
     const [ endpointAuthType, setEndpointAuthType ] = useState<AuthenticationType>(AuthenticationType.NONE);
     const [ nextShouldBeDisabled, setNextShouldBeDisabled ] = useState<boolean>(true);
+
+    // Certificate state — staged on the endpoint configuration step. The stored value is the
+    // base64-encoded PEM, ready for the API body.
+    const [ encodedCertificate, setEncodedCertificate ] = useState<string>("");
+    const [ userHasStagedCert, setUserHasStagedCert ] = useState<boolean>(false);
+    const [ triggerCertUpload, setTriggerCertUpload ] = useTrigger();
+
+    // Mirrors encodedCertificate so handleFormSubmit reads the value captured synchronously by
+    // handleCertificateSubmit (state updates are async). pendingSubmit defers the wizard submit
+    // until the staged cert has been extracted.
+    const encodedCertificateRef: MutableRefObject<string> = useRef<string>("");
+    const pendingSubmit: MutableRefObject<boolean> = useRef<boolean>(false);
 
     useEffect(() => {
         setWizardSteps([
@@ -220,6 +238,8 @@ const FlowExtensionCreateWizard: FunctionComponent<FlowExtensionCreateWizardProp
             description: values.description?.trim()
                 ? values.description
                 : FlowExtensionConstants.FLOW_EXTENSION_DEFAULT_DESCRIPTION,
+            // Read from the ref so the value captured synchronously by handleCertificateSubmit is used.
+            ...(encodedCertificateRef.current ? { encryption: { certificate: encodedCertificateRef.current } } : {}),
             ...(values.iconUrl ? { iconUrl: values.iconUrl } : {}),
             endpoint: {
                 authentication: {
@@ -248,6 +268,27 @@ const FlowExtensionCreateWizard: FunctionComponent<FlowExtensionCreateWizardProp
             })
             .catch((error: AxiosError<HttpErrorResponseDataInterface>): void => handleCreateError(error))
             .finally((): void => setIsSubmitting(false));
+    };
+
+    /**
+     * Called by AddCertificateFormComponent once the staged certificate has been extracted. Stores
+     * it on state (for the UI) and a ref (for the submit closure), and resumes a deferred wizard submit.
+     *
+     * @param value - Base64-encoded PEM certificate string.
+     */
+    const handleCertificateSubmit = (value: string): void => {
+        setEncodedCertificate(value);
+        encodedCertificateRef.current = value;
+        if (pendingSubmit.current) {
+            pendingSubmit.current = false;
+            submitForm.current?.();
+        }
+    };
+
+    const handleClearCertificate = (): void => {
+        setEncodedCertificate("");
+        encodedCertificateRef.current = "";
+        setUserHasStagedCert(false);
     };
 
     const generalSettingsPage = (): ReactElement => (
@@ -295,14 +336,51 @@ const FlowExtensionCreateWizard: FunctionComponent<FlowExtensionCreateWizardProp
 
     const endpointConfigPage = (): ReactElement => (
         <WizardPage validate={ validateEndpointConfigs }>
-            <ActionEndpointConfigForm
-                initialValues={ null }
-                isCreateFormState={ true }
-                isReadOnly={ false }
-                showHeadersAndParams={ false }
-                authenticationTypes={ FlowExtensionConstants.FLOW_EXTENSION_AUTH_TYPES }
-                onAuthenticationTypeChange={ (type: AuthenticationType): void => setEndpointAuthType(type) }
-                data-componentid={ `${componentId}-endpoint-config-form` }
+            <Box sx={ { "& .secondary-button": { mt: 2 } } }>
+                <ActionEndpointConfigForm
+                    initialValues={ null }
+                    isCreateFormState={ true }
+                    isReadOnly={ false }
+                    showHeadersAndParams={ false }
+                    authenticationTypes={ FlowExtensionConstants.FLOW_EXTENSION_AUTH_TYPES }
+                    onAuthenticationTypeChange={ (type: AuthenticationType): void => setEndpointAuthType(type) }
+                    data-componentid={ `${componentId}-endpoint-config-form` }
+                />
+            </Box>
+            <Divider sx={ { my: 3 } } />
+            <Heading as="h5">
+                { t("flowExtension:createWizard.steps.endpointConfig.certificate.title") }
+            </Heading>
+            <Typography variant="body2" color="text.secondary" sx={ { mb: 2 } }>
+                { t("flowExtension:createWizard.steps.endpointConfig.certificate.hint") }
+            </Typography>
+            { encodedCertificate && (
+                <Alert
+                    severity="success"
+                    sx={ { mb: 2 } }
+                    action={ (
+                        <LinkButton
+                            onClick={ handleClearCertificate }
+                            data-componentid={ `${componentId}-clear-certificate` }
+                        >
+                            { t("common:clear") }
+                        </LinkButton>
+                    ) }
+                    data-componentid={ `${componentId}-certificate-status` }
+                >
+                    <Trans
+                        i18nKey={ "flowExtension:createWizard.steps.endpointConfig" +
+                            ".certificate.uploaded" }
+                    >
+                        Certificate configured. You can re-upload to replace it or clear it.
+                    </Trans>
+                </Alert>
+            ) }
+            <AddCertificateFormComponent
+                triggerCertificateUpload={ triggerCertUpload }
+                onSubmit={ handleCertificateSubmit }
+                setShowFinishButton={ setUserHasStagedCert }
+                data-componentid={ `${componentId}-certificate-upload` }
             />
         </WizardPage>
     );
@@ -399,7 +477,16 @@ const FlowExtensionCreateWizard: FunctionComponent<FlowExtensionCreateWizardProp
                                         disabled={ nextShouldBeDisabled || isSubmitting }
                                         floated="right"
                                         loading={ isSubmitting }
-                                        onClick={ (): void => submitForm.current?.() }
+                                        onClick={ (): void => {
+                                            if (userHasStagedCert) {
+                                                // Two-phase: extract the staged cert first; handleCertificateSubmit
+                                                // resumes the wizard submit once the PEM is captured.
+                                                pendingSubmit.current = true;
+                                                setTriggerCertUpload();
+                                            } else {
+                                                submitForm.current?.();
+                                            }
+                                        } }
                                         data-componentid={ `${componentId}-submit-button` }
                                     >
                                         { t("authenticationProvider:wizards.buttons.finish") }

--- a/features/admin.flow-extensions.v1/components/edit/flow-extension-access-config-settings.tsx
+++ b/features/admin.flow-extensions.v1/components/edit/flow-extension-access-config-settings.tsx
@@ -37,12 +37,11 @@ import {
     FlowExtensionUpdateRequestInterface
 } from "../../models/flow-extension";
 import {
-    AccessConfigOutputInterface,
     FlowContextTree,
+    FlowExtensionAccessConfigInterface,
     FlowExtensionContextTreeResponseInterface,
     InitialAccessConfigInterface
 } from "../flow-context-tree";
-
 
 /**
  * Props for the Flow Extension access config settings tab.
@@ -94,6 +93,10 @@ const FlowExtensionAccessConfigSettings: FunctionComponent<FlowExtensionAccessCo
 
     const [ accessConfig, setAccessConfig ] = useState<ClaimAccessConfigInterface>({ expose: [], modify: [] });
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
+
+    // Backend does not return the certificate value (security); presence of the
+    // `encryption` object indicates a certificate is configured for this extension.
+    const hasCertificate: boolean = !!flowExtension?.encryption;
     const [ showResetConfirmation, setShowResetConfirmation ] = useState<boolean>(false);
     const [ resetKey, setResetKey ] = useState<number>(0);
 
@@ -112,7 +115,7 @@ const FlowExtensionAccessConfigSettings: FunctionComponent<FlowExtensionAccessCo
     );
 
     const handleAccessConfigChange = (
-        newAccessConfig: AccessConfigOutputInterface
+        newAccessConfig: FlowExtensionAccessConfigInterface
     ): void => {
         setAccessConfig(newAccessConfig as ClaimAccessConfigInterface);
     };
@@ -197,12 +200,22 @@ const FlowExtensionAccessConfigSettings: FunctionComponent<FlowExtensionAccessCo
                         { t("flowExtension:edit.accessConfig.emptyInfo") }
                     </Alert>
                 ) }
+                { !hasCertificate && (
+                    <Alert
+                        severity="warning"
+                        sx={ { mb: 2 } }
+                        data-componentid={ `${componentId}-no-certificate-info` }
+                    >
+                        { t("flowExtension:edit.accessConfig.noCertificateInfo") }
+                    </Alert>
+                ) }
                 <FlowContextTree
                     key={ resetKey }
                     contextTree={ contextTreeData.context }
                     onChange={ handleAccessConfigChange }
                     initialAccessConfig={ initialAccessConfig }
                     readOnly={ isReadOnly }
+                    hasCertificate={ hasCertificate }
                     allowReadOnlyClaimsModification={ contextTreeData.allowReadOnlyClaimsModification }
                     redirectionEnabled={ contextTreeData.redirectionEnabled }
                     data-componentid={ `${componentId}-tree` }

--- a/features/admin.flow-extensions.v1/components/edit/flow-extension-endpoint-settings.tsx
+++ b/features/admin.flow-extensions.v1/components/edit/flow-extension-endpoint-settings.tsx
@@ -16,23 +16,29 @@
  * under the License.
  */
 
+import Alert from "@oxygen-ui/react/Alert";
+import Box from "@oxygen-ui/react/Box";
 import Button from "@oxygen-ui/react/Button";
+import Divider from "@oxygen-ui/react/Divider";
+import Typography from "@oxygen-ui/react/Typography";
 import ActionEndpointConfigForm from "@wso2is/admin.actions.v1/components/action-endpoint-config-form";
 import {
     AuthenticationType,
     EndpointConfigFormPropertyInterface
 } from "@wso2is/admin.actions.v1/models/actions";
 import { validateActionEndpointFields } from "@wso2is/admin.actions.v1/util/form-field-util";
+import { AddCertificateFormComponent } from "@wso2is/admin.core.v1/components/add-certificate-form";
 import {
     AlertLevels,
     IdentifiableComponentInterface
 } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { FinalForm, FormRenderProps } from "@wso2is/forms";
-import { ContentLoader, EmphasizedSegment } from "@wso2is/react-components";
+import { useTrigger } from "@wso2is/forms/legacy";
+import { ContentLoader, EmphasizedSegment, Heading, LinkButton } from "@wso2is/react-components";
 import { FormApi } from "final-form";
 import React, { FunctionComponent, ReactElement, useMemo, useState } from "react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { Dispatch } from "redux";
 import updateFlowExtension from "../../api/update-flow-extension";
@@ -63,6 +69,22 @@ interface FlowExtensionEndpointSettingsPropsInterface extends IdentifiableCompon
      * Callback to refresh the Flow Extension after an update.
      */
     mutateFlowExtension: () => void;
+}
+
+/**
+ * Endpoint form values, extended with the certificate fields that are carried in form state rather
+ * than rendered as visible inputs. Keeping them in the form (instead of component state) lets a submit
+ * resumed synchronously from the certificate-extraction callback read fresh values without stale closures.
+ */
+interface FlowExtensionEndpointFormValues extends EndpointConfigFormPropertyInterface {
+    /**
+     * Base64-encoded PEM certificate staged for encryption. `undefined` means untouched, `""` means cleared.
+     */
+    encodedCertificate?: string;
+    /**
+     * Whether the certificate was staged or cleared since the last successful save.
+     */
+    certificateModified?: boolean;
 }
 
 /**
@@ -134,6 +156,12 @@ const FlowExtensionEndpointSettings: FunctionComponent<FlowExtensionEndpointSett
     );
     const [ isAuthenticationUpdateFormState, setIsAuthenticationUpdateFormState ] = useState<boolean>(false);
 
+    // The user staged a certificate in the add-certificate form (entered but not yet extracted). Gates
+    // the two-phase submit: extract the staged cert first, then submit. The staged value itself and the
+    // "modified" gate live in form state (see FlowExtensionEndpointFormValues).
+    const [ userHasStagedCert, setUserHasStagedCert ] = useState<boolean>(false);
+    const [ triggerCertUpload, setTriggerCertUpload ] = useTrigger();
+
     // Memoized so the reference is stable across renders. ActionEndpointConfigForm resets its
     // authentication state in a useEffect keyed on initialValues — a fresh object each render would
     // continually revert the auth-type selection.
@@ -177,31 +205,42 @@ const FlowExtensionEndpointSettings: FunctionComponent<FlowExtensionEndpointSett
         });
 
     const handleSubmit = (
-        values: EndpointConfigFormPropertyInterface,
-        changedFields: Record<string, boolean>
+        values: FlowExtensionEndpointFormValues,
+        form: FormApi
     ): void => {
-        setIsSubmitting(true);
+        const changedFields: Record<string, boolean> = form.getState().dirtyFields;
         const isEndpointChanged: boolean = isAuthenticationUpdateFormState
             || Boolean(changedFields?.endpointUri)
             || Boolean(changedFields?.allowedHeaders);
 
-        if (!isEndpointChanged) {
+        const body: FlowExtensionUpdateRequestInterface = {};
+
+        if (isEndpointChanged) {
+            body.endpoint = {
+                ...(changedFields?.allowedHeaders && { allowedHeaders: values.allowedHeaders }),
+                ...(isAuthenticationUpdateFormState && {
+                    authentication: {
+                        properties: resolveAuthProperties(values),
+                        type: endpointAuthType
+                    }
+                }),
+                ...(changedFields?.endpointUri && { uri: values.endpointUri })
+            };
+        }
+
+        // Include the encryption update only when the certificate was explicitly changed (staged or
+        // cleared). `certificateModified` is carried in form state, so this reads a fresh value even when
+        // the submit is resumed synchronously from the certificate-extraction callback.
+        if (values.certificateModified) {
+            body.encryption = { certificate: values.encodedCertificate || "" };
+        }
+
+        // Nothing changed — skip the API call.
+        if (!body.endpoint && !body.encryption) {
             return;
         }
 
-        const endpoint: Partial<FlowExtensionEndpointInterface> = {
-            ...(changedFields?.allowedHeaders && { allowedHeaders: values.allowedHeaders }),
-            ...(isAuthenticationUpdateFormState && {
-                authentication: {
-                    properties: resolveAuthProperties(values),
-                    type: endpointAuthType
-                }
-            }),
-            ...(changedFields?.endpointUri && { uri: values.endpointUri })
-        };
-
-        const body: FlowExtensionUpdateRequestInterface = { endpoint };
-
+        setIsSubmitting(true);
         updateFlowExtension(flowExtension.id, body)
             .then((): void => {
                 dispatch(addAlert({
@@ -210,6 +249,10 @@ const FlowExtensionEndpointSettings: FunctionComponent<FlowExtensionEndpointSett
                     message: t("flowExtension:notifications.updateSuccess.message")
                 }));
                 setIsAuthenticationUpdateFormState(false);
+                // Reset the modified gate so a subsequent unrelated update doesn't re-send `encryption`.
+                // The staged certificate value is intentionally kept so the "configured" alert persists.
+                form.change("certificateModified", false);
+                setUserHasStagedCert(false);
                 mutateFlowExtension();
             })
             .catch((): void => {
@@ -232,36 +275,104 @@ const FlowExtensionEndpointSettings: FunctionComponent<FlowExtensionEndpointSett
                 initialValues={ initialValues }
                 validate={ validateForm }
                 onSubmit={ (
-                    values: EndpointConfigFormPropertyInterface,
+                    values: FlowExtensionEndpointFormValues,
                     form: FormApi
-                ): void => handleSubmit(values, form.getState().dirtyFields) }
-                render={ ({ handleSubmit }: FormRenderProps): ReactElement => (
-                    <form onSubmit={ handleSubmit } className="form-container with-max-width">
-                        <ActionEndpointConfigForm
-                            initialValues={ initialValues }
-                            isCreateFormState={ false }
-                            isReadOnly={ isReadOnly }
-                            showHeadersAndParams={ false }
-                            authenticationTypes={ FlowExtensionConstants.FLOW_EXTENSION_AUTH_TYPES }
-                            onAuthenticationTypeChange={ (updatedValue: AuthenticationType, change: boolean): void => {
-                                setEndpointAuthType(updatedValue);
-                                setIsAuthenticationUpdateFormState(change);
-                            } }
-                            data-componentid={ `${componentId}-endpoint-config-form` }
-                        />
-                        <Button
-                            size="medium"
-                            variant="contained"
-                            type="submit"
-                            sx={ { marginTop: 3.75 } }
-                            data-componentid={ `${componentId}-update-button` }
-                            loading={ isSubmitting }
-                            disabled={ isReadOnly || isSubmitting }
-                        >
-                            { t("common:update") }
-                        </Button>
-                    </form>
-                ) }
+                ): void => handleSubmit(values, form) }
+                render={ ({ handleSubmit, form, values }: FormRenderProps): ReactElement => {
+                    const stagedCertificate: string | undefined = values.encodedCertificate;
+                    const hasCertificate: boolean = stagedCertificate === undefined
+                        ? Boolean(flowExtension?.encryption)
+                        : stagedCertificate !== "";
+
+                    const handleCertificateSubmit = (value: string): void => {
+                        if (value) {
+                            form.change("encodedCertificate", value);
+                            form.change("certificateModified", true);
+                        }
+                        handleSubmit();
+                    };
+
+                    const handleClearCertificate = (): void => {
+                        form.change("encodedCertificate", "");
+                        form.change("certificateModified", true);
+                    };
+
+                    return (
+                        <form onSubmit={ handleSubmit } className="form-container with-max-width">
+                            <Box sx={ { "& .secondary-button": { mt: 2 } } }>
+                                <ActionEndpointConfigForm
+                                    initialValues={ initialValues }
+                                    isCreateFormState={ false }
+                                    isReadOnly={ isReadOnly }
+                                    showHeadersAndParams={ false }
+                                    authenticationTypes={ FlowExtensionConstants.FLOW_EXTENSION_AUTH_TYPES }
+                                    onAuthenticationTypeChange={
+                                        (updatedValue: AuthenticationType, change: boolean): void => {
+                                            setEndpointAuthType(updatedValue);
+                                            setIsAuthenticationUpdateFormState(change);
+                                        }
+                                    }
+                                    data-componentid={ `${componentId}-endpoint-config-form` }
+                                />
+                            </Box>
+                            <Divider sx={ { my: 3 } } />
+                            <Heading as="h5">
+                                { t("flowExtension:createWizard.steps.endpointConfig.certificate.title") }
+                            </Heading>
+                            <Typography variant="body2" color="text.secondary" sx={ { mb: 2 } }>
+                                { t("flowExtension:createWizard.steps.endpointConfig.certificate.hint") }
+                            </Typography>
+                            { hasCertificate && (
+                                <Alert
+                                    severity="success"
+                                    sx={ { alignItems: "center", mb: 2 } }
+                                    action={ (
+                                        <LinkButton
+                                            onClick={ handleClearCertificate }
+                                            data-componentid={ `${componentId}-clear-certificate` }
+                                        >
+                                            { t("common:clear") }
+                                        </LinkButton>
+                                    ) }
+                                    data-componentid={ `${componentId}-certificate-status` }
+                                >
+                                    <Trans
+                                        i18nKey={ "flowExtension:createWizard.steps.endpointConfig" +
+                                        ".certificate.uploaded" }
+                                    >
+                                    Certificate configured. Clear it to upload a different certificate.
+                                    </Trans>
+                                </Alert>
+                            ) }
+                            { !hasCertificate && (
+                                <AddCertificateFormComponent
+                                    triggerCertificateUpload={ triggerCertUpload }
+                                    onSubmit={ handleCertificateSubmit }
+                                    setShowFinishButton={ setUserHasStagedCert }
+                                    data-componentid={ `${componentId}-certificate-upload` }
+                                />
+                            ) }
+                            <Button
+                                size="medium"
+                                variant="contained"
+                                onClick={ (): void => {
+                                    if (userHasStagedCert) {
+                                    // Two-phase: extract the staged cert first, then submit.
+                                        setTriggerCertUpload();
+                                    } else {
+                                        handleSubmit();
+                                    }
+                                } }
+                                sx={ { marginTop: 3.75 } }
+                                data-componentid={ `${componentId}-update-button` }
+                                loading={ isSubmitting }
+                                disabled={ isReadOnly || isSubmitting }
+                            >
+                                { t("common:update") }
+                            </Button>
+                        </form>
+                    );
+                } }
             />
         </EmphasizedSegment>
     );

--- a/features/admin.flow-extensions.v1/components/edit/flow-extension-general-settings.tsx
+++ b/features/admin.flow-extensions.v1/components/edit/flow-extension-general-settings.tsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import Box from "@oxygen-ui/react/Box";
 import Button from "@oxygen-ui/react/Button";
 import { FeatureAccessConfigInterface, Show, useRequiredScopes } from "@wso2is/access-control";
 import { history } from "@wso2is/admin.core.v1/helpers/history";
@@ -215,9 +216,11 @@ const FlowExtensionGeneralSettings: FunctionComponent<FlowExtensionGeneralSettin
                                 label={ t("flowExtension:edit.general.name.label") }
                                 placeholder={ t("flowExtension:edit.general.name.placeholder") }
                                 helperText={
-                                    (<Hint className="hint" compact>
-                                        { t("flowExtension:edit.general.name.hint") }
-                                    </Hint>)
+                                    (<Box sx={ { mb: 1.5 } }>
+                                        <Hint className="hint" compact>
+                                            { t("flowExtension:edit.general.name.hint") }
+                                        </Hint>
+                                    </Box>)
                                 }
                                 component={ TextFieldAdapter }
                                 maxLength={ 255 }
@@ -254,9 +257,11 @@ const FlowExtensionGeneralSettings: FunctionComponent<FlowExtensionGeneralSettin
                                 label={ t("flowExtension:edit.general.iconUrl.label") }
                                 placeholder={ t("flowExtension:edit.general.iconUrl.placeholder") }
                                 helperText={
-                                    (<Hint className="hint" compact>
-                                        { t("flowExtension:edit.general.iconUrl.hint") }
-                                    </Hint>)
+                                    (<Box sx={ { mb: 1.5 } }>
+                                        <Hint className="hint" compact>
+                                            { t("flowExtension:edit.general.iconUrl.hint") }
+                                        </Hint>
+                                    </Box>)
                                 }
                                 component={ TextFieldAdapter }
                                 maxLength={ 2048 }

--- a/features/admin.flow-extensions.v1/components/flow-context-tree/flow-context-tree-node.tsx
+++ b/features/admin.flow-extensions.v1/components/flow-context-tree/flow-context-tree-node.tsx
@@ -23,6 +23,7 @@ import Typography from "@oxygen-ui/react/Typography";
 import { ChevronRightIcon } from "@oxygen-ui/react-icons";
 import React, { FunctionComponent, ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { ReactComponent as LockIcon } from "../../resources/assets/images/icons/lock.svg";
 import { NodeType, TreeNodeStateInterface } from "./models";
 
 const INDENT: number = 18;
@@ -79,7 +80,19 @@ const OpChips = ({
         >
             { canExpose && (
                 <Chip
-                    label={ t("flowExtension:contextTree.node.readChip") }
+                    label={ (
+                        <Box component="span">
+                            { node.exposed && node.exposeEncrypted && (
+                                <LockIcon
+                                    width={ 8 }
+                                    height={ 8 }
+                                    strokeWidth={ 2.5 }
+                                    style={ { marginRight: 3, verticalAlign: "middle" } }
+                                />
+                            ) }
+                            { t("flowExtension:contextTree.node.readChip") }
+                        </Box>
+                    ) }
                     size="small"
                     onClick={ readOnly ? undefined : (e: React.MouseEvent) => {
                         e.stopPropagation();
@@ -111,7 +124,19 @@ const OpChips = ({
             ) }
             { canModify && (
                 <Chip
-                    label={ t("flowExtension:contextTree.node.writeChip") }
+                    label={ (
+                        <Box component="span">
+                            { node.modify && node.modifyEncrypted && (
+                                <LockIcon
+                                    width={ 8 }
+                                    height={ 8 }
+                                    strokeWidth={ 2.5 }
+                                    style={ { marginRight: 3, verticalAlign: "middle" } }
+                                />
+                            ) }
+                            { t("flowExtension:contextTree.node.writeChip") }
+                        </Box>
+                    ) }
                     size="small"
                     onClick={ readOnly ? undefined : (e: React.MouseEvent) => {
                         e.stopPropagation();

--- a/features/admin.flow-extensions.v1/components/flow-context-tree/flow-context-tree.tsx
+++ b/features/admin.flow-extensions.v1/components/flow-context-tree/flow-context-tree.tsx
@@ -16,14 +16,17 @@
  * under the License.
  */
 
+import { Theme, styled } from "@mui/material/styles";
 import Box from "@oxygen-ui/react/Box";
 import Chip from "@oxygen-ui/react/Chip";
 import IconButton from "@oxygen-ui/react/IconButton";
+import Switch from "@oxygen-ui/react/Switch";
 import Tooltip from "@oxygen-ui/react/Tooltip";
 import Typography from "@oxygen-ui/react/Typography";
 import { TrashIcon } from "@oxygen-ui/react-icons";
 import { getAllLocalClaims } from "@wso2is/admin.claims.v1/api";
 import { Claim, ClaimsGetParams } from "@wso2is/core/models";
+import classNames from "classnames";
 import React, {
     FunctionComponent,
     ReactElement,
@@ -33,11 +36,13 @@ import React, {
     useState
 } from "react";
 import { useTranslation } from "react-i18next";
+import { ReactComponent as LockIcon } from "../../resources/assets/images/icons/lock.svg";
 import AddClaimModal from "./add-claim-modal";
 import FlowContextTreeNode from "./flow-context-tree-node";
 import {
     AddEntryModalStateInterface,
     FlowContextTreePropsInterface,
+    FlowExtensionAccessConfigInterface,
     NodeType,
     TreeNodeStateInterface
 } from "./models";
@@ -63,10 +68,90 @@ import {
 const isClaimContainer = (node: TreeNodeStateInterface): boolean =>
     node.path.replace(/\/+$/, "") === "/user/claims";
 
+/**
+ * Container of the encryption configuration card. The `disabled` class dims the
+ * whole card while keeping its layout stable.
+ */
+const EncryptionCardRoot: typeof Box = styled(Box)(({ theme }: { theme: Theme }) => ({
+    "&.disabled": {
+        opacity: 0.55
+    },
+    alignItems: "center",
+    backgroundColor: theme.palette.background.paper,
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadius,
+    display: "flex",
+    gap: theme.spacing(1.5),
+    minHeight: 64,
+    padding: theme.spacing(1, 1.5)
+}));
+
+interface EncryptionCardProps {
+    title: string;
+    color: string;
+    checked: boolean;
+    disabled: boolean;
+    disabledReason: string;
+    enabledDescription: string;
+    onToggle: () => void;
+    "data-componentid"?: string;
+}
+
+/**
+ * Encryption configuration card for the field-configuration panel.
+ * Shows an explanatory line both when disabled (why it can't be enabled) and
+ * when active (what enabling means) so the height stays stable across states.
+ */
+const EncryptionCard: FunctionComponent<EncryptionCardProps> = ({
+    title,
+    color,
+    checked,
+    disabled,
+    disabledReason,
+    enabledDescription,
+    onToggle,
+    "data-componentid": componentId = "encryption-card"
+}: EncryptionCardProps): ReactElement => (
+    <Tooltip title={ disabled ? disabledReason : "" } placement="top" arrow>
+        <EncryptionCardRoot
+            className={ classNames({ disabled }) }
+            data-componentid={ componentId }
+        >
+            <Box
+                component="span"
+                sx={ { color: disabled ? "action.disabled" : color, display: "inline-flex", flexShrink: 0 } }
+            >
+                <LockIcon width={ 13 } height={ 13 } />
+            </Box>
+            <Box sx={ { flex: "1 1 auto", minWidth: 0 } }>
+                <Typography variant="body2" sx={ { fontWeight: 600, lineHeight: 1.2 } }>
+                    { title }
+                </Typography>
+                <Typography
+                    variant="caption"
+                    color="text.disabled"
+                    sx={ { display: "block", lineHeight: 1.3, mt: 0.3 } }
+                >
+                    { disabled ? disabledReason : enabledDescription }
+                </Typography>
+            </Box>
+            <Switch
+                checked={ checked }
+                disabled={ disabled }
+                onChange={ disabled ? undefined : onToggle }
+            />
+        </EncryptionCardRoot>
+    </Tooltip>
+);
+
 interface FieldConfigPanelProps {
     selectedNode: TreeNodeStateInterface | null;
     readOnly: boolean;
+    hasCertificate: boolean;
+    onToggleExposeEncrypt: (key: string) => void;
+    onToggleModifyEncrypt: (key: string) => void;
     onDelete: (key: string) => void;
+    "data-componentid"?: string;
 }
 
 /**
@@ -76,7 +161,11 @@ interface FieldConfigPanelProps {
 const FieldConfigPanel: FunctionComponent<FieldConfigPanelProps> = ({
     selectedNode,
     readOnly,
-    onDelete
+    hasCertificate,
+    onToggleExposeEncrypt,
+    onToggleModifyEncrypt,
+    onDelete,
+    "data-componentid": componentId = "field-config-panel"
 }: FieldConfigPanelProps): ReactElement => {
 
     const { t } = useTranslation();
@@ -86,6 +175,39 @@ const FieldConfigPanel: FunctionComponent<FieldConfigPanelProps> = ({
     const displayDataType: string = selectedNode?.dataType ?? "";
 
     const canDeleteNode: boolean = !readOnly && !!selectedNode?.canDelete;
+
+    const canExposeOp: boolean = !!selectedNode?.allowedOperations.includes("EXPOSE") && isLeaf;
+    const canModifyOp: boolean = !!selectedNode?.allowedOperations.includes("MODIFY")
+        && isLeaf
+        && !selectedNode?.readOnly;
+
+    const getExposeEncryptionDisabledReason: () => string = (): string => {
+        if (!canExposeOp) {
+            return t("flowExtension:contextTree.fieldConfig.encryption.read.notAllowed");
+        }
+
+        if (!selectedNode?.exposed) {
+            return t("flowExtension:contextTree.fieldConfig.encryption.read.markFirst");
+        }
+
+        if (!hasCertificate) {
+            return t("flowExtension:contextTree.fieldConfig.encryption.read.needCertificate");
+        }
+
+        return t("flowExtension:contextTree.fieldConfig.encryption.formReadOnly");
+    };
+
+    const getModifyEncryptionDisabledReason: () => string = (): string => {
+        if (!canModifyOp) {
+            return t("flowExtension:contextTree.fieldConfig.encryption.write.notAllowed");
+        }
+
+        if (!selectedNode?.modify) {
+            return t("flowExtension:contextTree.fieldConfig.encryption.write.markFirst");
+        }
+
+        return t("flowExtension:contextTree.fieldConfig.encryption.formReadOnly");
+    };
 
     return (
         <Box
@@ -209,6 +331,41 @@ const FieldConfigPanel: FunctionComponent<FieldConfigPanelProps> = ({
                             </Box>
                         ) }
                     </Box>
+
+                    { /* ── Encryption section ── */ }
+                    <Typography
+                        variant="subtitle2"
+                        color="text.secondary"
+                        sx={ { display: "block", fontWeight: 600, mt: 2.5 } }
+                    >
+                        { t("flowExtension:contextTree.fieldConfig.encryption.title") }
+                    </Typography>
+                    <Box sx={ { display: "flex", flexDirection: "column", gap: 1.5, mt: 1 } }>
+                        <EncryptionCard
+                            title={ t("flowExtension:contextTree.fieldConfig.encryption.read.title") }
+                            color="var(--tree-expose)"
+                            checked={ !!selectedNode.exposeEncrypted }
+                            disabled={ !canExposeOp || readOnly || !selectedNode.exposed || !hasCertificate }
+                            disabledReason={ getExposeEncryptionDisabledReason() }
+                            enabledDescription={
+                                t("flowExtension:contextTree.fieldConfig.encryption.read.enabledDescription")
+                            }
+                            onToggle={ () => onToggleExposeEncrypt(selectedNode.key) }
+                            data-componentid={ `${componentId}-expose-encryption` }
+                        />
+                        <EncryptionCard
+                            title={ t("flowExtension:contextTree.fieldConfig.encryption.write.title") }
+                            color="var(--tree-modify)"
+                            checked={ !!selectedNode.modifyEncrypted }
+                            disabled={ !canModifyOp || readOnly || !selectedNode.modify }
+                            disabledReason={ getModifyEncryptionDisabledReason() }
+                            enabledDescription={
+                                t("flowExtension:contextTree.fieldConfig.encryption.write.enabledDescription")
+                            }
+                            onToggle={ () => onToggleModifyEncrypt(selectedNode.key) }
+                            data-componentid={ `${componentId}-modify-encryption` }
+                        />
+                    </Box>
                 </>
             ) }
         </Box>
@@ -224,6 +381,7 @@ const FlowContextTree: FunctionComponent<FlowContextTreePropsInterface> = ({
     onChange,
     initialAccessConfig,
     readOnly,
+    hasCertificate,
     allowReadOnlyClaimsModification = true,
     "data-componentid": componentId = "flow-context-tree"
 }: FlowContextTreePropsInterface): ReactElement => {
@@ -270,7 +428,7 @@ const FlowContextTree: FunctionComponent<FlowContextTreePropsInterface> = ({
         parentNode: null
     });
 
-    const builtConfig: ReturnType<typeof buildAccessConfig> = useMemo(
+    const builtConfig: FlowExtensionAccessConfigInterface = useMemo(
         () => buildAccessConfig(tree),
         [ tree ]
     );
@@ -336,18 +494,40 @@ const FlowContextTree: FunctionComponent<FlowContextTreePropsInterface> = ({
 
     const handleToggleExpose = useCallback((key: string): void => {
         setTree((prev: TreeNodeStateInterface[]) =>
-            updateNode(prev, key, (n: TreeNodeStateInterface) => ({
-                ...n,
-                exposed: !n.exposed
+            updateNode(prev, key, (node: TreeNodeStateInterface) => ({
+                ...node,
+                // Clear the encryption mark when un-exposing — an unexposed field cannot be encrypted.
+                exposeEncrypted: node.exposed ? false : node.exposeEncrypted,
+                exposed: !node.exposed
             }))
         );
     }, []);
 
     const handleToggleModify = useCallback((key: string): void => {
         setTree((prev: TreeNodeStateInterface[]) =>
-            updateNode(prev, key, (n: TreeNodeStateInterface) => ({
-                ...n,
-                modify: !n.modify
+            updateNode(prev, key, (node: TreeNodeStateInterface) => ({
+                ...node,
+                modify: !node.modify,
+                // Clear the encryption mark when un-marking modify.
+                modifyEncrypted: node.modify ? false : node.modifyEncrypted
+            }))
+        );
+    }, []);
+
+    const handleToggleExposeEncrypt = useCallback((key: string): void => {
+        setTree((prev: TreeNodeStateInterface[]) =>
+            updateNode(prev, key, (node: TreeNodeStateInterface) => ({
+                ...node,
+                exposeEncrypted: !node.exposeEncrypted
+            }))
+        );
+    }, []);
+
+    const handleToggleModifyEncrypt = useCallback((key: string): void => {
+        setTree((prev: TreeNodeStateInterface[]) =>
+            updateNode(prev, key, (node: TreeNodeStateInterface) => ({
+                ...node,
+                modifyEncrypted: !node.modifyEncrypted
             }))
         );
     }, []);
@@ -386,10 +566,12 @@ const FlowContextTree: FunctionComponent<FlowContextTreePropsInterface> = ({
                     dataType: "String",
                     dynamicEntryAllowed: false,
                     dynamicEntryType: "",
+                    exposeEncrypted: false,
                     exposed: false,
                     isClaim: true,
                     key: `claim-${Date.now()}-${idx}`,
                     modify: false,
+                    modifyEncrypted: false,
                     nodeType: NodeType.LEAF,
                     // Join with a single slash regardless of whether the container path carries a
                     // trailing one, so the internal form is always `/user/claims/<uri>` — the shape
@@ -453,7 +635,11 @@ const FlowContextTree: FunctionComponent<FlowContextTreePropsInterface> = ({
                     <FieldConfigPanel
                         selectedNode={ selectedNode }
                         readOnly={ !!readOnly }
+                        hasCertificate={ !!hasCertificate }
+                        onToggleExposeEncrypt={ handleToggleExposeEncrypt }
+                        onToggleModifyEncrypt={ handleToggleModifyEncrypt }
                         onDelete={ handleDelete }
+                        data-componentid={ `${componentId}-field-config-panel` }
                     />
                 </Box>
             </Box>

--- a/features/admin.flow-extensions.v1/components/flow-context-tree/index.ts
+++ b/features/admin.flow-extensions.v1/components/flow-context-tree/index.ts
@@ -18,7 +18,7 @@
 
 export { default as FlowContextTree } from "./flow-context-tree";
 export type {
-    AccessConfigOutputInterface,
+    FlowExtensionAccessConfigInterface,
     FlowExtensionContextTreeResponseInterface,
     InitialAccessConfigInterface
 } from "./models";

--- a/features/admin.flow-extensions.v1/components/flow-context-tree/models.ts
+++ b/features/admin.flow-extensions.v1/components/flow-context-tree/models.ts
@@ -85,6 +85,10 @@ export interface TreeNodeStateInterface {
     dynamicEntryType: string;
     exposed: boolean;
     modify: boolean;
+    /** Whether the exposed (read) value of this field is sent to the extension encrypted. */
+    exposeEncrypted: boolean;
+    /** Whether the extension returns this field's modified (write) value encrypted. */
+    modifyEncrypted: boolean;
     isClaim?: boolean;
     children?: TreeNodeStateInterface[];
 }
@@ -94,8 +98,13 @@ export interface TreeNodeStateInterface {
  */
 export interface FlowContextTreePropsInterface extends IdentifiableComponentInterface {
     contextTree: ContextTreeNodeMetadataInterface[];
-    onChange: (accessConfig: AccessConfigOutputInterface) => void;
+    onChange: (accessConfig: FlowExtensionAccessConfigInterface) => void;
     initialAccessConfig?: InitialAccessConfigInterface;
+    /**
+     * Whether an encryption certificate is configured for the extension. When false, the
+     * per-field encryption toggles are disabled (a certificate is required to encrypt).
+     */
+    hasCertificate?: boolean;
     readOnly?: boolean;
     /**
      * Whether the active flow type permits MODIFY on read-only claims (and other read-only
@@ -123,18 +132,19 @@ export interface InitialAccessConfigInterface {
 }
 
 /**
- * Access config output shape — matches the existing AccessConfigInterface.
+ * Access config emitted by the flow context tree — matches the existing AccessConfigInterface.
  */
-export interface AccessConfigOutputInterface {
+export interface FlowExtensionAccessConfigInterface {
     expose: ContextPathOutputInterface[];
     modify: ContextPathOutputInterface[];
 }
 
 /**
- * A single path entry.
+ * A single path entry with encryption flag.
  */
 export interface ContextPathOutputInterface {
     path: string;
+    encrypted?: boolean;
 }
 
 /**

--- a/features/admin.flow-extensions.v1/components/flow-context-tree/utils.ts
+++ b/features/admin.flow-extensions.v1/components/flow-context-tree/utils.ts
@@ -17,9 +17,9 @@
  */
 
 import {
-    AccessConfigOutputInterface,
     ContextPathOutputInterface,
     ContextTreeNodeMetadataInterface,
+    FlowExtensionAccessConfigInterface,
     InitialAccessConfigInterface,
     NodeType,
     TreeNodeStateInterface
@@ -41,6 +41,9 @@ const isContainer = (node: TreeNodeStateInterface): boolean =>
 //   runtime entries in the map rather than only the ones the user configured.
 //
 // modify: LEAF-ONLY, no propagation.
+//
+// exposeEncrypted: LEAF-ONLY, no propagation.
+// modifyEncrypted: LEAF-ONLY, no propagation.
 
 // ── Tree Mutation Helpers ─────────────────────────────────────────────────────
 
@@ -110,12 +113,14 @@ export const mapMetadataToState = (
         dataType: node.dataType,
         dynamicEntryAllowed: node.dynamicEntryAllowed ?? false,
         dynamicEntryType: node.dynamicEntryType ?? "",
+        exposeEncrypted: false,
         exposed: false,
         // Path-derived key — backend metadata reuses bare names like "id" across
         // siblings (user.id, organization.id, application.id). Using node.key
         // verbatim makes updateNode match all of them at once.
         key: `node:${normalisePath(node.path)}`,
         modify: false,
+        modifyEncrypted: false,
         nodeType: node.nodeType,
         path: node.path,
         readOnly: node.readOnly ?? false,
@@ -164,9 +169,9 @@ const decodeClaimPath = (path: string): string =>
  * by the GET action API.
  *
  * For each node the algorithm:
- *   1. Checks if the node's path appears in `expose[]` → set exposed.
+ *   1. Checks if the node's path appears in `expose[]` → set exposed + exposeEncrypted.
  *   2. Checks if a *parent* path in `expose[]` covers this node → cascade exposed.
- *   3. Checks if the node's path appears in `modify[]` → set modify.
+ *   3. Checks if the node's path appears in `modify[]` → set modify + modifyEncrypted.
  *
  * Dynamic entries (e.g. claim keys under /user/claims/) that exist in the
  * access config but NOT in the metadata are synthesised as children.
@@ -191,24 +196,26 @@ export const mapMetadataToStateWithAccessConfig = (
     const allowReadOnlyClaimsModification: boolean =
         options.allowReadOnlyClaimsModification !== false;
     const claimReadOnlyMap: Map<string, boolean> = options.claimReadOnlyMap ?? new Map();
-    const exposePaths: Set<string> = new Set();
-    const modifyPaths: Set<string> = new Set();
+    // path → encrypted flag. The encrypted bit round-trips the per-field encryption
+    // marks saved on the access config.
+    const exposePaths: Map<string, boolean> = new Map();
+    const modifyPaths: Map<string, boolean> = new Map();
     // Preserve the type-hint string ("Integer", "[String]", "risk: String, …") keyed
     // by clean path so synthesised properties children get the correct dataType on
     // reload. Without this, the round-trip collapses every dynamic entry's type back
     // to the container's `dynamicEntryType` ("Object").
     const modifyTypeHints: Map<string, string> = new Map();
 
-    (accessConfig.expose ?? []).forEach((e: { path: string }) => {
-        exposePaths.add(normalisePath(decodeClaimPath(e.path)));
+    (accessConfig.expose ?? []).forEach((e: { path: string; encrypted?: boolean }) => {
+        exposePaths.set(normalisePath(decodeClaimPath(e.path)), !!e.encrypted);
     });
-    (accessConfig.modify ?? []).forEach((m: { path: string }) => {
+    (accessConfig.modify ?? []).forEach((m: { path: string; encrypted?: boolean }) => {
         const decoded: string = decodeClaimPath(m.path);
         const typeHintMatch: RegExpMatchArray | null = decoded.match(/\{([^}]+)\}$/);
         const cleanPath: string = decoded.replace(/\{[^}]+\}$/, "");
         const norm: string = normalisePath(cleanPath);
 
-        modifyPaths.add(norm);
+        modifyPaths.set(norm, !!m.encrypted);
         if (typeHintMatch) {
             modifyTypeHints.set(norm, typeHintMatch[1]);
         }
@@ -217,7 +224,7 @@ export const mapMetadataToStateWithAccessConfig = (
     /**
      * Check if a path is covered by an ancestor path in the expose set.
      */
-    const isCoveredByAncestor = (path: string): boolean => {
+    const isCoveredByAncestor = (path: string): { covered: boolean; encrypted: boolean } => {
         const normalised: string = normalisePath(path);
         const parts: string[] = normalised.split("/").filter(Boolean);
         let current: string = "";
@@ -225,16 +232,17 @@ export const mapMetadataToStateWithAccessConfig = (
         for (const part of parts) {
             current += "/" + part;
             if (current !== normalised && exposePaths.has(current)) {
-                return true;
+                return { covered: true, encrypted: !!exposePaths.get(current) };
             }
         }
 
-        return false;
+        return { covered: false, encrypted: false };
     };
 
     const convert = (
         metaNodes: ContextTreeNodeMetadataInterface[],
-        parentExposed: boolean
+        parentExposed: boolean,
+        parentEncrypted: boolean
     ): TreeNodeStateInterface[] => {
         const result: TreeNodeStateInterface[] = [];
 
@@ -246,31 +254,46 @@ export const mapMetadataToStateWithAccessConfig = (
 
             // Direct match in expose (only meaningful for leaf nodes)
             const directExpose: boolean = exposePaths.has(np);
+            const directExposeEnc: boolean = directExpose ? !!exposePaths.get(np) : false;
 
             // For leaf nodes: exposed if directly in expose paths or covered by ancestor
             // For container nodes: never exposed (expose is leaf-only)
-            const ancestorCovered: boolean = isCoveredByAncestor(np);
+            const ancestor: { covered: boolean; encrypted: boolean } = isCoveredByAncestor(np);
             const exposed: boolean = nodeIsContainer
                 ? false
-                : (directExpose || ancestorCovered || parentExposed);
+                : (directExpose || ancestor.covered || parentExposed);
+            const exposeEncrypted: boolean = nodeIsContainer
+                ? false
+                : (directExpose
+                    ? directExposeEnc
+                    : ancestor.covered
+                        ? ancestor.encrypted
+                        : parentEncrypted);
 
             // Modify (leaf-only in practice). When the flow type forbids modifying read-only
             // nodes, drop a previously-saved MODIFY mark on render. The cleanup commits on
             // the next save — the saved access config remains untouched until then.
             const nodeReadOnly: boolean = node.readOnly ?? false;
             let directModify: boolean = modifyPaths.has(np);
+            let modifyEncrypted: boolean = directModify ? !!modifyPaths.get(np) : false;
 
             if (nodeReadOnly && !allowReadOnlyClaimsModification) {
                 directModify = false;
+                modifyEncrypted = false;
             }
 
             let children: TreeNodeStateInterface[] | undefined;
 
             if (node.children) {
                 // Pass parent exposed state down so child leaves inherit coverage
-                const childExposed: boolean = directExpose || ancestorCovered || parentExposed;
+                const childExposed: boolean = directExpose || ancestor.covered || parentExposed;
+                const childEncrypted: boolean = directExpose
+                    ? directExposeEnc
+                    : ancestor.covered
+                        ? ancestor.encrypted
+                        : parentEncrypted;
 
-                children = convert(node.children, childExposed);
+                children = convert(node.children, childExposed, childEncrypted);
             }
 
             // Synthesise dynamic entries that exist in accessConfig but not in metadata
@@ -286,7 +309,7 @@ export const mapMetadataToStateWithAccessConfig = (
                 // because claim URIs contain slashes (e.g. http://wso2.org/claims/displayName).
                 const dynamicKeys: Set<string> = new Set<string>();
 
-                exposePaths.forEach((ePath: string) => {
+                exposePaths.forEach((_enc: boolean, ePath: string) => {
                     if (ePath.startsWith(containerPrefix)) {
                         const key: string = ePath.slice(containerPrefix.length);
 
@@ -296,7 +319,7 @@ export const mapMetadataToStateWithAccessConfig = (
                     }
                 });
 
-                modifyPaths.forEach((mPath: string) => {
+                modifyPaths.forEach((_enc: boolean, mPath: string) => {
                     if (mPath.startsWith(containerPrefix)) {
                         const key: string = mPath.slice(containerPrefix.length);
 
@@ -321,8 +344,10 @@ export const mapMetadataToStateWithAccessConfig = (
                             // node when the flow type forbids it.
                             if (existingChild.readOnly && !allowReadOnlyClaimsModification) {
                                 existingChild.modify = false;
+                                existingChild.modifyEncrypted = false;
                             } else {
                                 existingChild.modify = true;
+                                existingChild.modifyEncrypted = modifyPaths.get(synthPath) ?? false;
                             }
                         }
 
@@ -330,7 +355,9 @@ export const mapMetadataToStateWithAccessConfig = (
                     }
 
                     const isExposed: boolean = exposePaths.has(synthPath);
+                    const synthExEnc: boolean = exposePaths.get(synthPath) ?? false;
                     let isModify: boolean = modifyPaths.has(synthPath);
+                    let synthModEnc: boolean = modifyPaths.get(synthPath) ?? false;
                     const displayName: string = claimDisplayNames?.get(key) ?? key;
                     // For dynamic entries under a claims map, prefer the per-claim readOnly
                     // status (from the Claims API) over the parent container's flag. Falls
@@ -343,6 +370,7 @@ export const mapMetadataToStateWithAccessConfig = (
                     // carries it; the cleanup commits on the next save.
                     if (synthReadOnly && !allowReadOnlyClaimsModification) {
                         isModify = false;
+                        synthModEnc = false;
                     }
 
                     const isUnderClaims: boolean = containerPrefix === "/user/claims/";
@@ -362,12 +390,14 @@ export const mapMetadataToStateWithAccessConfig = (
                         dataType: synthDataType,
                         dynamicEntryAllowed: false,
                         dynamicEntryType: "",
+                        exposeEncrypted: synthExEnc,
                         exposed: isExposed,
                         isClaim: isUnderClaims,
                         // Path-derived key so two synthesised entries in different containers
                         // never collide (Date.now() collisions caused dual-row highlighting).
                         key: `synth:${synthPath}`,
                         modify: isModify,
+                        modifyEncrypted: synthModEnc,
                         nodeType: NodeType.LEAF,
                         path: synthPath,
                         readOnly: synthReadOnly,
@@ -385,12 +415,14 @@ export const mapMetadataToStateWithAccessConfig = (
                 dataType: node.dataType,
                 dynamicEntryAllowed: node.dynamicEntryAllowed ?? false,
                 dynamicEntryType: node.dynamicEntryType ?? "",
+                exposeEncrypted,
                 exposed,
                 // Path-derived key — backend metadata reuses bare names like "id"
                 // across siblings, which caused updateNode to toggle every node
                 // sharing the same key at once.
                 key: `node:${np}`,
                 modify: directModify,
+                modifyEncrypted,
                 nodeType: node.nodeType,
                 path: node.path,
                 readOnly: node.readOnly ?? false,
@@ -402,15 +434,17 @@ export const mapMetadataToStateWithAccessConfig = (
         return result;
     };
 
-    return convert(nodes, false);
+    return convert(nodes, false, false);
 };
 
 // ── Access Config Builder ────────────────────────────────────────────────────
 //
 // expose[]:  LEAF nodes with exposed=true.
 //            Container nodes are never exposed; only individual leaf paths appear.
+//            If exposeEncrypted → { path, encrypted: true }, else { path, encrypted: false }.
 //
 // modify[]:  LEAF nodes with modify=true.
+//            If modifyEncrypted → { path, encrypted: true }, else { path, encrypted: false }.
 
 // ── Selection Helpers ────────────────────────────────────────────────────────
 
@@ -461,10 +495,11 @@ export const findNode = (
 /**
  * Build the access config output from the current tree state.
  * Only leaf nodes contribute to the output — containers are never exposed.
+ * The per-field `encrypted` flag travels on each expose/modify entry.
  */
 export const buildAccessConfig = (
     nodes: TreeNodeStateInterface[]
-): AccessConfigOutputInterface => {
+): FlowExtensionAccessConfigInterface => {
 
     const expose: ContextPathOutputInterface[] = [];
     const modify: ContextPathOutputInterface[] = [];
@@ -476,7 +511,7 @@ export const buildAccessConfig = (
             if (isLeaf) {
                 // Expose: leaf-only
                 if (node.exposed) {
-                    expose.push({ path: encodeClaimPath(node.path) });
+                    expose.push({ encrypted: !!node.exposeEncrypted, path: encodeClaimPath(node.path) });
                 }
 
                 // Modify: leaf-only
@@ -487,7 +522,7 @@ export const buildAccessConfig = (
                         ? `${node.path}{${node.dataType}}`
                         : node.path;
 
-                    modify.push({ path: encodeClaimPath(modifyPath) });
+                    modify.push({ encrypted: !!node.modifyEncrypted, path: encodeClaimPath(modifyPath) });
                 }
             }
 

--- a/features/admin.flow-extensions.v1/models/flow-extension.ts
+++ b/features/admin.flow-extensions.v1/models/flow-extension.ts
@@ -22,6 +22,11 @@
  */
 interface ContextPathInterface {
     path: string;
+    /**
+     * Whether this field's value is encrypted in transit to/from the extension. Round-trips the
+     * per-field encryption mark; gated UI until certificate-based encryption ships end-to-end.
+     */
+    encrypted?: boolean;
 }
 
 /**
@@ -30,6 +35,15 @@ interface ContextPathInterface {
 export interface ClaimAccessConfigInterface {
     expose: ContextPathInterface[];
     modify: ContextPathInterface[];
+}
+
+/**
+ * Encryption configuration for a Flow Extension — the PEM certificate used to encrypt
+ * per-field values. The backend never returns the certificate value (security); the mere
+ * presence of this object on a response indicates a certificate is configured.
+ */
+interface EncryptionInterface {
+    certificate?: string;
 }
 
 /**
@@ -54,6 +68,7 @@ export interface FlowExtensionCreateRequestInterface {
     iconUrl?: string;
     endpoint: FlowExtensionEndpointInterface;
     accessConfig?: ClaimAccessConfigInterface;
+    encryption?: EncryptionInterface;
 }
 
 /**
@@ -78,3 +93,11 @@ export type FlowExtensionListResponseInterface = Pick<
     FlowExtensionResponseInterface,
     "id" | "name" | "description" | "iconUrl"
 >;
+
+/**
+ * Filter tags used to surface Flow Extensions in listing views (e.g. the Connections page).
+ * Flow Extensions have no server-side tag concept; this is a client-side synthetic tag.
+ */
+export enum FlowExtensionTags {
+    FLOW_EXTENSION = "Flow-Extension"
+}

--- a/features/admin.flow-extensions.v1/package.json
+++ b/features/admin.flow-extensions.v1/package.json
@@ -7,6 +7,7 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@asgardeo/auth-react": "^5.1.2",
+        "@mui/material": "catalog:",
         "@oxygen-ui/react": "catalog:",
         "@wso2is/access-control": "workspace:^",
         "@wso2is/admin.actions.v1": "workspace:^",
@@ -17,6 +18,7 @@
         "@wso2is/react-components": "workspace:^",
         "@wso2is/validation": "^2.4.1",
         "axios": "^1.7.0",
+        "classnames": "^2.2.6",
         "final-form": "^4.20.10",
         "react-i18next": "^11.18.5",
         "react-redux": "^7.2.9",

--- a/features/admin.flow-extensions.v1/resources/assets/images/icons/lock.svg
+++ b/features/admin.flow-extensions.v1/resources/assets/images/icons/lock.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
+    <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+</svg>

--- a/modules/i18n/src/models/namespaces/flow-extension-ns.ts
+++ b/modules/i18n/src/models/namespaces/flow-extension-ns.ts
@@ -47,6 +47,11 @@ export interface flowExtensionNS {
             };
             endpointConfig: {
                 title: string;
+                certificate: {
+                    title: string;
+                    hint: string;
+                    uploaded: string;
+                };
             };
         };
     };
@@ -94,6 +99,7 @@ export interface flowExtensionNS {
         };
         accessConfig: {
             emptyInfo: string;
+            noCertificateInfo: string;
             treeLoadError: string;
             resetButton: string;
         };
@@ -168,6 +174,23 @@ export interface flowExtensionNS {
             readOnlyBadge: string;
             editTooltip: string;
             deleteTooltip: string;
+            encryption: {
+                title: string;
+                formReadOnly: string;
+                read: {
+                    title: string;
+                    notAllowed: string;
+                    markFirst: string;
+                    needCertificate: string;
+                    enabledDescription: string;
+                };
+                write: {
+                    title: string;
+                    notAllowed: string;
+                    markFirst: string;
+                    enabledDescription: string;
+                };
+            };
         };
         node: {
             readChip: string;

--- a/modules/i18n/src/translations/en-US/portals/flow-extension.ts
+++ b/modules/i18n/src/translations/en-US/portals/flow-extension.ts
@@ -22,6 +22,11 @@ export const flowExtension: flowExtensionNS = {
     createWizard: {
         steps: {
             endpointConfig: {
+                certificate: {
+                    hint: "Upload a certificate to encrypt field values exchanged with the extension endpoint.",
+                    title: "Encryption Certificate",
+                    uploaded: "Certificate configured. Clear it to upload a different certificate."
+                },
                 title: "Endpoint Configuration"
             },
             generalSettings: {
@@ -57,6 +62,9 @@ export const flowExtension: flowExtensionNS = {
         accessConfig: {
             emptyInfo: "No access configuration has been set. The extension will not send any data and "
                 + "will not allow any modifications until you configure access here.",
+            noCertificateInfo: "No encryption certificate provided. Fields sent to the extension (read) "
+                + "cannot be marked as encrypted until you upload a certificate in the Settings tab. "
+                + "Values returned by the extension (write) can still be encrypted.",
             resetButton: "Reset",
             treeLoadError: "Failed to load the Flow Extension context tree from the server. Refresh the "
                 + "page to retry. If the problem persists, ensure the flow-management API is reachable."
@@ -211,6 +219,23 @@ export const flowExtension: flowExtensionNS = {
             editTooltip: "Edit",
             emptyHint: "Select a leaf field from the tree to configure it.",
             emptyTitle: "No field selected",
+            encryption: {
+                formReadOnly: "This form is read-only.",
+                read: {
+                    enabledDescription: "This field will be sent to the extension encrypted.",
+                    markFirst: "Mark this field as READ in the tree to enable encryption.",
+                    needCertificate: "Add a certificate to enable encryption.",
+                    notAllowed: "Read is not allowed for this field.",
+                    title: "Read encrypted"
+                },
+                title: "Encryption",
+                write: {
+                    enabledDescription: "The extension will return this field's value encrypted.",
+                    markFirst: "Mark this field as WRITE in the tree to enable encryption.",
+                    notAllowed: "Write is not allowed for this field.",
+                    title: "Write encrypted"
+                }
+            },
             readOnlyBadge: "Read-Only",
             title: "Field Configuration"
         },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5084,6 +5084,9 @@ importers:
       '@asgardeo/auth-react':
         specifier: ^5.6.1
         version: 5.6.1(@babel/runtime-corejs3@7.29.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/material':
+        specifier: ^5.13.0
+        version: 5.18.0(@emotion/react@11.14.0(@types/react@18.0.18)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.0.18)(react@18.3.1))(@types/react@18.0.18)(react@18.3.1))(@types/react@18.0.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@oxygen-ui/react':
         specifier: 'catalog:'
         version: 2.4.6(43a10c969c8ffe9f55ba3c36a34c927d)
@@ -5114,6 +5117,9 @@ importers:
       axios:
         specifier: 1.7.0
         version: 1.7.0
+      classnames:
+        specifier: ^2.2.6
+        version: 2.5.1
       final-form:
         specifier: ^4.20.10
         version: 4.20.10


### PR DESCRIPTION
## Purpose
Add encryption support for flow extensions so that flow extension configuration data can be encrypted.

## Related Issue
- https://github.com/wso2/product-is/issues/28129

## Implementation
Extends the flow extensions feature to support encryption of configuration data. Changes span the flow extension create wizard, edit settings (access config, endpoint, general), the flow context tree components, and the flow extension models, along with the corresponding i18n namespace and translation additions.