### PR TITLE
Fix consent policy apps endpoint not using sub-org path

### DIFF
--- a/.changeset/tiny-mice-smile.md
+++ b/.changeset/tiny-mice-smile.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/common.consents.v1": patch
+---
+
+Fix consent policy apps endpoint not using sub-org path

--- a/features/common.consents.v1/configs/endpoints.ts
+++ b/features/common.consents.v1/configs/endpoints.ts
@@ -27,13 +27,9 @@ import { ConsentMgtResourceEndpointsInterface } from "../models/endpoints";
 export const getConsentMgtResourceEndpoints = (serverHost: string): ConsentMgtResourceEndpointsInterface => {
     const normalizedHost: string = serverHost?.replace(/\/+$/, "") ?? "";
 
-    // config-mgt does not support the sub-org path (/o or /o/<uuid>).
-    // Strip it so requests always go to the tenant-level endpoint.
-    const tenantHost: string = normalizedHost.replace(/\/o(\/.*)?$/, "");
-
     return {
         consentMgtElements: `${ normalizedHost }/api/identity/consent-mgt/v2.0/elements`,
         consentMgtPurposes: `${ normalizedHost }/api/identity/consent-mgt/v2.0/purposes`,
-        consentPolicyApps: `${ tenantHost }/api/server/v1/configs/consent/purposes`
+        consentPolicyApps: `${ normalizedHost }/api/server/v1/configs/consent/purposes`
     };
 };


### PR DESCRIPTION
### Purpose
Fix the issue where sub organizations cannot assign applications to policies

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- https://github.com/wso2/product-is/issues/26859

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
