### PR TITLE
Support app ID as the CDS application identifier and display application name in UIs

### DIFF
--- a/.changeset/app-identifier-improvements.md
+++ b/.changeset/app-identifier-improvements.md
@@ -1,0 +1,8 @@
+---
+"@wso2is/console": patch
+"@wso2is/admin.applications.v1": patch
+"@wso2is/admin.cds.v1": patch
+"@wso2is/i18n": patch
+---
+
+Support app ID as the CDS application identifier based on a config and always display application names in CDS UIs

--- a/.changeset/app-identifier-improvements.md
+++ b/.changeset/app-identifier-improvements.md
@@ -2,6 +2,7 @@
 "@wso2is/console": patch
 "@wso2is/admin.applications.v1": patch
 "@wso2is/admin.cds.v1": patch
+"@wso2is/admin.core.v1": patch
 "@wso2is/i18n": patch
 ---
 

--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -103,6 +103,8 @@
         {% for key, value in console.extensions.items() %}
         {% if key == 'cds_host' %}
             "cdsHost": "{{ value }}"{{ "," if not loop.last }}
+        {% elif key == 'cds_application_identifier_type' %}
+            "cdsApplicationIdentifierType": "{{ value }}"{{ "," if not loop.last }}
         {% elif value is number or value is boolean %}
             "{{ key }}": {{ value }}{{ "," if not loop.last }}
         {% elif value is mapping %}

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -41,6 +41,7 @@
                 "termsOfServiceUrl": ""
             }
         },
