### PR TITLE
Show a specific error when agent creation hits the application limit

### DIFF
--- a/.changeset/hungry-crabs-repair.md
+++ b/.changeset/hungry-crabs-repair.md
@@ -1,6 +1,7 @@
 ---
 "@wso2is/admin.agents.v1": patch
 "@wso2is/i18n": patch
+"@wso2is/console": patch
 ---
 
 Show a specific error message when agent creation fails because the organization's application limit has been reached, instead of the generic "Something went wrong" alert.

--- a/.changeset/hungry-crabs-repair.md
+++ b/.changeset/hungry-crabs-repair.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.agents.v1": patch
+"@wso2is/i18n": patch
+---
+
+Show a specific error message when agent creation fails because the organization's application limit has been reached, instead of the generic "Something went wrong" alert.

--- a/features/admin.agents.v1/components/wizards/add-agent-wizard.tsx
+++ b/features/admin.agents.v1/components/wizards/add-agent-wizard.tsx
@@ -28,6 +28,7 @@ import { AppState } from "@wso2is/admin.core.v1/store";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { URLUtils } from "@wso2is/core/utils";
+import { AxiosError } from "axios";
 import {
     CheckboxFieldAdapter,
     CheckboxGroupFieldAdapter,
@@ -44,6 +45,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { Dispatch } from "redux";
 import { Divider, Grid, Icon, Message } from "semantic-ui-react";
 import { addAgent, updateAgentApplicationConfiguration } from "../../api/agents";
+import { AGENT_APP_LIMIT_REACHED_SCIM_TYPE } from "../../constants/agents";
 import { AgentScimSchema, AgentType } from "../../models/agents";
 import "./add-agent-wizard.scss";
 
@@ -168,18 +170,33 @@ const AddAgentWizard: FunctionComponent<AddAgentWizardPropsInterface> = (
             setCreationResult(result);
             setIsShowingSuccessScreen(true);
             setIsSubmitting(false);
-        } catch (_err: unknown) {
+        } catch (error: unknown) {
             // On error, stay on form with the user's values.
             setIsShowingSuccessScreen(false);
             setCreationResult(null);
             setSubmittedValues(null);
-            dispatch(
-                addAlert({
-                    description: t("agents:wizard.alerts.error.description"),
-                    level: AlertLevels.ERROR,
-                    message: t("agents:wizard.alerts.error.message")
-                })
-            );
+
+            const errorResponse: AxiosError<{ scimType?: string }>["response"] =
+                (error as AxiosError<{ scimType?: string }>)?.response;
+
+            if (errorResponse?.status === 403
+                && errorResponse?.data?.scimType === AGENT_APP_LIMIT_REACHED_SCIM_TYPE) {
+                dispatch(
+                    addAlert({
+                        description: t("agents:wizard.alerts.limitReached.description"),
+                        level: AlertLevels.ERROR,
+                        message: t("agents:wizard.alerts.limitReached.message")
+                    })
+                );
+            } else {
+                dispatch(
+                    addAlert({
+                        description: t("agents:wizard.alerts.error.description"),
+                        level: AlertLevels.ERROR,
+                        message: t("agents:wizard.alerts.error.message")
+                    })
+                );
+            }
             setIsSubmitting(false);
         }
     };

--- a/features/admin.agents.v1/constants/agents.ts
+++ b/features/admin.agents.v1/constants/agents.ts
@@ -18,6 +18,12 @@
 
 export const AGENT_SHARING_ERROR: string = "AGENT_SHARING_ERROR";
 
+/**
+ * SCIM `scimType` value returned when agent creation fails because the
+ * organization has reached its allowed application limit.
+ */
+export const AGENT_APP_LIMIT_REACHED_SCIM_TYPE: string = "applicationLimitReached";
+
 export const AGENT_FEATURE_DICTIONARY: Map<string, string> = new Map()
     .set("AGENT_GROUPS", "agents.groups")
     .set("AGENT_SHARED_ACCESS", "agents.sharedAccess")

--- a/modules/i18n/src/models/namespaces/agents-ns.ts
+++ b/modules/i18n/src/models/namespaces/agents-ns.ts
@@ -116,6 +116,10 @@ export interface AgentsNS {
                 message: string;
                 description: string;
             };
+            limitReached: {
+                message: string;
+                description: string;
+            };
             clientIdFetchFailed: {
                 message: string;
                 description: string;

--- a/modules/i18n/src/translations/en-US/portals/agents.ts
+++ b/modules/i18n/src/translations/en-US/portals/agents.ts
@@ -208,6 +208,11 @@ export const agents: AgentsNS = {
             error: {
                 description: "Creating agent failed",
                 message: "Something went wrong"
+            },
+            limitReached: {
+                description: "You have reached the maximum number of applications allowed "
+                    + "for this organization, so an application cannot be created for this agent.",
+                message: "Application limit reached"
             }
         },
         buttons: {

--- a/modules/i18n/src/translations/en-US/portals/agents.ts
+++ b/modules/i18n/src/translations/en-US/portals/agents.ts
@@ -210,8 +210,7 @@ export const agents: AgentsNS = {
                 message: "Something went wrong"
             },
             limitReached: {
-                description: "You have reached the maximum number of applications allowed "
-                    + "for this organization, so an application cannot be created for this agent.",
+                description: "Agent application creation failed. Maximum application limit reached.",
                 message: "Application limit reached"
             }
         },


### PR DESCRIPTION
### Purpose

The agent creation wizard shows the generic **"Something went wrong" / "Creating agent failed"** alert for every failure — the `catch` block in `add-agent-wizard.tsx` discards the error response entirely.

When a user-serving agent cannot be created because the organization has reached its allowed application limit, the backend (with the related backend PRs) now returns **HTTP 403 with `scimType: applicationLimitReached`**. This PR makes the wizard detect that case and show a dedicated message: "Application limit reached — Agent application creation failed. Maximum application limit reached." All other failures keep the existing generic alert.

This follows the same pattern the add-user wizard uses for `userLimitReached` (403 + `scimType` check).

### Related Issues
- N/A

### Related PRs
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/3277 (surface the application-limit client error instead of a 500)
- https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/799 (map the limit error to 403 + `scimType: applicationLimitReached`)

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [x] Relevant backend changes deployed and verified
- [ ] Unit tests provided.
- [ ] Integration tests provided.

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets



