### PR TITLE
fix: stop webhook secret input triggering password autocomplete

### DIFF
--- a/.changeset/tricky-webhooks-autocomplete.md
+++ b/.changeset/tricky-webhooks-autocomplete.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.webhooks.v1": patch
+---
+
+Stop the webhook secret input from triggering browser password autocomplete prompts

--- a/features/admin.webhooks.v1/components/webhook-endpoint-config-form.tsx
+++ b/features/admin.webhooks.v1/components/webhook-endpoint-config-form.tsx
@@ -154,6 +154,7 @@ const WebhookEndpointConfigForm: FunctionComponent<WebhookEndpointConfigFormInte
                             data-componentid={ `${_componentId}-secret-property-field` }
                             name="secret"
                             type={ isShowSecret ? "text" : "password" }
+                            autoComplete="new-password"
                             InputProps={ {
                                 endAdornment: renderInputAdornmentOfSecret(isShowSecret, () =>
                                     setShowSecret(!isShowSecret)


### PR DESCRIPTION
Fixes wso2/product-is#28161

The webhook secret field (`webhook-endpoint-config-form.tsx`) renders as `type="password"` without an `autocomplete` attribute, so browsers treat it as an account credential and pop the save/autofill password prompt shown in the issue screenshot.

Added `autoComplete="new-password"` to the `FinalFormField`, which suppresses credential autofill for non-login secret inputs. This mirrors the existing pattern on the same `FinalFormField` + `TextFieldAdapter` combination in `admin.sms-providers.v1/pages/vonage-sms-provider.tsx` and `admin.email-providers.v1/pages/email-providers.tsx`.

Includes a patch changeset for `@wso2is/admin.webhooks.v1`.