+        "cdsApplicationIdentifierType": "client_id",
         "cdsHost": "",
         "defaultBrandedLoginScreenCopyright": "${copyright} ${year} WSO2 LLC.",
         "emailTemplates": [

--- a/features/admin.applications.v1/api/application.ts
+++ b/features/admin.applications.v1/api/application.ts
@@ -215,6 +215,8 @@ export const updateApplicationDetails = (
  * @param limit - Maximum Limit of the application List.
  * @param offset - Offset for get to start.
  * @param filter - Search filter.
+ * @param excludeSystemPortals - Whether to exclude system portal applications.
+ * @param attributes - Additional attributes to include in the response (comma-separated).
  *
  * @returns A promise containing the response.
  */
@@ -222,7 +224,8 @@ export const getApplicationList = (
     limit: number,
     offset: number,
     filter: string,
-    excludeSystemPortals:boolean = false
+    excludeSystemPortals:boolean = false,
+    attributes?: string
 ): Promise<ApplicationListInterface> => {
     const requestConfig: AxiosRequestConfig = {
         headers: {
@@ -232,6 +235,7 @@ export const getApplicationList = (
         },
         method: HttpMethods.GET,
         params: {
+            attributes,
             excludeSystemPortals,
             filter,
             limit,

--- a/features/admin.cds.v1/components/advanced-search-with-multiple-filters.tsx
+++ b/features/admin.cds.v1/components/advanced-search-with-multiple-filters.tsx
@@ -51,6 +51,7 @@ import React, {
 import { useTranslation } from "react-i18next";
 import { Divider, Form, Grid } from "semantic-ui-react";
 import { SWRResponse } from "swr";
+import { useCDSApplications } from "../hooks/use-cds-applications";
 import { useProfileSchemaDropdownOptions } from "../hooks/use-profile-attributes";
 import { AND_OPERATOR, APPLICATION_DATA, IDENTITY_ATTRIBUTES, TRAITS } from "../models/constants";
 import { FilterAttributeOption, ProfileSchemaScopeResponse } from "../models/profile-attributes";
@@ -148,6 +149,8 @@ export const AdvancedSearchWithMultipleFilters: FunctionComponent<AdvancedSearch
     const appDataResult: ProfileSchemaDropdownResult = useProfileSchemaDropdownOptions(
         activeScopesSet.has("application_data") ? "application_data" : null
     );
+
+    const { getApplicationDisplayName } = useCDSApplications(activeScopesSet.has("application_data"));
 
     // Combine results into a lookup map
     const optionsByScope: Record<string, FilterAttributeOption[]> = useMemo(() => {
@@ -307,7 +310,10 @@ export const AdvancedSearchWithMultipleFilters: FunctionComponent<AdvancedSearch
             .filter((o: FilterAttributeOption) => o.applicationId)
             .map((o: FilterAttributeOption) => o.applicationId as string);
 
-        return Array.from(new Set(ids)).sort();
+        return Array.from(new Set(ids)).sort(
+            (a: string, b: string): number =>
+                getApplicationDisplayName(a).localeCompare(getApplicationDisplayName(b))
+        );
     };
 
     const getAttributesForRow = (row: FilterGroup): FilterAttributeOption[] => {
@@ -522,7 +528,7 @@ export const AdvancedSearchWithMultipleFilters: FunctionComponent<AdvancedSearch
                                                                     type="dropdown"
                                                                     children={ apps.map((id: string) => ({
                                                                         key: id,
-                                                                        text: id,
+                                                                        text: getApplicationDisplayName(id),
                                                                         value: id
                                                                     })) }
                                                                     value={ row.applicationId }

--- a/features/admin.cds.v1/components/profile-attribute.tsx
+++ b/features/admin.cds.v1/components/profile-attribute.tsx
@@ -47,6 +47,7 @@ import { RouteComponentProps } from "react-router";
 import { Dispatch } from "redux";
 import { Grid, Icon, Image, Label, Message, TabProps } from "semantic-ui-react";
 import { deleteSchemaAttributeById, updateSchemaAttributeById } from "../api/profile-attributes";
+import { useCDSApplications } from "../hooks/use-cds-applications";
 import { useSchemaAttributeById } from "../hooks/use-profile-attributes";
 import { useSearchSubAttributes } from "../hooks/use-search-sub-attributes";
 import { SCOPE_CONFIG, SchemaListingScope } from "../models/profile-attribute-listing";
@@ -109,6 +110,8 @@ const ProfileAttributeEditPage: FunctionComponent<RouteComponentProps<RouteParam
     const [ attribute, setAttribute ] = useState<ProfileSchemaAttribute>(null);
     const [ subAttributes, setSubAttributes ] = useState<ProfileSchemaSubAttributeRef[]>([]);
     const [ currentValueType, setCurrentValueType ] = useState<ValueType>(null);
+
+    const { getApplicationDisplayName } = useCDSApplications(scope === "application_data");
 
     // Canonical values editor
     const [ canonicalValues, setCanonicalValues ] = useState<CanonicalValues[]>([]);
@@ -481,12 +484,12 @@ const ProfileAttributeEditPage: FunctionComponent<RouteComponentProps<RouteParam
                                 <Grid.Row columns={ 1 }>
                                     <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
                                         <Field.Input
-                                            ariaLabel="Application identifier"
+                                            ariaLabel="Application"
                                             inputType="default"
                                             name="application_identifier_display"
                                             label={ t("customerDataService:profileAttributes.edit."+
                                                 "fields.applicationIdentifier.label") }
-                                            value={ attribute.application_identifier }
+                                            value={ getApplicationDisplayName(attribute.application_identifier) }
                                             readOnly
                                             maxLength={ 200 }
                                             minLength={ 3 }
@@ -777,7 +780,8 @@ const ProfileAttributeEditPage: FunctionComponent<RouteComponentProps<RouteParam
             isUpdating,
             isDeleting,
             isLoadingSubAttrs,
-            currentValueType
+            currentValueType,
+            getApplicationDisplayName
         ]
     );
 

--- a/features/admin.cds.v1/components/profile-attribute.tsx
+++ b/features/admin.cds.v1/components/profile-attribute.tsx
@@ -481,27 +481,50 @@ const ProfileAttributeEditPage: FunctionComponent<RouteComponentProps<RouteParam
 
                             { /* Application identifier (application_data only) */ }
                             { scope === "application_data" && attribute.application_identifier && (
-                                <Grid.Row columns={ 1 }>
-                                    <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
-                                        <Field.Input
-                                            ariaLabel="Application"
-                                            inputType="default"
-                                            name="application_identifier_display"
-                                            label={ t("customerDataService:profileAttributes.edit."+
-                                                "fields.applicationIdentifier.label") }
-                                            value={ getApplicationDisplayName(attribute.application_identifier) }
-                                            readOnly
-                                            maxLength={ 200 }
-                                            minLength={ 3 }
-                                            data-componentid={ `${componentId}-application-identifier-input` }
-                                            width={ 16 }
-                                        />
-                                        <Hint>
-                                            { t("customerDataService:profileAttributes.edit."+
-                                            "fields.applicationIdentifier.hint") }
-                                        </Hint>
-                                    </Grid.Column>
-                                </Grid.Row>
+                                <>
+                                    <Grid.Row columns={ 1 }>
+                                        <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
+                                            <Field.Input
+                                                ariaLabel="Application identifier"
+                                                inputType="default"
+                                                name="application_identifier"
+                                                label={ t("customerDataService:profileAttributes.edit."+
+                                                    "fields.applicationIdentifier.label") }
+                                                value={ attribute.application_identifier }
+                                                readOnly
+                                                maxLength={ 200 }
+                                                minLength={ 3 }
+                                                data-componentid={ `${componentId}-application-identifier-input` }
+                                                width={ 16 }
+                                            />
+                                            <Hint>
+                                                { t("customerDataService:profileAttributes.edit."+
+                                                "fields.applicationIdentifier.hint") }
+                                            </Hint>
+                                        </Grid.Column>
+                                    </Grid.Row>
+                                    <Grid.Row columns={ 1 }>
+                                        <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
+                                            <Field.Input
+                                                ariaLabel="Application name"
+                                                inputType="default"
+                                                name="application_name_display"
+                                                label={ t("customerDataService:profileAttributes.edit."+
+                                                    "fields.applicationName.label") }
+                                                value={ getApplicationDisplayName(attribute.application_identifier) }
+                                                readOnly
+                                                maxLength={ 200 }
+                                                minLength={ 3 }
+                                                data-componentid={ `${componentId}-application-name-input` }
+                                                width={ 16 }
+                                            />
+                                            <Hint>
+                                                { t("customerDataService:profileAttributes.edit."+
+                                                "fields.applicationName.hint") }
+                                            </Hint>
+                                        </Grid.Column>
+                                    </Grid.Row>
+                                </>
                             ) }
 
                             { /* Value type */ }

--- a/features/admin.cds.v1/components/profile-attributes.tsx
+++ b/features/admin.cds.v1/components/profile-attributes.tsx
@@ -43,6 +43,7 @@ import { Dispatch } from "redux";
 import { Header, Label, SemanticICONS, SemanticWIDTHS } from "semantic-ui-react";
 
 import { deleteSchemaAttributeById } from "../api/profile-attributes";
+import { useCDSApplications } from "../hooks/use-cds-applications";
 import { ProfileSchemaListingRow, SCOPE_CONFIG } from "../models/profile-attribute-listing";
 
 const COL_WIDTH_ATTRIBUTE: SemanticWIDTHS = 7;
@@ -67,6 +68,16 @@ export const ProfileSchemaListing: FunctionComponent<ProfileSchemaListingPropsIn
 
     const [ deleting, setDeleting ] = useState<ProfileSchemaListingRow | null>(null);
     const [ showDeleteModal, setShowDeleteModal ] = useState<boolean>(false);
+
+    const hasApplicationDataRows: boolean = useMemo(
+        (): boolean => rows.some(
+            (row: ProfileSchemaListingRow): boolean =>
+                row.scope === "application_data" && Boolean(row.belongs_to)
+        ),
+        [ rows ]
+    );
+
+    const { getApplicationDisplayName } = useCDSApplications(hasApplicationDataRows);
 
     const columns: TableColumnInterface[] = useMemo(() => ([
         {
@@ -118,7 +129,7 @@ export const ProfileSchemaListing: FunctionComponent<ProfileSchemaListingPropsIn
                         />
                         { row.scope === "application_data" && row.belongs_to && (
                             <Label pointing="left" size="small">
-                                { row.belongs_to }
+                                { getApplicationDisplayName(row.belongs_to) }
                             </Label>
                         ) }
                     </>
@@ -137,7 +148,7 @@ export const ProfileSchemaListing: FunctionComponent<ProfileSchemaListingPropsIn
             title: "",
             width: COL_WIDTH_ACTIONS
         }
-    ]), [ componentId, t ]);
+    ]), [ componentId, t, getApplicationDisplayName ]);
 
     const actions: TableActionsInterface[] = useMemo(() => ([
         {

--- a/features/admin.cds.v1/hooks/use-cds-applications.ts
+++ b/features/admin.cds.v1/hooks/use-cds-applications.ts
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { getApplicationList } from "@wso2is/admin.applications.v1/api/application";
+import {
+    ApplicationListInterface,
+    ApplicationListItemInterface
+} from "@wso2is/admin.applications.v1/models/application";
+import { MutableRefObject, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { CDSApplicationIdentifierType } from "../models/config";
+import { getCDSApplicationIdentifierType } from "../utils/application-identifier-utils";
+
+/**
+ * An application enriched with the identifier used when communicating with CDS APIs.
+ */
+export interface CDSApplicationInterface {
+    /**
+     * Identity Server application UUID.
+     */
+    id: string;
+    /**
+     * Application display name.
+     */
+    name: string;
+    /**
+     * Identifier submitted to CDS APIs. Resolved based on the configured
+     * CDS application identifier type: the app UUID in `app_id` mode, or the
+     * OAuth client ID (falling back to the SAML issuer) in `client_id` mode.
+     */
+    identifier: string;
+}
+
+export interface UseCDSApplicationsReturn {
+    /**
+     * Applications with a resolvable CDS identifier.
+     */
+    applications: CDSApplicationInterface[];
+    /**
+     * Resolves a CDS application identifier (app UUID, client ID or issuer)
+     * to the application display name. Falls back to the identifier itself
+     * when the application cannot be resolved.
+     */
+    getApplicationDisplayName: (identifier: string) => string;
+    isLoading: boolean;
+}
+
+/**
+ * Number of applications fetched per page when resolving the full list.
+ */
+const APPLICATION_LIST_PAGE_SIZE: number = 100;
+
+/**
+ * Fetches all applications by paginating through the application list API
+ * until `totalResults` is covered.
+ *
+ * @returns All applications with client ID and issuer attributes.
+ */
+const fetchAllApplications = async (): Promise<ApplicationListItemInterface[]> => {
+    const allApplications: ApplicationListItemInterface[] = [];
+    let offset: number = 0;
+    let totalResults: number = 0;
+
+    do {
+        const page: ApplicationListInterface = await getApplicationList(
+            APPLICATION_LIST_PAGE_SIZE,
+            offset,
+            null,
+            true,
+            "clientId,issuer"
+        );
+        const pageApplications: ApplicationListItemInterface[] = page?.applications ?? [];
+
+        if (pageApplications.length === 0) {
+            break;
+        }
+
+        allApplications.push(...pageApplications);
+        totalResults = page?.totalResults ?? 0;
+        offset += pageApplications.length;
+    } while (offset < totalResults);
+
+    return allApplications;
+};
+
+/**
+ * Hook to fetch applications for CDS application data operations.
+ *
+ * Provides the config-aware identifier to submit to CDS APIs and a resolver
+ * to always display application names in the UI regardless of the identifier
+ * type stored in CDS.
+ *
+ * @param shouldFetch - Should fetch the application list.
+ * @returns Applications, a display-name resolver and the loading state.
+ */
+export const useCDSApplications = (shouldFetch: boolean = true): UseCDSApplicationsReturn => {
+
+    const identifierType: CDSApplicationIdentifierType = getCDSApplicationIdentifierType();
+
+    const [ applicationList, setApplicationList ] = useState<ApplicationListItemInterface[]>([]);
+    const [ isLoading, setIsLoading ] = useState<boolean>(shouldFetch);
+    const hasFetchedRef: MutableRefObject<boolean> = useRef<boolean>(false);
+
+    useEffect(() => {
+        if (!shouldFetch || hasFetchedRef.current) {
+            return;
+        }
+
+        hasFetchedRef.current = true;
+
+        let isCancelled: boolean = false;
+
+        setIsLoading(true);
+
+        fetchAllApplications()
+            .then((fetchedApplications: ApplicationListItemInterface[]): void => {
+                if (!isCancelled) {
+                    setApplicationList(fetchedApplications);
+                }
+            })
+            // Fail silently - the UI falls back to displaying raw identifiers.
+            .catch((): void => undefined)
+            .finally((): void => {
+                if (!isCancelled) {
+                    setIsLoading(false);
+                }
+            });
+
+        return (): void => {
+            isCancelled = true;
+        };
+    }, [ shouldFetch ]);
+
+    const applications: CDSApplicationInterface[] = useMemo((): CDSApplicationInterface[] => {
+        return applicationList
+            .map((app: ApplicationListItemInterface): CDSApplicationInterface => ({
+                id: app.id ?? "",
+                identifier: identifierType === CDSApplicationIdentifierType.APP_ID
+                    ? app.id ?? ""
+                    : app.clientId || app.issuer || "",
+                name: app.name
+            }))
+            .filter((app: CDSApplicationInterface): boolean => Boolean(app.identifier));
+    }, [ applicationList, identifierType ]);
+
+    // Index names by every known identifier so display resolution works for
+    // both identifier modes and for data stored before a mode switch.
+    const displayNamesByIdentifier: Map<string, string> = useMemo((): Map<string, string> => {
+        const names: Map<string, string> = new Map<string, string>();
+
+        applicationList.forEach((app: ApplicationListItemInterface): void => {
+            if (app.id) names.set(app.id, app.name);
+            if (app.clientId) names.set(app.clientId, app.name);
+            if (app.issuer) names.set(app.issuer, app.name);
+        });
+
+        return names;
+    }, [ applicationList ]);
+
+    const getApplicationDisplayName: (identifier: string) => string = useCallback(
+        (identifier: string): string =>
+            displayNamesByIdentifier.get(identifier) ?? identifier,
+        [ displayNamesByIdentifier ]
+    );
+
+    return {
+        applications,
+        getApplicationDisplayName,
+        isLoading
+    };
+};

--- a/features/admin.cds.v1/hooks/use-cds-applications.ts
+++ b/features/admin.cds.v1/hooks/use-cds-applications.ts
@@ -45,7 +45,7 @@ export interface CDSApplicationInterface {
     identifier: string;
 }
 
-export interface UseCDSApplicationsReturn {
+interface UseCDSApplicationsReturn {
     /**
      * Applications with a resolvable CDS identifier.
      */
@@ -70,32 +70,33 @@ const APPLICATION_LIST_PAGE_SIZE: number = 100;
  *
  * @returns All applications with client ID and issuer attributes.
  */
-const fetchAllApplications = async (): Promise<ApplicationListItemInterface[]> => {
-    const allApplications: ApplicationListItemInterface[] = [];
-    let offset: number = 0;
-    let totalResults: number = 0;
+const fetchAllApplications: () => Promise<ApplicationListItemInterface[]> =
+    async (): Promise<ApplicationListItemInterface[]> => {
+        const allApplications: ApplicationListItemInterface[] = [];
+        let offset: number = 0;
+        let totalResults: number = 0;
 
-    do {
-        const page: ApplicationListInterface = await getApplicationList(
-            APPLICATION_LIST_PAGE_SIZE,
-            offset,
-            null,
-            true,
-            "clientId,issuer"
-        );
-        const pageApplications: ApplicationListItemInterface[] = page?.applications ?? [];
+        do {
+            const page: ApplicationListInterface = await getApplicationList(
+                APPLICATION_LIST_PAGE_SIZE,
+                offset,
+                null,
+                true,
+                "clientId,issuer"
+            );
+            const pageApplications: ApplicationListItemInterface[] = page?.applications ?? [];
 
-        if (pageApplications.length === 0) {
-            break;
-        }
+            if (pageApplications.length === 0) {
+                break;
+            }
 
-        allApplications.push(...pageApplications);
-        totalResults = page?.totalResults ?? 0;
-        offset += pageApplications.length;
-    } while (offset < totalResults);
+            allApplications.push(...pageApplications);
+            totalResults = page?.totalResults ?? 0;
+            offset += pageApplications.length;
+        } while (offset < totalResults);
 
-    return allApplications;
-};
+        return allApplications;
+    };
 
 /**
  * Hook to fetch applications for CDS application data operations.
@@ -133,7 +134,10 @@ export const useCDSApplications = (shouldFetch: boolean = true): UseCDSApplicati
                 }
             })
             // Fail silently - the UI falls back to displaying raw identifiers.
-            .catch((): void => undefined)
+            // Clear the latch so a later shouldFetch change can retry the fetch.
+            .catch((): void => {
+                hasFetchedRef.current = false;
+            })
             .finally((): void => {
                 if (!isCancelled) {
                     setIsLoading(false);

--- a/features/admin.cds.v1/models/config.ts
+++ b/features/admin.cds.v1/models/config.ts
@@ -17,6 +17,20 @@
  */
 
 /**
+ * Application identifier types used when communicating with CDS APIs.
+ */
+export enum CDSApplicationIdentifierType {
+    /**
+     * Applications are identified by the Identity Server application UUID.
+     */
+    APP_ID = "app_id",
+    /**
+     * Applications are identified by the OAuth client ID (legacy behavior).
+     */
+    CLIENT_ID = "client_id"
+}
+
+/**
  * CDS Configuration response interface.
  */
 export interface CDSConfig {

--- a/features/admin.cds.v1/pages/profile-attribute-create-page.tsx
+++ b/features/admin.cds.v1/pages/profile-attribute-create-page.tsx
@@ -34,7 +34,6 @@ import Stepper from "@oxygen-ui/react/Stepper";
 import TextField from "@oxygen-ui/react/TextField";
 import Typography from "@oxygen-ui/react/Typography";
 import { TrashIcon } from "@oxygen-ui/react-icons";
-import { useApplicationList } from "@wso2is/admin.applications.v1/api/application";
 import { AppConstants } from "@wso2is/admin.core.v1/constants/app-constants";
 import { history } from "@wso2is/admin.core.v1/helpers/history";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
@@ -57,6 +56,7 @@ import { useDispatch } from "react-redux";
 import { Dispatch } from "redux";
 import { Icon, Message } from "semantic-ui-react";
 import { createSchemaAttributes, fetchProfileSchemaByScope } from "../api/profile-attributes";
+import { CDSApplicationInterface, useCDSApplications } from "../hooks/use-cds-applications";
 import { APPLICATION_DATA, TRAITS } from "../models/constants";
 import type { SchemaListingScope } from "../models/profile-attribute-listing";
 import type {
@@ -68,13 +68,6 @@ import type {
     ValueType
 } from "../models/profile-attributes";
 import { stripScopePrefix } from "../utils/profile-attribute-utils";
-
-// Minimal local interface covering only the fields consumed in this file.
-interface AppListItemInterface {
-    name: string;
-    clientId?: string;
-    issuer?: string;
-}
 
 const StepActionsContainer: typeof Box = styled(Box)(({ theme }: { theme: Theme }) => ({
     display: "flex",
@@ -159,8 +152,6 @@ const AttributeGeneralForm: React.ForwardRefExoticComponent<
         const [ isNameAvailable, setIsNameAvailable ] = useState<boolean | null>(
             initialValues?.name ? true : null
         );
-        const [ appIdentifierOptions, setAppIdentifierOptions ] =
-            useState<ApplicationIdentifierOptionInterface[]>([]);
 
         const debounceTimer: React.MutableRefObject<ReturnType<typeof setTimeout> | null> =
             useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -168,15 +159,29 @@ const AttributeGeneralForm: React.ForwardRefExoticComponent<
         const shouldFetchApplications: boolean = scope === APPLICATION_DATA;
 
         const {
-            data: applicationListData,
+            applications,
             isLoading: isLoadingAppIds
-        } = useApplicationList(
-            "advancedConfigurations,templateId,clientId,issuer",
-            null,
-            null,
-            null,
-            shouldFetchApplications,
-            true
+        } = useCDSApplications(shouldFetchApplications);
+
+        // The application name is always shown as the label while the config-resolved
+        // identifier (app UUID or client ID) is submitted to the CDS APIs.
+        const appIdentifierOptions: ApplicationIdentifierOptionInterface[] = useMemo(
+            (): ApplicationIdentifierOptionInterface[] => {
+                if (scope !== APPLICATION_DATA) return [];
+
+                return applications
+                    .map((app: CDSApplicationInterface): ApplicationIdentifierOptionInterface => ({
+                        label: app.name,
+                        value: app.identifier
+                    }))
+                    .sort(
+                        (
+                            a: ApplicationIdentifierOptionInterface,
+                            b: ApplicationIdentifierOptionInterface
+                        ): number => a.label.localeCompare(b.label)
+                    );
+            },
+            [ scope, applications ]
         );
 
         const scopeOptions: { value: ScopeValue; label: string }[] = useMemo(() => [
@@ -202,35 +207,6 @@ const AttributeGeneralForm: React.ForwardRefExoticComponent<
 
             return `${scope}.${name.trim()}`;
         }, [ scope, applicationIdentifier, name ]);
-
-        useEffect((): void => {
-            if (scope !== APPLICATION_DATA) {
-                setAppIdentifierOptions([]);
-
-                return;
-            }
-
-            if (!(applicationListData as { applications?: AppListItemInterface[] })?.applications) {
-                return;
-            }
-
-            const appList: { applications?: AppListItemInterface[] } =
-                applicationListData as { applications?: AppListItemInterface[] };
-            const options: ApplicationIdentifierOptionInterface[] = (appList.applications ?? [])
-                .map((app: AppListItemInterface): ApplicationIdentifierOptionInterface | null => {
-                    const id: string = app.clientId || app.issuer || "";
-
-                    if (!id) return null;
-
-                    return { label: id, value: id };
-                })
-                .filter(
-                    (opt: ApplicationIdentifierOptionInterface | null):
-                        opt is ApplicationIdentifierOptionInterface => opt !== null
-                );
-
-            setAppIdentifierOptions(options);
-        }, [ scope, applicationListData ]);
 
         useEffect((): (() => void) => {
             setIsNameAvailable(null);

--- a/features/admin.cds.v1/utils/application-identifier-utils.ts
+++ b/features/admin.cds.v1/utils/application-identifier-utils.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { CDSApplicationIdentifierType } from "../models/config";
+
+/**
+ * Resolves the application identifier type to use when communicating with CDS APIs.
+ *
+ * Reads the optional `extensions.cdsApplicationIdentifierType` deployment config.
+ * Any value other than `app_id` — including unset — selects the legacy
+ * `client_id` mode to match the CDS server default.
+ *
+ * @returns The configured CDS application identifier type.
+ */
+export const getCDSApplicationIdentifierType = (): CDSApplicationIdentifierType => {
+    const configuredType: string =
+        window["AppUtils"]?.getConfig()?.extensions?.cdsApplicationIdentifierType as string;
+
+    return configuredType === CDSApplicationIdentifierType.APP_ID
+        ? CDSApplicationIdentifierType.APP_ID
+        : CDSApplicationIdentifierType.CLIENT_ID;
+};

--- a/features/admin.core.v1/hooks/use-preview-features.ts
+++ b/features/admin.core.v1/hooks/use-preview-features.ts
@@ -17,8 +17,12 @@
  */
 
 import { FeatureStatus, useCheckFeatureStatus, useRequiredScopes } from "@wso2is/access-control";
+import { getApplicationList } from "@wso2is/admin.applications.v1/api/application";
+import { ApplicationListInterface } from "@wso2is/admin.applications.v1/models/application";
 import { updateCDSConfig } from "@wso2is/admin.cds.v1/api/config";
 import useCDSConfig from "@wso2is/admin.cds.v1/hooks/use-config";
+import { CDSApplicationIdentifierType } from "@wso2is/admin.cds.v1/models/config";
+import { getCDSApplicationIdentifierType } from "@wso2is/admin.cds.v1/utils/application-identifier-utils";
 import FeatureGateConstants from "@wso2is/admin.feature-gate.v1/constants/feature-gate-constants";
 import useFeatureGate from "@wso2is/admin.feature-gate.v1/hooks/use-feature-gate";
 import { AlertLevels, FeatureAccessConfigInterface } from "@wso2is/core/models";
@@ -32,8 +36,42 @@ import { history } from "../helpers/history";
 import { AppState } from "../store";
 import { addForceExpandedParent } from "../utils/route-utils";
 
-/** Added or removed as a system application when CDS is toggled. */
+/**
+ * Console system application client ID (reserved consumer key). Also the
+ * identifier registered with CDS in legacy `client_id` mode.
+ */
 const CDS_CONSOLE_APP: string = "CONSOLE";
+
+/**
+ * Resolves the identifier used to register the Console as a CDS system application,
+ * honoring the configured CDS application identifier type.
+ *
+ * In `client_id` mode this is the Console client ID (`CONSOLE`). In `app_id` mode
+ * the Console application UUID is looked up via the application list API.
+ *
+ * @returns The Console system application identifier for the configured mode.
+ * @throws If the Console application UUID cannot be resolved in `app_id` mode.
+ */
+const resolveConsoleSystemApplicationIdentifier = async (): Promise<string> => {
+    if (getCDSApplicationIdentifierType() !== CDSApplicationIdentifierType.APP_ID) {
+        return CDS_CONSOLE_APP;
+    }
+
+    // Console is a system portal, so system portals must NOT be excluded from the lookup.
+    const response: ApplicationListInterface = await getApplicationList(
+        1,
+        0,
+        `clientId eq ${CDS_CONSOLE_APP}`,
+        false
+    );
+    const consoleApplicationId: string | undefined = response?.applications?.[0]?.id;
+
+    if (!consoleApplicationId) {
+        throw new Error("Unable to resolve the Console application UUID for the CDS system application list.");
+    }
+
+    return consoleApplicationId;
+};
 
 /**
  * Preview features list item interface.
@@ -160,13 +198,23 @@ export const usePreviewFeatures = (): UsePreviewFeaturesReturnInterface => {
     const handleCDSToggle: (enable: boolean) => Promise<void> = useCallback(
         async (enable: boolean): Promise<void> => {
             const currentApps: string[] = cdsConfig?.system_applications ?? [];
-            const nextApps: string[] = enable
-                ? currentApps.length === 0
-                    ? [ CDS_CONSOLE_APP ]
-                    : currentApps
-                : currentApps.filter((app: string) => app !== CDS_CONSOLE_APP);
 
             try {
+                // Resolve the Console system application identifier for the configured mode.
+                // Aborts the toggle if the UUID cannot be resolved in `app_id` mode so that a
+                // wrong identifier is never written to the CDS system application list.
+                const consoleAppIdentifier: string = await resolveConsoleSystemApplicationIdentifier();
+
+                const nextApps: string[] = enable
+                    ? currentApps.includes(consoleAppIdentifier)
+                        ? currentApps
+                        : [ ...currentApps, consoleAppIdentifier ]
+                    // Remove both the resolved identifier and the legacy client ID to clear
+                    // any entry stored before an identifier type switch.
+                    : currentApps.filter(
+                        (app: string) => app !== consoleAppIdentifier && app !== CDS_CONSOLE_APP
+                    );
+
                 await updateCDSConfig({
                     cds_enabled: enable,
                     system_applications: nextApps

--- a/features/admin.core.v1/hooks/use-preview-features.ts
+++ b/features/admin.core.v1/hooks/use-preview-features.ts
@@ -209,11 +209,7 @@ export const usePreviewFeatures = (): UsePreviewFeaturesReturnInterface => {
                     ? currentApps.includes(consoleAppIdentifier)
                         ? currentApps
                         : [ ...currentApps, consoleAppIdentifier ]
-                    // Remove both the resolved identifier and the legacy client ID to clear
-                    // any entry stored before an identifier type switch.
-                    : currentApps.filter(
-                        (app: string) => app !== consoleAppIdentifier && app !== CDS_CONSOLE_APP
-                    );
+                    : currentApps.filter((app: string) => app !== consoleAppIdentifier);
 
                 await updateCDSConfig({
                     cds_enabled: enable,

--- a/modules/i18n/src/models/namespaces/customer-data-service-ns.ts
+++ b/modules/i18n/src/models/namespaces/customer-data-service-ns.ts
@@ -100,6 +100,7 @@ export interface CustomerDataServiceNS {
                             label: string;
                             loading: string;
                             noOptions: string;
+                            placeholder: string;
                             validations: {
                                 empty: string;
                             };

--- a/modules/i18n/src/models/namespaces/customer-data-service-ns.ts
+++ b/modules/i18n/src/models/namespaces/customer-data-service-ns.ts
@@ -210,6 +210,10 @@ export interface CustomerDataServiceNS {
                     hint: string;
                     label: string;
                 };
+                applicationName: {
+                    hint: string;
+                    label: string;
+                };
                 attribute: {
                     hint: string;
                     label: string;

--- a/modules/i18n/src/translations/en-US/portals/customer-data-service.ts
+++ b/modules/i18n/src/translations/en-US/portals/customer-data-service.ts
@@ -259,8 +259,12 @@ export const customerDataService: CustomerDataServiceNS = {
             },
             fields: {
                 applicationIdentifier: {
-                    hint: "The application this attribute belongs to.",
-                    label: "Application"
+                    hint: "The application identifier this attribute belongs to, as stored in the customer data service.",
+                    label: "Application Identifier"
+                },
+                applicationName: {
+                    hint: "The name of the application this attribute belongs to.",
+                    label: "Application Name"
                 },
                 attribute: {
                     hint: "The name of this attribute.",

--- a/modules/i18n/src/translations/en-US/portals/customer-data-service.ts
+++ b/modules/i18n/src/translations/en-US/portals/customer-data-service.ts
@@ -96,11 +96,12 @@ export const customerDataService: CustomerDataServiceNS = {
                     fields: {
                         // NEW: application identifier field (application_data scope)
                         applicationIdentifier: {
-                            label: "Application Identifier",
+                            label: "Application",
                             loading: "Loading applications…",
                             noOptions: "No applications found.",
+                            placeholder: "Select an application",
                             validations: {
-                                empty: "Application identifier is required."
+                                empty: "An application is required."
                             }
                         },
                         // NEW: compound attribute row
@@ -259,7 +260,7 @@ export const customerDataService: CustomerDataServiceNS = {
             fields: {
                 applicationIdentifier: {
                     hint: "The application this attribute belongs to.",
-                    label: "Application Identifier"
+                    label: "Application"
                 },
                 attribute: {
                     hint: "The name of this attribute.",


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
Currently CDS UIs use client ID as the app identifier. with the recent changes, we need to update that to application ID instead. Additionally, in listing UIs application name is shown

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- N/A

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
