### PR TITLE
Pass product name and plan to Moesif canvas iframe URL

### DIFF
--- a/.changeset/moesif-canvas-product-plan.md
+++ b/.changeset/moesif-canvas-product-plan.md
@@ -1,5 +1,6 @@
 ---
 "@wso2is/admin.analytics.v1": patch
+"@wso2is/console": patch
 ---
 
 Pass the product name and subscription plan to the Moesif embedded canvas URL

--- a/.changeset/moesif-canvas-product-plan.md
+++ b/.changeset/moesif-canvas-product-plan.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.analytics.v1": patch
+---
+
+Pass the product name and subscription plan to the Moesif embedded canvas URL

--- a/features/admin.analytics.v1/components/moesif-canvas-iframe.tsx
+++ b/features/admin.analytics.v1/components/moesif-canvas-iframe.tsx
@@ -146,7 +146,7 @@ interface MoesifCanvasIframePropsInterface {
     /**
      * Base URL of the Moesif Embedded Portal, e.g. `https://www.moesif.com`.
      * The iframe is loaded at
-     * `{embeddingDomain}/wrap/app/{orgId}-{appId}/product={product}&plan={plan}canvas#auth=post`.
+     * `{embeddingDomain}/wrap/app/{orgId}-{appId}/canvas?product={product}&plan={plan}#auth=post`.
      */
     embeddingDomain: string;
 }
@@ -368,7 +368,7 @@ const MoesifCanvasIframe: FunctionComponent<MoesifCanvasIframePropsInterface> = 
     // it is URL-encoded before being placed in the canvas URL.
     const iframeSrc: string = dashboardInfo
         ? `${ embeddingDomain }/wrap/app/${ dashboardInfo.moesifOrgId }-${ dashboardInfo.moesifAppId }`
-            + `/product=${ encodeURIComponent(productName) }&plan=${ plan }canvas#auth=post`
+            + `/canvas?product=${ encodeURIComponent(productName) }&plan=${ plan }#auth=post`
         : "";
 
     return (

--- a/features/admin.analytics.v1/components/moesif-canvas-iframe.tsx
+++ b/features/admin.analytics.v1/components/moesif-canvas-iframe.tsx
@@ -21,6 +21,7 @@ import { Theme, styled, useTheme } from "@mui/material/styles";
 import Box from "@oxygen-ui/react/Box";
 import Skeleton from "@oxygen-ui/react/Skeleton";
 import Typography from "@oxygen-ui/react/Typography";
+import { AppState } from "@wso2is/admin.core.v1/store";
 import useSubscription, { UseSubscriptionInterface } from "@wso2is/admin.subscription.v1/hooks/use-subscription";
 import React, {
     FunctionComponent,
@@ -32,8 +33,9 @@ import React, {
     useState
 } from "react";
 import { useTranslation } from "react-i18next";
+import { useSelector } from "react-redux";
 import { getMoesifDashboardInfo } from "../api/get-moesif-dashboard-info";
-import { MoesifDashboardConstants } from "../constants/moesif-dashboard-constants";
+import { MoesifDashboardConstants, MoesifDashboardPlan } from "../constants/moesif-dashboard-constants";
 import { MoesifDashboardInfoInterface } from "../models/moesif-analytics";
 
 /**
@@ -143,7 +145,8 @@ interface MoesifCanvasIframePropsInterface {
     "data-componentid"?: string;
     /**
      * Base URL of the Moesif Embedded Portal, e.g. `https://www.moesif.com`.
-     * The iframe is loaded at `{embeddingDomain}/wrap/app/{orgId}-{appId}/canvas#auth=post`.
+     * The iframe is loaded at
+     * `{embeddingDomain}/wrap/app/{orgId}-{appId}/product={product}&plan={plan}canvas#auth=post`.
      */
     embeddingDomain: string;
 }
@@ -169,6 +172,7 @@ const MoesifCanvasIframe: FunctionComponent<MoesifCanvasIframePropsInterface> = 
     const { t } = useTranslation();
     const theme: Theme = useTheme();
     const { tierName }: UseSubscriptionInterface = useSubscription();
+    const productName: string = useSelector((state: AppState) => state?.config?.ui?.productName) ?? "";
 
     const [ dashboardInfo, setDashboardInfo ] = useState<MoesifDashboardInfoInterface | null>(null);
     const [ isLoading, setIsLoading ] = useState<boolean>(true);
@@ -189,6 +193,13 @@ const MoesifCanvasIframe: FunctionComponent<MoesifCanvasIframePropsInterface> = 
     // and swaps the dashboards live.
     const template: Record<string, unknown> = useMemo(
         () => MoesifDashboardConstants.getTemplate(tierName),
+        [ tierName ]
+    );
+
+    // Plan identifier for the canvas URL, resolved from the subscription tier
+    // with the same tier-to-template mapping used to pick the dashboard set.
+    const plan: MoesifDashboardPlan = useMemo(
+        () => MoesifDashboardConstants.getPlan(tierName),
         [ tierName ]
     );
 
@@ -353,8 +364,11 @@ const MoesifCanvasIframe: FunctionComponent<MoesifCanvasIframePropsInterface> = 
         );
     }
 
