### PR TITLE
fix(branding): remove decorative input from tab order in sign-up preview

### DIFF
--- a/features/admin.branding.v1/components/preview/sign-in-box/fragments/sign-up-fragment.tsx
+++ b/features/admin.branding.v1/components/preview/sign-in-box/fragments/sign-up-fragment.tsx
@@ -436,7 +436,7 @@ const SignUpFragment: FunctionComponent<SignUpFragmentInterface> = (props: SignU
                             >
                                 <input type="hidden" id="country" name="http://wso2.org/claims/country" />
                                 <i className="dropdown icon"></i>
-                                <input className="search" autoComplete="off" tabIndex={ 0 } role="presentation" />
+                                <input className="search" autoComplete="off" tabIndex={ -1 } role="presentation" />
                                 <div className="default text">Enter Country</div>
                             </div>
 


### PR DESCRIPTION
### Purpose
React Doctor flagged `role="presentation"` on an `<input>` in the sign-up
branding preview as invalid, since interactive elements shouldn't carry
non-interactive roles. However, this input lives in a static branding
*preview* skeleton (no onClick/onChange/state) — it's a decorative mockup of
a country dropdown, not a real functional control.

Removing `role="presentation"` outright would make things worse: a screen
reader user would be told this is a real interactive combobox that does
nothing when activated.

The actual inconsistency is `tabIndex={0}` combined with `role="presentation"`
— the element is marked decorative for screen readers but still reachable by
keyboard tabbing. This PR changes `tabIndex={0}` to `tabIndex={-1}` so the
dead, non-functional preview element is removed from the tab order entirely,
consistent with its `role="presentation"`, instead of removing the role and
making a non-functional element announce as interactive.

### Related Issues
- Fixes wso2/product-is#27924

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.