### PR TITLE
Add flow extension step support to password recovery and ask password flow builders

### DIFF
--- a/.changeset/allow-flow-extensions.md
+++ b/.changeset/allow-flow-extensions.md
@@ -1,4 +1,5 @@
 ---
+"@wso2is/console": patch
 "@wso2is/admin.ask-password-flow-builder.v1": patch
 "@wso2is/admin.flow-builder-core.v1": patch
 "@wso2is/admin.password-recovery-flow-builder.v1": patch

--- a/.changeset/allow-flow-extensions.md
+++ b/.changeset/allow-flow-extensions.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/admin.ask-password-flow-builder.v1": patch
+"@wso2is/admin.flow-builder-core.v1": patch
+"@wso2is/admin.password-recovery-flow-builder.v1": patch
+---
+
+Add flow extension step support to password recovery and ask password flow builders

--- a/features/admin.ask-password-flow-builder.v1/components/resource-property-panel/resource-properties.tsx
+++ b/features/admin.ask-password-flow-builder.v1/components/resource-property-panel/resource-properties.tsx
@@ -21,6 +21,7 @@ import TextField from "@oxygen-ui/react/TextField";
 import {
     CommonResourcePropertiesPropsInterface
 } from "@wso2is/admin.flow-builder-core.v1/components/resource-property-panel/resource-properties";
+import FlowExtensionProperties from "@wso2is/admin.flow-builder-core.v1/components/resource-property-panel/flow-extension-properties/flow-extension-properties";
 import { FieldKey, FieldValue } from "@wso2is/admin.flow-builder-core.v1/models/base";
 import { Element, ElementCategories, ElementTypes } from "@wso2is/admin.flow-builder-core.v1/models/elements";
 import { Resource } from "@wso2is/admin.flow-builder-core.v1/models/resources";
@@ -195,6 +196,20 @@ const ResourceProperties: FunctionComponent<ResourcePropertiesPropsInterface> = 
 
             break;
         case StepCategories.Workflow:
+            if (resource?.data?.action?.executor?.name === ExecutionTypes.FlowExtension) {
+                return (
+                    <>
+                        { renderElementId() }
+                        <FlowExtensionProperties
+                            resource={ resource }
+                            data-componentid="flow-extension-properties"
+                            onChange={ onChange }
+                        />
+                        { renderElementPropertyFactory() }
+                    </>
+                );
+            }
+
             if (resource.type === StepTypes.Execution
                 && resource?.data?.action?.executor?.name === ExecutionTypes.ConfirmationCode) {
                 return (

--- a/features/admin.flow-builder-core.v1/data/steps.json
+++ b/features/admin.flow-builder-core.v1/data/steps.json
@@ -178,6 +178,30 @@
         "version": "0.1.0",
         "deprecated": false,
         "display": {
+            "label": "Flow Extension",
+            "image": "assets/images/icons/flow-extension.svg",
+            "showOnResourcePanel": true
+        },
+        "data": {
+            "action": {
+                "type": "EXECUTOR",
+                "executor": {
+                    "name": "FlowExtensionExecutor",
+                    "meta": {
+                        "actionId": ""
+                    }
+                },
+                "next": ""
+            }
+        }
+    },
+    {
+        "resourceType": "STEP",
+        "category": "WORKFLOW",
+        "type": "EXECUTION",
+        "version": "0.1.0",
+        "deprecated": false,
+        "display": {
             "label": "Execution",
             "image": "assets/images/icons/play.svg",
             "showOnResourcePanel": false

--- a/features/admin.password-recovery-flow-builder.v1/components/resource-property-panel/resource-properties.tsx
+++ b/features/admin.password-recovery-flow-builder.v1/components/resource-property-panel/resource-properties.tsx
@@ -21,10 +21,11 @@ import TextField from "@oxygen-ui/react/TextField";
 import {
     CommonResourcePropertiesPropsInterface
 } from "@wso2is/admin.flow-builder-core.v1/components/resource-property-panel/resource-properties";
+import FlowExtensionProperties from "@wso2is/admin.flow-builder-core.v1/components/resource-property-panel/flow-extension-properties/flow-extension-properties";
 import { FieldKey, FieldValue } from "@wso2is/admin.flow-builder-core.v1/models/base";
 import { Element, ElementCategories, ElementTypes } from "@wso2is/admin.flow-builder-core.v1/models/elements";
 import { Resource } from "@wso2is/admin.flow-builder-core.v1/models/resources";
-import { StepCategories, StepTypes } from "@wso2is/admin.flow-builder-core.v1/models/steps";
+import { ExecutionTypes, StepCategories, StepTypes } from "@wso2is/admin.flow-builder-core.v1/models/steps";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import isEmpty from "lodash-es/isEmpty";
 import React, { ChangeEvent, FunctionComponent, ReactElement, useMemo } from "react";
@@ -164,6 +165,20 @@ const ResourceProperties: FunctionComponent<ResourcePropertiesPropsInterface> = 
 
             break;
         case StepCategories.Workflow:
+            if (resource?.data?.action?.executor?.name === ExecutionTypes.FlowExtension) {
+                return (
+                    <>
+                        { renderElementId() }
+                        <FlowExtensionProperties
+                            resource={ resource }
+                            data-componentid="flow-extension-properties"
+                            onChange={ onChange }
+                        />
+                        { renderElementPropertyFactory() }
+                    </>
+                );
+            }
+
             return (
                 <>
                     { renderElementId() }


### PR DESCRIPTION
## Purpose
Flow extensions could not be added to or configured in the password recovery and invited user registration (ask password) flows from the Console. This change makes the Flow Extension step available in those flow builders so extensions can be placed and configured in these flows.

## Related Issue
- https://github.com/wso2/product-is/issues/28177

## Implementation
- Added a `Flow Extension` step definition (backed by `FlowExtensionExecutor`) to `features/admin.flow-builder-core.v1/data/steps.json` so the step appears on the resource panel.
- Updated the resource property panels in `features/admin.password-recovery-flow-builder.v1` and `features/admin.ask-password-flow-builder.v1` to render `FlowExtensionProperties` when the selected workflow step's executor is a flow extension, so the extension can be configured from the property panel.