+    // The product name can contain spaces (e.g. "WSO2 Identity Platform"), so
+    // it is URL-encoded before being placed in the canvas URL.
     const iframeSrc: string = dashboardInfo
-        ? `${ embeddingDomain }/wrap/app/${ dashboardInfo.moesifOrgId }-${ dashboardInfo.moesifAppId }/canvas#auth=post`
+        ? `${ embeddingDomain }/wrap/app/${ dashboardInfo.moesifOrgId }-${ dashboardInfo.moesifAppId }`
+            + `/product=${ encodeURIComponent(productName) }&plan=${ plan }canvas#auth=post`
         : "";
 
     return (

--- a/features/admin.analytics.v1/constants/moesif-dashboard-constants.ts
+++ b/features/admin.analytics.v1/constants/moesif-dashboard-constants.ts
@@ -22,6 +22,16 @@ import freeDashboardTemplate from "../assets/moesif-dashboard-free.json";
 import premiumDashboardTemplate from "../assets/moesif-dashboard-premium.json";
 
 /**
+ * Plan identifier passed to the Moesif Embedded Portal in the canvas URL.
+ * Mirrors the three tier-aware dashboard templates.
+ */
+export enum MoesifDashboardPlan {
+    FREE = "free",
+    ESSENTIALS = "essentials",
+    PREMIUM = "premium"
+}
+
+/**
  * Constants for the tier-aware Moesif Canvas dashboard templates.
  */
 export class MoesifDashboardConstants {
@@ -62,5 +72,32 @@ export class MoesifDashboardConstants {
     public static getTemplate(tierName: TenantTier): Record<string, unknown> {
         return MoesifDashboardConstants.TEMPLATES[tierName]
             ?? MoesifDashboardConstants.TEMPLATES[TenantTier.FREE];
+    }
+
+    /**
+     * Plan identifier per subscription tier. Mirrors the tier-to-template
+     * mapping in {@link TEMPLATES} so the same tier resolves to a consistent
+     * dashboard template and plan.
+     */
+    public static readonly PLANS: Record<TenantTier, MoesifDashboardPlan> = {
+        [ TenantTier.ENTERPRISE ]: MoesifDashboardPlan.PREMIUM,
+        [ TenantTier.ESSENTIALS ]: MoesifDashboardPlan.ESSENTIALS,
+        [ TenantTier.FREE ]: MoesifDashboardPlan.FREE,
+        [ TenantTier.FREE_V2 ]: MoesifDashboardPlan.FREE,
+        [ TenantTier.PROFESSIONAL ]: MoesifDashboardPlan.PREMIUM,
+        [ TenantTier.PYG ]: MoesifDashboardPlan.PREMIUM,
+        [ TenantTier.PYG_TRIAL ]: MoesifDashboardPlan.PREMIUM
+    };
+
+    /**
+     * Resolves the plan identifier for a given subscription tier.
+     *
+     * @param tierName - Subscription tier of the tenant.
+     * @returns The plan identifier. Falls back to the Free plan when the
+     *          tier is unknown.
+     */
+    public static getPlan(tierName: TenantTier): MoesifDashboardPlan {
+        return MoesifDashboardConstants.PLANS[tierName]
+            ?? MoesifDashboardConstants.PLANS[TenantTier.FREE];
     }
 }


### PR DESCRIPTION
### Purpose

Pass the product name and subscription plan to the Moesif embedded canvas URL so the embedded portal can render the correct product/plan-scoped view.

### Changes

- `moesif-canvas-iframe.tsx`
  - Read `productName` from `state.config.ui.productName` (deployment.config.json).
  - Resolve the `plan` from the subscription tier using the same tier-to-template mapping used to pick the dashboard set.
  - Build the iframe URL as:
    ```
    {embeddingDomain}/wrap/app/{orgId}-{appId}/canvas?product={product}&plan={plan}#auth=post
    ```
    `productName` is URL-encoded (it contains spaces, e.g. "WSO2 Identity Platform").
- `moesif-dashboard-constants.ts`
  - Add a `MoesifDashboardPlan` enum (`free` / `essentials` / `premium`) and a `PLANS` map + `getPlan(tierName)`, mirroring `TEMPLATES` / `getTemplate` so tier, template, and plan stay consistent.

### Tier to plan mapping

| Tier | Plan |
|------|------|
| Free / FreeV2 | free |
| Essentials | essentials |
| Professional / Enterprise / PYG / PYG-Trial | premium |
| unknown (fallback) | free |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
