### PR TITLE
fix: correct invalid aria-label attribute

### DIFF
--- a/features/admin.identity-verification-providers.v1/components/edit/attribute-mapping/attribute-mapping-list-item.tsx
+++ b/features/admin.identity-verification-providers.v1/components/edit/attribute-mapping/attribute-mapping-list-item.tsx
@@ -290,7 +290,7 @@ export const AttributeMappingListItem: FunctionComponent<AttributeMappingListIte
                             initialValue={ selectedLocalAttributeInputValue }
                             options={ getListOfAvailableAttributes() }
                             label={ !editingMode && t("idvp:edit.attributeSettings.modal.labels.localClaim") }
-                            aria-Label="Local Claim Attribute"
+                            aria-label="Local Claim Attribute"
                             name="localClaimId"
                             placeholder= { t("idvp:edit.attributeSettings.modal.placeholders.localClaim") }
                             onChange={ (e: React.SyntheticEvent<HTMLInputElement>, data: DropdownProps) => {


### PR DESCRIPTION
### Purpose

Fixes the invalid `aria-Label` attribute reported by React Doctor by replacing it with the valid `aria-label` attribute.

### Related Issues

- Fixes https://github.com/wso2/product-is/issues/27873

### Related PRs

- N/A

### Checklist

- [x] Manual test round performed and verified.

### Security checks

- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)

- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.

### Screenshots

The following DevTools screenshot shows the valid `aria-label="Local Claim Attribute"` applied to the rendered **Maps to** combobox in the Onfido Identity Verification Provider's **Add Attribute Mappings** modal.

<img width="1917" height="982" alt="Screenshot 2026-07-19 005855" src="https://github.com/user-attachments/assets/a142cd94-be71-4533-a29f-0bf283e0f61d" />