### PR TITLE
fix: hoist static InfoLabel JSX to module scope

### DIFF
--- a/features/admin.applications.v1/components/settings/sign-on-methods/step-based-flow/authenticators.tsx
+++ b/features/admin.applications.v1/components/settings/sign-on-methods/step-based-flow/authenticators.tsx
@@ -35,6 +35,12 @@ import { ApplicationManagementConstants } from "../../../../constants/applicatio
 import { AuthenticationStepInterface } from "../../../../models/application";
 import { SignInMethodUtils } from "../../../../utils/sign-in-method-utils";
 
+const INFO_LABEL: JSX.Element = (
+    <Label attached="top">
+        <Icon name="info circle" /> Info
+    </Label>
+);
+
 /**
  * Proptypes for the authenticators component.
  */
@@ -187,12 +193,6 @@ export const Authenticators: FunctionComponent<AuthenticatorsPropsInterface> = (
      * @returns React element.
      */
     const resolvePopupContent = (authenticator: GenericAuthenticatorInterface): ReactElement => {
-        const InfoLabel: JSX.Element = (
-            <Label attached="top">
-                <Icon name="info circle" /> Info
-            </Label>
-        );
-
         if (
             authenticator.category === AuthenticatorCategories.SECOND_FACTOR ||
             authenticator.category === AuthenticatorCategories.TWO_FACTOR_CUSTOM
@@ -201,7 +201,7 @@ export const Authenticators: FunctionComponent<AuthenticatorsPropsInterface> = (
                 <>
                     { currentStep === 0 ? (
                         <Fragment>
-                            { InfoLabel }
+                            { INFO_LABEL }
                             <Text>
                                 { applicationConfig.signInMethod.authenticatorSelection.messages
                                     .secondFactorDisabledInFirstStep ??
@@ -214,7 +214,7 @@ export const Authenticators: FunctionComponent<AuthenticatorsPropsInterface> = (
                         </Fragment>
                     ) : (
                         <Fragment>
-                            { InfoLabel }
+                            { INFO_LABEL }
                             <Text>
                                 { applicationConfig.signInMethod.authenticatorSelection.messages
                                     .secondFactorDisabled ?? (
@@ -244,7 +244,7 @@ export const Authenticators: FunctionComponent<AuthenticatorsPropsInterface> = (
                 <>
                     { currentStep === 0 ? (
                         <Fragment>
-                            { InfoLabel }
+                            { INFO_LABEL }
                             <Text>
                                 { t(
                                     "applications:edit.sections" +
@@ -255,7 +255,7 @@ export const Authenticators: FunctionComponent<AuthenticatorsPropsInterface> = (
                         </Fragment>
                     ) : (
                         <Fragment>
-                            { InfoLabel }
+                            { INFO_LABEL }
                             <Text>
                                 { t(
                                     "applications:edit.sections" +
@@ -270,7 +270,7 @@ export const Authenticators: FunctionComponent<AuthenticatorsPropsInterface> = (
         } else if (authenticator.category === AuthenticatorCategories.SOCIAL) {
             return (
                 <Fragment>
-                    { InfoLabel }
+                    { INFO_LABEL }
                     <Text>
                         { t(
                             "applications:edit.sections.signOnMethod.sections." +
@@ -291,7 +291,7 @@ export const Authenticators: FunctionComponent<AuthenticatorsPropsInterface> = (
 
             return (
                 <Fragment>
-                    { InfoLabel }
+                    { INFO_LABEL }
                     <Text>
                         {
                             t(
@@ -307,7 +307,7 @@ export const Authenticators: FunctionComponent<AuthenticatorsPropsInterface> = (
             .ACTIVE_SESSION_LIMIT_HANDLER_AUTHENTICATOR_NAME) {
             return (
                 <Fragment>
-                    { InfoLabel }
+                    { INFO_LABEL }
                     <Text>
                         {
                             (authenticationSteps[currentStep]?.options?.length !== 0)


### PR DESCRIPTION
### Purpose

This PR addresses the React Doctor warning about hoisting static JSX out of the render path.

Previously, the `InfoLabel` JSX element was recreated every time `resolvePopupContent()` was called. This change moves the static JSX to module scope and reuses it, avoiding unnecessary JSX recreation without changing the existing behavior.

### Related Issues

- Fixes https://github.com/wso2/product-is/issues/27948

### Related PRs

- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] Unit tests provided.
- [ ] Integration tests provided.

### Security checks

- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report

## Developer Checklist (Mandatory)

- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.