### PR TITLE
Fix role claim URI in applications being set to empty during update

### DIFF
--- a/.changeset/role-claim-empty-guard.md
+++ b/.changeset/role-claim-empty-guard.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.applications.v1": patch
+---
+
+Preserve the configured role claim URI during application update instead of overwriting it with an empty value.

--- a/.changeset/role-claim-empty-guard.md
+++ b/.changeset/role-claim-empty-guard.md
@@ -1,5 +1,6 @@
 ---
 "@wso2is/admin.applications.v1": patch
+"@wso2is/console": patch
 ---
 
 Preserve the configured role claim URI during application update instead of overwriting it with an empty value.

--- a/features/admin.applications.v1/components/settings/attribute-management/advance-attribute-settings.tsx
+++ b/features/admin.applications.v1/components/settings/attribute-management/advance-attribute-settings.tsx
@@ -292,6 +292,22 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
             settingValues.subject.claim = claimConfigurations.subject.claim.uri;
         }
 
+        // Preserve the configured role claim URI when the resolved value is empty, as the User Attributes tab does
+        // not expose a control to manage it and sending an empty value overwrites the persisted configuration.
+        if ((!settingValues?.role?.claim || settingValues?.role?.claim === "")
+            && claimConfigurations?.role?.claim?.uri
+            && claimConfigurations?.role?.claim?.uri !== "http://wso2.org/claims/role") {
+            settingValues.role.claim = claimConfigurations.role.claim.uri;
+        }
+
+        // Preserve the configured role userstore-domain flag when its checkbox is not rendered,
+        // as the tab exposes no control to manage it and sending false overwrites the persisted value.
+        if ((!config.showIncludeUserstoreDomainRole || !UIConfig?.legacyMode?.roleMapping)
+            && settingValues?.role?.includeUserDomain === false
+            && claimConfigurations?.role?.includeUserDomain !== undefined) {
+            settingValues.role.includeUserDomain = claimConfigurations.role.includeUserDomain;
+        }
+
         setSubmissionValues(settingValues);
     };
 


### PR DESCRIPTION
## Purpose

Fix the application's configured role claim URI (and role userstore-domain flag) being wiped when the application update is submitted from the **User Attributes** tab.

## Root cause and fix

- The User Attributes tab does not render controls for the role claim URI or the include-userstore-domain flag, so the resolved form values are empty/`false`. Submitting them overwrote the persisted configuration.
- On submit, when the resolved role claim is empty, preserve the persisted `claimConfigurations.role.claim.uri` (unless it is the default `http://wso2.org/claims/role`).
- Likewise preserve the persisted `role.includeUserDomain` flag when its checkbox is not rendered.

## Related PRs

## Related Issues
- https://github.com/wso2/product-is/issues/28146