### PR TITLE
Fix 'Include organization name' cleared when unchecking 'Include user domain' in application subject settings

### DIFF
--- a/.changeset/subject-domain-flags-independent.md
+++ b/.changeset/subject-domain-flags-independent.md
@@ -1,5 +1,6 @@
 ---
 "@wso2is/admin.applications.v1": patch
+"@wso2is/console": patch
 ---
 
 Persist the "Include organization name" and "Include user domain" options independently in the application subject identifier settings, so un-checking one no longer clears the other on save.

--- a/.changeset/subject-domain-flags-independent.md
+++ b/.changeset/subject-domain-flags-independent.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.applications.v1": patch
+---
+
+Persist the "Include organization name" and "Include user domain" options independently in the application subject identifier settings, so un-checking one no longer clears the other on save.

--- a/features/admin.applications.v1/components/settings/attribute-management/advance-attribute-settings.tsx
+++ b/features/admin.applications.v1/components/settings/attribute-management/advance-attribute-settings.tsx
@@ -119,6 +119,10 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
         useState<boolean>(initialSubject?.useMappedLocalSubject);
     const [ mandateLinkedLocalAccount, setMandateLinkedLocalAccount ] =
         useState<boolean>(initialSubject?.mappedLocalSubjectMandatory);
+    const [ subjectIncludeUserDomain, setSubjectIncludeUserDomain ] =
+        useState<boolean>(initialSubject?.includeUserDomain);
+    const [ subjectIncludeTenantDomain, setSubjectIncludeTenantDomain ] =
+        useState<boolean>(initialSubject?.includeTenantDomain);
 
     useEffect(() => {
         if (claimMappingOn && dropDownOptions && dropDownOptions.length > 0) {
@@ -260,8 +264,8 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
             },
             subject: {
                 claim: getSelectedDropDownValue(dropDownOptions, values.subjectAttribute),
-                includeTenantDomain: !!values.subjectIncludeTenantDomain,
-                includeUserDomain: !!values.subjectIncludeUserDomain,
+                includeTenantDomain: !!subjectIncludeTenantDomain,
+                includeUserDomain: !!subjectIncludeUserDomain,
                 mappedLocalSubjectMandatory: mandateLinkedLocalAccount,
                 useMappedLocalSubject: validateLinkedLocalAccount
             }
@@ -351,6 +355,14 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
 
     const mandateLinkedAccountCheckboxHandler = (value: boolean) => {
         setMandateLinkedLocalAccount(value);
+    };
+
+    const subjectIncludeUserDomainChangeHandler = (value: boolean) => {
+        setSubjectIncludeUserDomain(value);
+    };
+
+    const subjectIncludeTenantDomainChangeHandler = (value: boolean) => {
+        setSubjectIncludeTenantDomain(value);
     };
 
     /**
@@ -543,13 +555,14 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
                                     >
                                         <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
                                             <Field.CheckboxLegacy
+                                                listen={ subjectIncludeUserDomainChangeHandler }
                                                 ariaLabel="Subject include user domain"
                                                 name="subjectIncludeUserDomain"
                                                 label={ t("applications:forms.advancedAttributeSettings." +
                                                     "sections.subject.fields.subjectIncludeUserDomain.label") }
                                                 required={ false }
                                                 value={
-                                                    initialSubject?.includeUserDomain ? [ "includeUserDomain" ] : [] }
+                                                    subjectIncludeUserDomain ? [ "includeUserDomain" ] : [] }
                                                 readOnly={ readOnly }
                                                 data-testid={ `${ componentId }-subject-iInclude-user-domain-checkbox` }
                                                 hint={
@@ -570,6 +583,7 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
                                     >
                                         <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
                                             <Field.CheckboxLegacy
+                                                listen={ subjectIncludeTenantDomainChangeHandler }
                                                 ariaLabel="Subject include tenant domain"
                                                 name="subjectIncludeTenantDomain"
                                                 label={
@@ -578,7 +592,7 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
                                                 }
                                                 required={ false }
                                                 value={
-                                                    initialSubject?.includeTenantDomain
+                                                    subjectIncludeTenantDomain
                                                         ? [ "includeTenantDomain" ]
                                                         : []
                                                 }


### PR DESCRIPTION
## Problem
In the Console application editor (User Attributes → Subject → "Assign alternate subject identifier"), un-checking **Include user domain** while **Include organization name** was checked silently cleared the organization-name flag on save (and vice versa). The persisted configuration came back with both flags off.

## Fix
The two subject-domain checkboxes (`Field.CheckboxLegacy`) had no external state and no `listen` handler, so their value was tracked only inside react-final-form on an uncontrolled checkbox and was lost on a sibling re-render. Give both parent-owned React state with `listen` handlers and read that state in `submitValues`, mirroring the existing linked-account checkboxes. The two flags now persist independently.

Single-file, Console-UI only. No server-side, REST, or config change.

Fixes wso2/product-is#28180
