### PR TITLE
Fix form reset on name field when claims load in create mode

### DIFF
--- a/.changeset/easy-zoos-juggle.md
+++ b/.changeset/easy-zoos-juggle.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/admin.consents.v1": patch
+---
+
+Fix form reset on name field when claims load in create mode

--- a/features/admin.consents.v1/components/edit-preference-management.tsx
+++ b/features/admin.consents.v1/components/edit-preference-management.tsx
@@ -81,6 +81,12 @@ const CLAIMS_PARAMS: ClaimsGetParams = {
     sort: null
 };
 
+const CREATE_INITIAL_VALUES: PreferenceFormValuesInterface = {
+    attributes: [],
+    description: "",
+    name: ""
+};
+
 /**
  * Generates the next version label from the current label.
  *
@@ -135,11 +141,7 @@ export const EditPreferenceManagement: FunctionComponent<EditPreferenceManagemen
     const initialValues: PreferenceFormValuesInterface | null = useMemo(
         (): PreferenceFormValuesInterface | null => {
             if (isCreateMode) {
-                return {
-                    attributes: [],
-                    description: "",
-                    name: ""
-                };
+                return CREATE_INITIAL_VALUES;
             }
 
             if (!consent) {


### PR DESCRIPTION
This pull request addresses a bug where the name field in the form was being reset unexpectedly when claims loaded in create mode. The fix ensures that the form retains its values correctly during the creation process.

**Bug fix for form reset in create mode:**

* Fixed an issue where the name field in the create preference form was reset when claims were loaded, by introducing a `CREATE_INITIAL_VALUES` constant and using it for initial values in create mode (`features/admin.consents.v1/components/edit-preference-management.tsx`). [[1]](diffhunk://#diff-c75921afbd055d55fa74770b4dfdb1025280299b401411f29e26de70eec41183R84-R89) [[2]](diffhunk://#diff-c75921afbd055d55fa74770b4dfdb1025280299b401411f29e26de70eec41183L138-R144)
* Added a changeset entry documenting the patch fix for both `@wso2is/console` and `@wso2is/admin.consents.v1` packages (`.changeset/easy-zoos-juggle.md`).