### PR TITLE
Pass anonymous profile tracker as a property in self registration

### DIFF
--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
@@ -411,6 +411,15 @@
         properties.add(spIdProperty);
         properties.add(appIsAccessUrlAvailableProperty);
 
+        // Pass the anonymous profile tracker as a property so that it is available through the identity context
+        // during registration (e.g. for external profile linking), in addition to the cdsProfile claim above.
+        if (StringUtils.isNotBlank(cdsProfileCookie)) {
+            Property anonymousProfileTrackerProperty = new Property();
+            anonymousProfileTrackerProperty.setKey("anonymous_profile_tracker");
+            anonymousProfileTrackerProperty.setValue(cdsProfileCookie);
+            properties.add(anonymousProfileTrackerProperty);
+        }
+
         SelfUserRegistrationRequest selfUserRegistrationRequest = new SelfUserRegistrationRequest();
         selfUserRegistrationRequest.setUser(selfRegistrationUser);
         selfUserRegistrationRequest.setProperties(properties);


### PR DESCRIPTION
## Purpose

Send the anonymous profile tracker value as a request property from the recovery portal self registration flow, so that it can be propagated through the identity context during registration.

## Changes

- Add the `anonymous_profile_tracker` property to the self registration request in `self-registration-process.jsp`, populated from the existing value already read on the page. The existing claim handling is left unchanged.
