### PR TITLE
Add agent analytics to Moesif dashboards and fix on-prem insights settings tab

### DIFF
--- a/.changeset/moesif-agent-analytics.md
+++ b/.changeset/moesif-agent-analytics.md
@@ -1,0 +1,8 @@
+---
+"@wso2is/admin.analytics.v1": patch
+"@wso2is/admin.org-insights.v1": patch
+"@wso2is/i18n": patch
+"@wso2is/console": patch
+---
+
+Add agent analytics to the Moesif dashboards and surface the fresh-start data retention note on the advanced analytics banner

--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -767,8 +767,8 @@
                 {% else %} true,
                 {% endif %}
                 "scopes": {
-                    {% if console.analytics.scopes is defined %}
-                    {% for operation, scopes in console.analytics.scopes.items() %}
+                    {% if console.analytics.moesif.scopes is defined %}
+                    {% for operation, scopes in console.analytics.moesif.scopes.items() %}
                     "{{ operation }}": [
                         {% for scope in scopes %}
                             "{{ scope }}"{{ "," if not loop.last }}

--- a/apps/console/src/configs/routes.tsx
+++ b/apps/console/src/configs/routes.tsx
@@ -91,6 +91,16 @@ export const getAppViewRoutes = (): RouteInterface[] => {
     const isMcpServersFeatureEnabled: boolean =
         window["AppUtils"]?.getConfig()?.ui?.features?.mcpServers?.enabled;
 
+    const isInsightsFeatureEnabled: boolean =
+        window["AppUtils"]?.getConfig()?.ui?.features?.insights?.enabled === true;
+    const isAnalyticsFeatureEnabled: boolean =
+        window["AppUtils"]?.getConfig()?.ui?.features?.analytics?.enabled === true;
+    const isAnalyticsSettingsEnabled: boolean =
+        (window["AppUtils"]?.getConfig()?.extensions?.analytics as Record<string, Record<string, unknown>>)
+            ?.collectorKey?.settingsEnabled === true;
+    const showAnalyticsSettingsAsTab: boolean =
+        isAnalyticsFeatureEnabled && isAnalyticsSettingsEnabled && !isInsightsFeatureEnabled;
+
     const defaultRoutes: RouteInterface[] = [
         {
             category: "extensions:manage.sidePanel.categories.userManagement",
@@ -1375,6 +1385,9 @@ export const getAppViewRoutes = (): RouteInterface[] => {
             showOnSidePanel: true
         },
         {
+            category: showAnalyticsSettingsAsTab
+                ? "extensions:develop.sidePanel.categories.monitor"
+                : undefined,
             component: lazy(() =>
                 import(
                     "@wso2is/admin.analytics.v1/pages/analytics-settings-page"
@@ -1385,11 +1398,11 @@ export const getAppViewRoutes = (): RouteInterface[] => {
                 icon: <LightbulbOnIcon fill="black" className="icon" />
             },
             id: "insightsSettings",
-            name: "Insights Settings",
+            name: showAnalyticsSettingsAsTab ? "Insights" : "Insights Settings",
             order: 24,
             path: AppConstants.getPaths().get("INSIGHTS_SETTINGS"),
             protected: true,
-            showOnSidePanel: false
+            showOnSidePanel: showAnalyticsSettingsAsTab
         },
         {
             category: "extensions:manage.sidePanel.categories.monitor",

--- a/features/admin.analytics.v1/assets/moesif-dashboard-essentials.json
+++ b/features/admin.analytics.v1/assets/moesif-dashboard-essentials.json
@@ -67,24 +67,52 @@
       "sort_order": 3
     },
     {
+      "_id": "6a5e2cd7e57d307b8ba6d537",
+      "name": "Agent",
+      "dashboard_ids": [],
+      "workspace_ids": [
+        [
+          "6a5e36ee8473bc558cd9b196",
+          "6a5e2d4ce57d307b8ba6d53e",
+          "6a5e2d30e57d307b8ba6d53a"
+        ],
+        [
+          "6a5e45698473bc558cd9b202"
+        ],
+        [
+          "6a5e435a8473bc558cd9b1de"
+        ]
+      ],
+      "parent": "6a0d5af342390139f7ac4a07",
+      "sort_order": 4
+    },
+    {
       "_id": "6a0d5af342390139f7ac4a07",
       "name": "Overview",
       "dashboard_ids": [
         "6a0d5b2842390139f7ac4a23",
         "6a0d5b3042390139f7ac4a26",
-        "6a1ea1475bc7c56efa5ea476"
+        "6a1ea1475bc7c56efa5ea476",
+        "6a5e2cd7e57d307b8ba6d537"
       ],
       "workspace_ids": [
         [
           "6a0db96342390139f7ac83e7",
+          "6a1e8f049ab5707f95230c0a",
+          "6a1e90c39ab5707f95230d67",
           "6a1ea2257f7e1a2185865daf",
           "6a1ea3e67f7e1a2185865dbb",
-          "6a1e8f049ab5707f95230c0a",
-          "6a1e90c39ab5707f95230d67"
+          "6a5e2e79e57d307b8ba6d549",
+          "6a5e2d748473bc558cd9b16d"
         ],
         [
-          "6a0db9f004a4ee1e28288627",
+          "6a0db9f004a4ee1e28288627"
+        ],
+        [
           "6a1e8fa55bc7c56efa5e9e89"
+        ],
+        [
+          "6a5e45698473bc558cd9b202"
         ]
       ],
       "parent": null,
@@ -125,6 +153,17 @@
                     }
                   }
                 }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.userStoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                }
               }
             ]
           }
@@ -159,6 +198,17 @@
                         }
                       }
                     }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.userStoreDomain.raw": [
+                            "AGENT"
+                          ]
+                        }
+                      }
+                    }
                   }
                 ]
               }
@@ -179,7 +229,7 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=e76aa628&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=698b6316&evtcf[filtersGroups][0][filters][2][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=Console&seg[metrics][0][metricName]=count%28distinct%28user_id%29%29&seg[metrics][0][customName]=%20",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=e76aa628&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=698b6316&evtcf[filtersGroups][0][filters][2][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=Console&evtcf[filtersGroups][0][filters][3][id]=8517df45&evtcf[filtersGroups][0][filters][3][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][3][op]=not_contain&evtcf[filtersGroups][0][filters][3][value][0]=AGENT&seg[metrics][0][metricName]=count%28distinct%28user_id%29%29&seg[metrics][0][customName]=%20",
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
@@ -222,6 +272,17 @@
                           "overall"
                         ]
                       }
+                    },
+                    {
+                      "bool": {
+                        "must_not": {
+                          "terms": {
+                            "metadata.userStoreDomain.raw": [
+                              "AGENT"
+                            ]
+                          }
+                        }
+                      }
                     }
                   ]
                 }
@@ -248,6 +309,17 @@
                         "metadata.authStepSuccess": [
                           "false"
                         ]
+                      }
+                    },
+                    {
+                      "bool": {
+                        "must_not": {
+                          "terms": {
+                            "metadata.userStoreDomain.raw": [
+                              "AGENT"
+                            ]
+                          }
+                        }
                       }
                     }
                   ]
@@ -278,6 +350,17 @@
                               "overall"
                             ]
                           }
+                        },
+                        {
+                          "bool": {
+                            "must_not": {
+                              "terms": {
+                                "metadata.userStoreDomain.raw": [
+                                  "AGENT"
+                                ]
+                              }
+                            }
+                          }
                         }
                       ]
                     }
@@ -304,6 +387,17 @@
                             "metadata.authStepSuccess": [
                               "false"
                             ]
+                          }
+                        },
+                        {
+                          "bool": {
+                            "must_not": {
+                              "terms": {
+                                "metadata.userStoreDomain.raw": [
+                                  "AGENT"
+                                ]
+                              }
+                            }
                           }
                         }
                       ]
@@ -376,7 +470,7 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=e76aa628&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][1][filters][0][id]=f44a8a2b&evtcf[filtersGroups][1][filters][0][field]=action_name.raw&evtcf[filtersGroups][1][filters][0][name]=&evtcf[filtersGroups][1][filters][0][op]=contains&evtcf[filtersGroups][1][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][1][filters][1][id]=a1e663e3&evtcf[filtersGroups][1][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][1][filters][1][name]=&evtcf[filtersGroups][1][filters][1][op]=contains&evtcf[filtersGroups][1][filters][1][value][0]=step&evtcf[filtersGroups][1][filters][2][id]=096cebdf&evtcf[filtersGroups][1][filters][2][field]=metadata.authStepSuccess&evtcf[filtersGroups][1][filters][2][name]=&evtcf[filtersGroups][1][filters][2][op]=eq&evtcf[filtersGroups][1][filters][2][value][0]=false&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=%20&seg[segments][0][name]=Login%20Success&seg[segments][0][filterGroups][0][id]=b73479b1&seg[segments][0][filterGroups][0][filters][0][id]=7939db5c&seg[segments][0][filterGroups][0][filters][0][field]=metadata.eventType.raw&seg[segments][0][filterGroups][0][filters][0][name]=&seg[segments][0][filterGroups][0][filters][0][op]=contains&seg[segments][0][filterGroups][0][filters][0][value][0]=overall&seg[segments][1][name]=Login%20Failure&seg[segments][1][filterGroups][0][id]=f45279f3&seg[segments][1][filterGroups][0][filters][0][id]=377b153b&seg[segments][1][filterGroups][0][filters][0][field]=metadata.eventType.raw&seg[segments][1][filterGroups][0][filters][0][name]=&seg[segments][1][filterGroups][0][filters][0][op]=contains&seg[segments][1][filterGroups][0][filters][0][value][0]=step&seg[segments][1][filterGroups][0][filters][1][id]=13c4b817&seg[segments][1][filterGroups][0][filters][1][field]=metadata.authStepSuccess&seg[segments][1][filterGroups][0][filters][1][name]=&seg[segments][1][filterGroups][0][filters][1][op]=eq&seg[segments][1][filterGroups][0][filters][1][value][0]=false&seg[chartType]=pie",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=e76aa628&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=3e4fa960&evtcf[filtersGroups][0][filters][2][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=AGENT&evtcf[filtersGroups][1][filters][0][id]=f44a8a2b&evtcf[filtersGroups][1][filters][0][field]=action_name.raw&evtcf[filtersGroups][1][filters][0][name]=&evtcf[filtersGroups][1][filters][0][op]=contains&evtcf[filtersGroups][1][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][1][filters][1][id]=a1e663e3&evtcf[filtersGroups][1][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][1][filters][1][name]=&evtcf[filtersGroups][1][filters][1][op]=contains&evtcf[filtersGroups][1][filters][1][value][0]=step&evtcf[filtersGroups][1][filters][2][id]=096cebdf&evtcf[filtersGroups][1][filters][2][field]=metadata.authStepSuccess&evtcf[filtersGroups][1][filters][2][name]=&evtcf[filtersGroups][1][filters][2][op]=eq&evtcf[filtersGroups][1][filters][2][value][0]=false&evtcf[filtersGroups][1][filters][3][id]=ee672ec4&evtcf[filtersGroups][1][filters][3][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][1][filters][3][op]=not_contain&evtcf[filtersGroups][1][filters][3][value][0]=AGENT&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=%20&seg[segments][0][name]=Login%20Success&seg[segments][0][filterGroups][0][id]=b73479b1&seg[segments][0][filterGroups][0][filters][0][id]=7939db5c&seg[segments][0][filterGroups][0][filters][0][field]=metadata.eventType.raw&seg[segments][0][filterGroups][0][filters][0][name]=&seg[segments][0][filterGroups][0][filters][0][op]=contains&seg[segments][0][filterGroups][0][filters][0][value][0]=overall&seg[segments][1][name]=Login%20Failure&seg[segments][1][filterGroups][0][id]=f45279f3&seg[segments][1][filterGroups][0][filters][0][id]=377b153b&seg[segments][1][filterGroups][0][filters][0][field]=metadata.eventType.raw&seg[segments][1][filterGroups][0][filters][0][name]=&seg[segments][1][filterGroups][0][filters][0][op]=contains&seg[segments][1][filterGroups][0][filters][0][value][0]=step&seg[segments][1][filterGroups][0][filters][1][id]=13c4b817&seg[segments][1][filterGroups][0][filters][1][field]=metadata.authStepSuccess&seg[segments][1][filterGroups][0][filters][1][name]=&seg[segments][1][filterGroups][0][filters][1][op]=eq&seg[segments][1][filterGroups][0][filters][1][value][0]=false&seg[chartType]=pie",
       "analyticType": "seg",
       "chartType": "pie",
       "settings": {
@@ -481,6 +575,17 @@
                     }
                   }
                 }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.userStoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                }
               }
             ]
           }
@@ -526,6 +631,17 @@
                         }
                       }
                     }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.userStoreDomain.raw": [
+                            "AGENT"
+                          ]
+                        }
+                      }
+                    }
                   }
                 ]
               }
@@ -566,7 +682,7 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=4b9d6fd9&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=3c6d0e27&evtcf[filtersGroups][0][filters][2][field]=metadata.authenticators.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=NOT_AVAILABLE&evtcf[filtersGroups][0][filters][3][id]=bf4b88a7&evtcf[filtersGroups][0][filters][3][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][0][filters][3][name]=&evtcf[filtersGroups][0][filters][3][op]=not_contain&evtcf[filtersGroups][0][filters][3][value][0]=Console&seg[groups][0][field]=metadata.authenticators.raw&seg[groups][0][func]=terms&seg[groups][0][by]=metric&seg[metrics][0][metricName]=sum%28events%29&seg[chartType]=pie",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=4b9d6fd9&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=3c6d0e27&evtcf[filtersGroups][0][filters][2][field]=metadata.authenticators.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=NOT_AVAILABLE&evtcf[filtersGroups][0][filters][3][id]=bf4b88a7&evtcf[filtersGroups][0][filters][3][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][0][filters][3][name]=&evtcf[filtersGroups][0][filters][3][op]=not_contain&evtcf[filtersGroups][0][filters][3][value][0]=Console&evtcf[filtersGroups][0][filters][4][id]=ee2b5fd5&evtcf[filtersGroups][0][filters][4][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][4][op]=not_contain&evtcf[filtersGroups][0][filters][4][value][0]=AGENT&seg[groups][0][field]=metadata.authenticators.raw&seg[groups][0][func]=terms&seg[groups][0][by]=metric&seg[metrics][0][metricName]=sum%28events%29&seg[chartType]=pie",
       "analyticType": "seg",
       "chartType": "pie",
       "settings": {
@@ -621,6 +737,17 @@
                           }
                         }
                       }
+                    },
+                    {
+                      "bool": {
+                        "must_not": {
+                          "terms": {
+                            "metadata.userStoreDomain.raw": [
+                              "AGENT"
+                            ]
+                          }
+                        }
+                      }
                     }
                   ]
                 }
@@ -655,6 +782,17 @@
                           "terms": {
                             "metadata.serviceProvider.raw": [
                               "Console"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "bool": {
+                        "must_not": {
+                          "terms": {
+                            "metadata.userStoreDomain.raw": [
+                              "AGENT"
                             ]
                           }
                         }
@@ -699,6 +837,17 @@
                               }
                             }
                           }
+                        },
+                        {
+                          "bool": {
+                            "must_not": {
+                              "terms": {
+                                "metadata.userStoreDomain.raw": [
+                                  "AGENT"
+                                ]
+                              }
+                            }
+                          }
                         }
                       ]
                     }
@@ -733,6 +882,17 @@
                               "terms": {
                                 "metadata.serviceProvider.raw": [
                                   "Console"
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "bool": {
+                            "must_not": {
+                              "terms": {
+                                "metadata.userStoreDomain.raw": [
+                                  "AGENT"
                                 ]
                               }
                             }
@@ -820,7 +980,7 @@
       },
       "view": "time",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=31f53870&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=6af3bb9b&evtcf[filtersGroups][0][filters][2][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=Console&evtcf[filtersGroups][1][filters][0][id]=aa7f60c8&evtcf[filtersGroups][1][filters][0][field]=action_name.raw&evtcf[filtersGroups][1][filters][0][name]=&evtcf[filtersGroups][1][filters][0][op]=contains&evtcf[filtersGroups][1][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][1][filters][1][id]=cbb3b1c3&evtcf[filtersGroups][1][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][1][filters][1][name]=&evtcf[filtersGroups][1][filters][1][op]=contains&evtcf[filtersGroups][1][filters][1][value][0]=step&evtcf[filtersGroups][1][filters][2][id]=6a52100d&evtcf[filtersGroups][1][filters][2][field]=metadata.authStepSuccess&evtcf[filtersGroups][1][filters][2][name]=&evtcf[filtersGroups][1][filters][2][op]=eq&evtcf[filtersGroups][1][filters][2][value][0]=false&evtcf[filtersGroups][1][filters][3][id]=28fca1e7&evtcf[filtersGroups][1][filters][3][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][1][filters][3][name]=&evtcf[filtersGroups][1][filters][3][op]=not_contain&evtcf[filtersGroups][1][filters][3][value][0]=Console&evt_ts[metrics][0][metricName]=sum%28events%29&evt_ts[interval]=24h&evt_ts[segments][0][name]=Login%20Success&evt_ts[segments][0][filterGroups][0][id]=bf054cca&evt_ts[segments][0][filterGroups][0][filters][0][id]=2e2dc3c1&evt_ts[segments][0][filterGroups][0][filters][0][field]=metadata.eventType.raw&evt_ts[segments][0][filterGroups][0][filters][0][name]=&evt_ts[segments][0][filterGroups][0][filters][0][op]=contains&evt_ts[segments][0][filterGroups][0][filters][0][value][0]=overall&evt_ts[segments][1][name]=Login%20Failure&evt_ts[segments][1][filterGroups][0][id]=bb97e258&evt_ts[segments][1][filterGroups][0][filters][0][id]=52cd10d0&evt_ts[segments][1][filterGroups][0][filters][0][field]=metadata.eventType.raw&evt_ts[segments][1][filterGroups][0][filters][0][name]=&evt_ts[segments][1][filterGroups][0][filters][0][op]=contains&evt_ts[segments][1][filterGroups][0][filters][0][value][0]=step&evt_ts[segments][1][filterGroups][0][filters][1][id]=ab18b766&evt_ts[segments][1][filterGroups][0][filters][1][field]=metadata.authStepSuccess&evt_ts[segments][1][filterGroups][0][filters][1][name]=&evt_ts[segments][1][filterGroups][0][filters][1][op]=eq&evt_ts[segments][1][filterGroups][0][filters][1][value][0]=false",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=31f53870&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=6af3bb9b&evtcf[filtersGroups][0][filters][2][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=Console&evtcf[filtersGroups][0][filters][3][id]=e4fa5862&evtcf[filtersGroups][0][filters][3][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][3][op]=not_contain&evtcf[filtersGroups][0][filters][3][value][0]=AGENT&evtcf[filtersGroups][1][filters][0][id]=aa7f60c8&evtcf[filtersGroups][1][filters][0][field]=action_name.raw&evtcf[filtersGroups][1][filters][0][name]=&evtcf[filtersGroups][1][filters][0][op]=contains&evtcf[filtersGroups][1][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][1][filters][1][id]=cbb3b1c3&evtcf[filtersGroups][1][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][1][filters][1][name]=&evtcf[filtersGroups][1][filters][1][op]=contains&evtcf[filtersGroups][1][filters][1][value][0]=step&evtcf[filtersGroups][1][filters][2][id]=6a52100d&evtcf[filtersGroups][1][filters][2][field]=metadata.authStepSuccess&evtcf[filtersGroups][1][filters][2][name]=&evtcf[filtersGroups][1][filters][2][op]=eq&evtcf[filtersGroups][1][filters][2][value][0]=false&evtcf[filtersGroups][1][filters][3][id]=28fca1e7&evtcf[filtersGroups][1][filters][3][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][1][filters][3][name]=&evtcf[filtersGroups][1][filters][3][op]=not_contain&evtcf[filtersGroups][1][filters][3][value][0]=Console&evtcf[filtersGroups][1][filters][4][id]=3f074353&evtcf[filtersGroups][1][filters][4][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][1][filters][4][op]=not_contain&evtcf[filtersGroups][1][filters][4][value][0]=AGENT&evt_ts[metrics][0][metricName]=sum%28events%29&evt_ts[interval]=24h&evt_ts[segments][0][name]=Login%20Success&evt_ts[segments][0][filterGroups][0][id]=bf054cca&evt_ts[segments][0][filterGroups][0][filters][0][id]=2e2dc3c1&evt_ts[segments][0][filterGroups][0][filters][0][field]=metadata.eventType.raw&evt_ts[segments][0][filterGroups][0][filters][0][name]=&evt_ts[segments][0][filterGroups][0][filters][0][op]=contains&evt_ts[segments][0][filterGroups][0][filters][0][value][0]=overall&evt_ts[segments][1][name]=Login%20Failure&evt_ts[segments][1][filterGroups][0][id]=bb97e258&evt_ts[segments][1][filterGroups][0][filters][0][id]=52cd10d0&evt_ts[segments][1][filterGroups][0][filters][0][field]=metadata.eventType.raw&evt_ts[segments][1][filterGroups][0][filters][0][name]=&evt_ts[segments][1][filterGroups][0][filters][0][op]=contains&evt_ts[segments][1][filterGroups][0][filters][0][value][0]=step&evt_ts[segments][1][filterGroups][0][filters][1][id]=ab18b766&evt_ts[segments][1][filterGroups][0][filters][1][field]=metadata.authStepSuccess&evt_ts[segments][1][filterGroups][0][filters][1][name]=&evt_ts[segments][1][filterGroups][0][filters][1][op]=eq&evt_ts[segments][1][filterGroups][0][filters][1][value][0]=false",
       "analyticType": "entTmSrs",
       "chartType": "line",
       "settings": {
@@ -903,6 +1063,17 @@
                     "overall"
                   ]
                 }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.userStoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                }
               }
             ]
           }
@@ -925,6 +1096,17 @@
                       "metadata.eventType.raw": [
                         "overall"
                       ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.userStoreDomain.raw": [
+                            "AGENT"
+                          ]
+                        }
+                      }
                     }
                   }
                 ]
@@ -961,7 +1143,7 @@
       },
       "view": "time",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=e76aa628&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evt_ts[metrics][0][metricName]=sum%28events%29&evt_ts[metrics][0][customName]=%20Total%20Succesfull%20Login&evt_ts[metrics][1][i]=641d37f2&evt_ts[metrics][1][metricName]=count%28distinct%28user_id%29%29&evt_ts[metrics][1][customName]=Total%20Unique%20Users&evt_ts[interval]=24h",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=e76aa628&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=269fd28b&evtcf[filtersGroups][0][filters][2][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=AGENT&evt_ts[metrics][0][metricName]=sum%28events%29&evt_ts[metrics][0][customName]=%20Total%20Succesfull%20Login&evt_ts[metrics][1][i]=641d37f2&evt_ts[metrics][1][metricName]=count%28distinct%28user_id%29%29&evt_ts[metrics][1][customName]=Total%20Unique%20Users&evt_ts[interval]=24h",
       "analyticType": "entTmSrs",
       "chartType": "line",
       "settings": {
@@ -1017,6 +1199,17 @@
                     }
                   ]
                 }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.userStoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                }
               }
             ]
           }
@@ -1055,6 +1248,17 @@
                           }
                         }
                       ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.userStoreDomain.raw": [
+                            "AGENT"
+                          ]
+                        }
+                      }
                     }
                   }
                 ]
@@ -1096,7 +1300,7 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=564bd5af&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=106390bd&evtcf[filtersGroups][0][filters][2][field]=request.user_agent.device.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=exists&evtcf[filtersGroups][0][filters][2][value]=&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=Logins%20By%20Device&seg[groups][0][field]=request.user_agent.device.raw&seg[groups][0][func]=terms&seg[groups][0][by]=metric",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=564bd5af&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=106390bd&evtcf[filtersGroups][0][filters][2][field]=request.user_agent.device.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=exists&evtcf[filtersGroups][0][filters][2][value]=&evtcf[filtersGroups][0][filters][3][id]=fd8e816d&evtcf[filtersGroups][0][filters][3][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][3][op]=not_contain&evtcf[filtersGroups][0][filters][3][value][0]=AGENT&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=Logins%20By%20Device&seg[groups][0][field]=request.user_agent.device.raw&seg[groups][0][func]=terms&seg[groups][0][by]=metric",
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
@@ -1148,6 +1352,17 @@
                     }
                   }
                 }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.userStoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                }
               }
             ]
           }
@@ -1178,6 +1393,17 @@
                         "terms": {
                           "metadata.serviceProvider.raw": [
                             "Console"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.userStoreDomain.raw": [
+                            "AGENT"
                           ]
                         }
                       }
@@ -1222,7 +1448,7 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=e76aa628&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=228de34f&evtcf[filtersGroups][0][filters][2][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=Console&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=Login%20By%20Application&seg[groups][0][field]=metadata.serviceProvider.raw&seg[groups][0][func]=terms&seg[groups][0][by]=metric",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=e76aa628&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=228de34f&evtcf[filtersGroups][0][filters][2][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=Console&evtcf[filtersGroups][0][filters][3][id]=1f11a71d&evtcf[filtersGroups][0][filters][3][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][3][op]=not_contain&evtcf[filtersGroups][0][filters][3][value][0]=AGENT&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=Login%20By%20Application&seg[groups][0][field]=metadata.serviceProvider.raw&seg[groups][0][func]=terms&seg[groups][0][by]=metric",
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
@@ -1262,6 +1488,17 @@
                   "metadata.eventType.raw": [
                     "overall"
                   ]
+                }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.userStoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
                 }
               }
             ]
@@ -1304,6 +1541,17 @@
                         "overall"
                       ]
                     }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.userStoreDomain.raw": [
+                            "AGENT"
+                          ]
+                        }
+                      }
+                    }
                   }
                 ]
               }
@@ -1343,7 +1591,7 @@
       },
       "view": "map",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=cc5e6918&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&mp[metrics][0][metricName]=sum%28events%29&mp[area][top_left][lat]=69.54987728327795&mp[area][top_left][lon]=-96.37207031250001&mp[area][bottom_right][lat]=53.14677033085084&mp[area][bottom_right][lon]=-38.49609375000001&mp[viewport][center][0]=62.44834907791381&mp[viewport][center][1]=-67.45056152343751&mp[viewport][zoom]=5"
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=cc5e6918&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=14da6720&evtcf[filtersGroups][0][filters][2][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=AGENT&mp[metrics][0][metricName]=sum%28events%29&mp[area][top_left][lat]=69.54987728327795&mp[area][top_left][lon]=-96.37207031250001&mp[area][bottom_right][lat]=53.14677033085084&mp[area][bottom_right][lon]=-38.49609375000001&mp[viewport][center][0]=62.44834907791381&mp[viewport][center][1]=-67.45056152343751&mp[viewport][zoom]=5"
     },
     {
       "_id": "6a1e90c39ab5707f95230d67",
@@ -1352,9 +1600,26 @@
       "args": "",
       "es_query": {
         "post_filter": {
-          "terms": {
-            "action_name.raw": [
-              "User-Registration"
+          "bool": {
+            "must": [
+              {
+                "terms": {
+                  "action_name.raw": [
+                    "User-Registration"
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.userstoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                }
+              }
             ]
           }
         },
@@ -1362,9 +1627,26 @@
         "aggs": {
           "seg": {
             "filter": {
-              "terms": {
-                "action_name.raw": [
-                  "User-Registration"
+              "bool": {
+                "must": [
+                  {
+                    "terms": {
+                      "action_name.raw": [
+                        "User-Registration"
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.userstoreDomain.raw": [
+                            "AGENT"
+                          ]
+                        }
+                      }
+                    }
+                  }
                 ]
               }
             },
@@ -1385,7 +1667,7 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=%20",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evtcf[filtersGroups][0][filters][1][id]=5d1d436a&evtcf[filtersGroups][0][filters][1][field]=metadata.userstoreDomain.raw&evtcf[filtersGroups][0][filters][1][op]=not_contain&evtcf[filtersGroups][0][filters][1][value][0]=AGENT&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=%20",
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
@@ -1425,6 +1707,17 @@
                     "SELF_SIGNUP"
                   ]
                 }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.userstoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                }
               }
             ]
           }
@@ -1448,6 +1741,17 @@
                         "SELF_SIGNUP"
                       ]
                     }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.userstoreDomain.raw": [
+                            "AGENT"
+                          ]
+                        }
+                      }
+                    }
                   }
                 ]
               }
@@ -1469,7 +1773,7 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evtcf[filtersGroups][0][filters][1][id]=17e73a23&evtcf[filtersGroups][0][filters][1][field]=metadata.userOnboardedMethod.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=SELF_SIGNUP&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=%20",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evtcf[filtersGroups][0][filters][1][id]=17e73a23&evtcf[filtersGroups][0][filters][1][field]=metadata.userOnboardedMethod.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=SELF_SIGNUP&evtcf[filtersGroups][0][filters][2][id]=f706448d&evtcf[filtersGroups][0][filters][2][field]=metadata.userstoreDomain.raw&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=AGENT&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=%20",
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
@@ -1494,9 +1798,26 @@
       "args": "",
       "es_query": {
         "post_filter": {
-          "terms": {
-            "action_name.raw": [
-              "User-Registration"
+          "bool": {
+            "must": [
+              {
+                "terms": {
+                  "action_name.raw": [
+                    "User-Registration"
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.userstoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                }
+              }
             ]
           }
         },
@@ -1504,9 +1825,26 @@
         "aggs": {
           "seg": {
             "filter": {
-              "terms": {
-                "action_name.raw": [
-                  "User-Registration"
+              "bool": {
+                "must": [
+                  {
+                    "terms": {
+                      "action_name.raw": [
+                        "User-Registration"
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.userstoreDomain.raw": [
+                            "AGENT"
+                          ]
+                        }
+                      }
+                    }
+                  }
                 ]
               }
             },
@@ -1546,7 +1884,7 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&seg[groups][0][field]=metadata.userOnboardedMethod.raw&seg[groups][0][func]=terms&seg[groups][0][by]=metric&seg[metrics][0][metricName]=sum%28events%29&seg[chartType]=pie",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evtcf[filtersGroups][0][filters][1][id]=c1838bf7&evtcf[filtersGroups][0][filters][1][field]=metadata.userstoreDomain.raw&evtcf[filtersGroups][0][filters][1][op]=not_contain&evtcf[filtersGroups][0][filters][1][value][0]=AGENT&seg[groups][0][field]=metadata.userOnboardedMethod.raw&seg[groups][0][func]=terms&seg[groups][0][by]=metric&seg[metrics][0][metricName]=sum%28events%29&seg[chartType]=pie",
       "analyticType": "seg",
       "chartType": "pie",
       "settings": {
@@ -1572,9 +1910,26 @@
       "args": "",
       "es_query": {
         "post_filter": {
-          "terms": {
-            "action_name.raw": [
-              "User-Registration"
+          "bool": {
+            "must": [
+              {
+                "terms": {
+                  "action_name.raw": [
+                    "User-Registration"
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.userstoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                }
+              }
             ]
           }
         },
@@ -1582,9 +1937,26 @@
         "aggs": {
           "entTmSrs": {
             "filter": {
-              "terms": {
-                "action_name.raw": [
-                  "User-Registration"
+              "bool": {
+                "must": [
+                  {
+                    "terms": {
+                      "action_name.raw": [
+                        "User-Registration"
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.userstoreDomain.raw": [
+                            "AGENT"
+                          ]
+                        }
+                      }
+                    }
+                  }
                 ]
               }
             },
@@ -1633,7 +2005,7 @@
       },
       "view": "time",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evt_ts[metrics][0][metricName]=sum%28events%29&evt_ts[interval]=1d&evt_ts[groups][0][field]=metadata.userOnboardedMethod.raw&evt_ts[groups][0][func]=terms&evt_ts[groups][0][by]=metric",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evtcf[filtersGroups][0][filters][1][id]=e092b4de&evtcf[filtersGroups][0][filters][1][field]=metadata.userstoreDomain.raw&evtcf[filtersGroups][0][filters][1][op]=not_contain&evtcf[filtersGroups][0][filters][1][value][0]=AGENT&evt_ts[metrics][0][metricName]=sum%28events%29&evt_ts[interval]=1d&evt_ts[groups][0][field]=metadata.userOnboardedMethod.raw&evt_ts[groups][0][func]=terms&evt_ts[groups][0][by]=metric",
       "analyticType": "entTmSrs",
       "chartType": "line",
       "settings": {
@@ -1674,6 +2046,17 @@
                     "END"
                   ]
                 }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.userStoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                }
               }
             ]
           }
@@ -1696,6 +2079,17 @@
                       "metadata.currentNodeId.raw": [
                         "END"
                       ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.userStoreDomain.raw": [
+                            "AGENT"
+                          ]
+                        }
+                      }
                     }
                   }
                 ]
@@ -1737,7 +2131,7 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration-Flow&evtcf[filtersGroups][0][filters][1][id]=0480937e&evtcf[filtersGroups][0][filters][1][field]=metadata.currentNodeId.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=END&seg[groups][0][field]=metadata.applicationId.raw&seg[groups][0][func]=terms&seg[groups][0][by]=metric&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=Registrations%20By%20Application&seg[chartType]=bar",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration-Flow&evtcf[filtersGroups][0][filters][1][id]=0480937e&evtcf[filtersGroups][0][filters][1][field]=metadata.currentNodeId.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=END&evtcf[filtersGroups][0][filters][2][id]=192589e3&evtcf[filtersGroups][0][filters][2][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=AGENT&seg[groups][0][field]=metadata.applicationId.raw&seg[groups][0][func]=terms&seg[groups][0][by]=metric&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=Registrations%20By%20Application&seg[chartType]=bar",
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
@@ -1786,6 +2180,17 @@
                     "false"
                   ]
                 }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.userStoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                }
               }
             ]
           }
@@ -1816,6 +2221,17 @@
                         "false"
                       ]
                     }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.userStoreDomain.raw": [
+                            "AGENT"
+                          ]
+                        }
+                      }
+                    }
                   }
                 ]
               }
@@ -1836,7 +2252,7 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][0][filters][1][id]=938597af&evtcf[filtersGroups][0][filters][1][field]=metadata.userType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=APPLICATION&evtcf[filtersGroups][0][filters][2][id]=2714f5ec&evtcf[filtersGroups][0][filters][2][field]=metadata.existingTokenUsed&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=eq&evtcf[filtersGroups][0][filters][2][value][0]=false&seg[metrics][0][metricName]=count%28event_id%29&seg[metrics][0][customName]=%20",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][0][filters][1][id]=938597af&evtcf[filtersGroups][0][filters][1][field]=metadata.userType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=APPLICATION&evtcf[filtersGroups][0][filters][2][id]=2714f5ec&evtcf[filtersGroups][0][filters][2][field]=metadata.existingTokenUsed&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=eq&evtcf[filtersGroups][0][filters][2][value][0]=false&evtcf[filtersGroups][0][filters][3][id]=9adf4672&evtcf[filtersGroups][0][filters][3][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][3][op]=not_contain&evtcf[filtersGroups][0][filters][3][value][0]=AGENT&seg[metrics][0][metricName]=count%28event_id%29&seg[metrics][0][customName]=%20",
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
@@ -2440,6 +2856,1295 @@
                 ]
               }
             ]
+          }
+        ]
+      }
+    },
+    {
+      "_id": "6a5e2e79e57d307b8ba6d549",
+      "type": "events",
+      "name": "New Agents",
+      "args": "",
+      "es_query": {
+        "post_filter": {
+          "bool": {
+            "must": [
+              {
+                "terms": {
+                  "action_name.raw": [
+                    "User-Registration"
+                  ]
+                }
+              },
+              {
+                "terms": {
+                  "metadata.userstoreDomain.raw": [
+                    "AGENT"
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "size": 0,
+        "aggs": {
+          "seg": {
+            "filter": {
+              "bool": {
+                "must": [
+                  {
+                    "terms": {
+                      "action_name.raw": [
+                        "User-Registration"
+                      ]
+                    }
+                  },
+                  {
+                    "terms": {
+                      "metadata.userstoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            "aggs": {
+              "weight|sum": {
+                "sum": {
+                  "field": "weight",
+                  "missing": 1
+                }
+              }
+            }
+          }
+        },
+        "track_total_hits": false
+      },
+      "dateRange": {
+        "from": "-52w",
+        "to": "now"
+      },
+      "view": "segment",
+      "funnel_query": {},
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evtcf[filtersGroups][0][filters][1][id]=a2892735&evtcf[filtersGroups][0][filters][1][field]=metadata.userstoreDomain.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=AGENT&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=%20",
+      "analyticType": "seg",
+      "chartType": "bar",
+      "settings": {
+        "singleValueSettings": {
+          "chartHeight": "80",
+          "hideLabel": "true",
+          "trendIndicator": {
+            "isIncreasementGreen": "true"
+          }
+        },
+        "metrics": [
+          {
+            "metricName": "sum(events)"
+          }
+        ]
+      }
+    },
+    {
+      "_id": "6a5e2d748473bc558cd9b16d",
+      "type": "events",
+      "name": "Agent Tokens",
+      "args": "",
+      "es_query": {
+        "post_filter": {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "terms": {
+                        "action_name.raw": [
+                          "OAuth-Token-Issuance"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.existingTokenUsed": [
+                          "false"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.userStoreDomain.raw": [
+                          "AGENT"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "terms": {
+                        "action_name.raw": [
+                          "OAuth-Token-Issuance"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.existingTokenUsed": [
+                          "false"
+                        ]
+                      }
+                    },
+                    {
+                      "bool": {
+                        "should": [
+                          {
+                            "exists": {
+                              "field": "metadata.actor.raw"
+                            }
+                          },
+                          {
+                            "exists": {
+                              "field": "metadata.actor"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "bool": {
+                        "must_not": {
+                          "terms": {
+                            "metadata.actor.raw": [
+                              "NOT_AVAILABLE"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "size": 0,
+        "aggs": {
+          "seg": {
+            "filter": {
+              "bool": {
+                "should": [
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "terms": {
+                            "action_name.raw": [
+                              "OAuth-Token-Issuance"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.existingTokenUsed": [
+                              "false"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.userStoreDomain.raw": [
+                              "AGENT"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "terms": {
+                            "action_name.raw": [
+                              "OAuth-Token-Issuance"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.existingTokenUsed": [
+                              "false"
+                            ]
+                          }
+                        },
+                        {
+                          "bool": {
+                            "should": [
+                              {
+                                "exists": {
+                                  "field": "metadata.actor.raw"
+                                }
+                              },
+                              {
+                                "exists": {
+                                  "field": "metadata.actor"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "bool": {
+                            "must_not": {
+                              "terms": {
+                                "metadata.actor.raw": [
+                                  "NOT_AVAILABLE"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            "aggs": {
+              "_id|cardinality": {
+                "cardinality": {
+                  "field": "_id"
+                }
+              }
+            }
+          }
+        },
+        "track_total_hits": false
+      },
+      "dateRange": {
+        "from": "-12w",
+        "to": "now"
+      },
+      "view": "segment",
+      "funnel_query": {},
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][0][filters][1][id]=2714f5ec&evtcf[filtersGroups][0][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=eq&evtcf[filtersGroups][0][filters][1][value][0]=false&evtcf[filtersGroups][0][filters][2][id]=b84a7b60&evtcf[filtersGroups][0][filters][2][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=contains&evtcf[filtersGroups][0][filters][2][value][0]=AGENT&evtcf[filtersGroups][1][filters][0][id]=ad5ef950&evtcf[filtersGroups][1][filters][0][field]=action_name.raw&evtcf[filtersGroups][1][filters][0][name]=&evtcf[filtersGroups][1][filters][0][op]=contains&evtcf[filtersGroups][1][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][1][filters][1][id]=0e44fc56&evtcf[filtersGroups][1][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][1][filters][1][name]=&evtcf[filtersGroups][1][filters][1][op]=eq&evtcf[filtersGroups][1][filters][1][value][0]=false&evtcf[filtersGroups][1][filters][2][id]=32fc6113&evtcf[filtersGroups][1][filters][2][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][2][name]=&evtcf[filtersGroups][1][filters][2][op]=exists&evtcf[filtersGroups][1][filters][2][value]=&evtcf[filtersGroups][1][filters][3][id]=83cacaad&evtcf[filtersGroups][1][filters][3][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][3][name]=&evtcf[filtersGroups][1][filters][3][op]=not_contain&evtcf[filtersGroups][1][filters][3][value][0]=NOT_AVAILABLE&seg[metrics][0][metricName]=count%28event_id%29&seg[metrics][0][customName]=%20",
+      "analyticType": "seg",
+      "chartType": "bar",
+      "settings": {
+        "singleValueSettings": {
+          "chartHeight": "80",
+          "hideLabel": "true",
+          "trendIndicator": {
+            "isIncreasementGreen": "true"
+          }
+        },
+        "metrics": [
+          {
+            "metricName": "count(event_id)"
+          }
+        ]
+      }
+    },
+    {
+      "_id": "6a5e45698473bc558cd9b202",
+      "type": "events",
+      "name": "Agent Tokens Over Time",
+      "args": "",
+      "es_query": {
+        "post_filter": {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "terms": {
+                        "action_name.raw": [
+                          "OAuth-Token-Issuance"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.existingTokenUsed": [
+                          "false"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.userStoreDomain.raw": [
+                          "AGENT"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "terms": {
+                        "action_name.raw": [
+                          "OAuth-Token-Issuance"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.existingTokenUsed": [
+                          "false"
+                        ]
+                      }
+                    },
+                    {
+                      "bool": {
+                        "should": [
+                          {
+                            "exists": {
+                              "field": "metadata.actor.raw"
+                            }
+                          },
+                          {
+                            "exists": {
+                              "field": "metadata.actor"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "bool": {
+                        "must_not": {
+                          "terms": {
+                            "metadata.actor.raw": [
+                              "NOT_AVAILABLE"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "size": 0,
+        "aggs": {
+          "entTmSrs": {
+            "filter": {
+              "bool": {
+                "should": [
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "terms": {
+                            "action_name.raw": [
+                              "OAuth-Token-Issuance"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.existingTokenUsed": [
+                              "false"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.userStoreDomain.raw": [
+                              "AGENT"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "terms": {
+                            "action_name.raw": [
+                              "OAuth-Token-Issuance"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.existingTokenUsed": [
+                              "false"
+                            ]
+                          }
+                        },
+                        {
+                          "bool": {
+                            "should": [
+                              {
+                                "exists": {
+                                  "field": "metadata.actor.raw"
+                                }
+                              },
+                              {
+                                "exists": {
+                                  "field": "metadata.actor"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "bool": {
+                            "must_not": {
+                              "terms": {
+                                "metadata.actor.raw": [
+                                  "NOT_AVAILABLE"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            "aggs": {
+              "segment__Direct Agent Logins": {
+                "filter": {
+                  "terms": {
+                    "metadata.userStoreDomain.raw": [
+                      "AGENT"
+                    ]
+                  }
+                },
+                "aggs": {
+                  "request.time": {
+                    "date_histogram": {
+                      "field": "request.time",
+                      "interval": "1d",
+                      "time_zone": "Asia/Colombo"
+                    },
+                    "aggs": {
+                      "_id|cardinality": {
+                        "cardinality": {
+                          "field": "_id"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "segment__Agent On Behalf of User": {
+                "filter": {
+                  "bool": {
+                    "must": [
+                      {
+                        "bool": {
+                          "should": [
+                            {
+                              "exists": {
+                                "field": "metadata.actor.raw"
+                              }
+                            },
+                            {
+                              "exists": {
+                                "field": "metadata.actor"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "bool": {
+                          "must_not": {
+                            "terms": {
+                              "metadata.actor.raw": [
+                                "NOT_AVAILABLE"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "aggs": {
+                  "request.time": {
+                    "date_histogram": {
+                      "field": "request.time",
+                      "interval": "1d",
+                      "time_zone": "Asia/Colombo"
+                    },
+                    "aggs": {
+                      "_id|cardinality": {
+                        "cardinality": {
+                          "field": "_id"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "dateRange": {
+        "from": "-12w",
+        "to": "now"
+      },
+      "view": "time",
+      "funnel_query": {},
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][0][filters][1][id]=2714f5ec&evtcf[filtersGroups][0][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=eq&evtcf[filtersGroups][0][filters][1][value][0]=false&evtcf[filtersGroups][0][filters][2][id]=b84a7b60&evtcf[filtersGroups][0][filters][2][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=contains&evtcf[filtersGroups][0][filters][2][value][0]=AGENT&evtcf[filtersGroups][1][filters][0][id]=ad5ef950&evtcf[filtersGroups][1][filters][0][field]=action_name.raw&evtcf[filtersGroups][1][filters][0][name]=&evtcf[filtersGroups][1][filters][0][op]=contains&evtcf[filtersGroups][1][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][1][filters][1][id]=0e44fc56&evtcf[filtersGroups][1][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][1][filters][1][name]=&evtcf[filtersGroups][1][filters][1][op]=eq&evtcf[filtersGroups][1][filters][1][value][0]=false&evtcf[filtersGroups][1][filters][2][id]=83cacaad&evtcf[filtersGroups][1][filters][2][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][2][name]=&evtcf[filtersGroups][1][filters][2][op]=exists&evtcf[filtersGroups][1][filters][2][value]=&evtcf[filtersGroups][1][filters][3][id]=c919c6ab&evtcf[filtersGroups][1][filters][3][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][3][name]=&evtcf[filtersGroups][1][filters][3][op]=not_contain&evtcf[filtersGroups][1][filters][3][value][0]=NOT_AVAILABLE&evt_ts[metrics][0][metricName]=count%28event_id%29&evt_ts[metrics][0][customName]=%20&evt_ts[segments][0][name]=Direct%20Agent%20Logins&evt_ts[segments][0][filterGroups][0][id]=d306199d&evt_ts[segments][0][filterGroups][0][filters][0][id]=12a24629&evt_ts[segments][0][filterGroups][0][filters][0][field]=metadata.userStoreDomain.raw&evt_ts[segments][0][filterGroups][0][filters][0][name]=&evt_ts[segments][0][filterGroups][0][filters][0][op]=contains&evt_ts[segments][0][filterGroups][0][filters][0][value][0]=AGENT&evt_ts[segments][1][name]=Agent%20On%20Behalf%20of%20User&evt_ts[segments][1][filterGroups][0][id]=ec24a1bf&evt_ts[segments][1][filterGroups][0][filters][0][id]=b140ce64&evt_ts[segments][1][filterGroups][0][filters][0][field]=metadata.actor.raw&evt_ts[segments][1][filterGroups][0][filters][0][name]=&evt_ts[segments][1][filterGroups][0][filters][0][op]=exists&evt_ts[segments][1][filterGroups][0][filters][0][value]=&evt_ts[segments][1][filterGroups][0][filters][1][id]=ec5b72df&evt_ts[segments][1][filterGroups][0][filters][1][field]=metadata.actor.raw&evt_ts[segments][1][filterGroups][0][filters][1][name]=&evt_ts[segments][1][filterGroups][0][filters][1][op]=not_contain&evt_ts[segments][1][filterGroups][0][filters][1][value][0]=NOT_AVAILABLE",
+      "analyticType": "entTmSrs",
+      "chartType": "line",
+      "settings": {
+        "metrics": [
+          {
+            "metricName": "count(event_id)",
+            "customName": " "
+          }
+        ],
+        "segments": [
+          {
+            "name": "Direct Agent Logins",
+            "filterGroups": [
+              {
+                "id": "d306199d",
+                "filters": [
+                  {
+                    "id": "12a24629",
+                    "field": "metadata.userStoreDomain.raw",
+                    "name": "",
+                    "op": "contains",
+                    "value": [
+                      "AGENT"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Agent On Behalf of User",
+            "filterGroups": [
+              {
+                "id": "ec24a1bf",
+                "filters": [
+                  {
+                    "id": "b140ce64",
+                    "field": "metadata.actor.raw",
+                    "name": "",
+                    "op": "exists",
+                    "value": ""
+                  },
+                  {
+                    "id": "ec5b72df",
+                    "field": "metadata.actor.raw",
+                    "name": "",
+                    "op": "not_contain",
+                    "value": [
+                      "NOT_AVAILABLE"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "_id": "6a5e435a8473bc558cd9b1de",
+      "type": "events",
+      "name": "Agent Logins Over Time",
+      "args": "",
+      "es_query": {
+        "post_filter": {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "terms": {
+                        "action_name.raw": [
+                          "User-Authentication"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.eventType.raw": [
+                          "overall"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.userStoreDomain.raw": [
+                          "AGENT"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "terms": {
+                        "action_name.raw": [
+                          "User-Authentication"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.eventType.raw": [
+                          "step"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.authStepSuccess": [
+                          "false"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.userStoreDomain.raw": [
+                          "AGENT"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "size": 0,
+        "aggs": {
+          "entTmSrs": {
+            "filter": {
+              "bool": {
+                "should": [
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "terms": {
+                            "action_name.raw": [
+                              "User-Authentication"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.eventType.raw": [
+                              "overall"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.userStoreDomain.raw": [
+                              "AGENT"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "terms": {
+                            "action_name.raw": [
+                              "User-Authentication"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.eventType.raw": [
+                              "step"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.authStepSuccess": [
+                              "false"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.userStoreDomain.raw": [
+                              "AGENT"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            "aggs": {
+              "segment__Login Success": {
+                "filter": {
+                  "terms": {
+                    "metadata.eventType.raw": [
+                      "overall"
+                    ]
+                  }
+                },
+                "aggs": {
+                  "request.time": {
+                    "date_histogram": {
+                      "field": "request.time",
+                      "interval": "1d",
+                      "time_zone": "Asia/Colombo"
+                    },
+                    "aggs": {
+                      "weight|sum": {
+                        "sum": {
+                          "field": "weight",
+                          "missing": 1
+                        }
+                      },
+                      "user_id|cardinality": {
+                        "cardinality": {
+                          "field": "user_id.raw"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "segment__Login Fail": {
+                "filter": {
+                  "bool": {
+                    "must": [
+                      {
+                        "terms": {
+                          "metadata.eventType.raw": [
+                            "step"
+                          ]
+                        }
+                      },
+                      {
+                        "terms": {
+                          "metadata.authStepSuccess": [
+                            "false"
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                },
+                "aggs": {
+                  "request.time": {
+                    "date_histogram": {
+                      "field": "request.time",
+                      "interval": "1d",
+                      "time_zone": "Asia/Colombo"
+                    },
+                    "aggs": {
+                      "weight|sum": {
+                        "sum": {
+                          "field": "weight",
+                          "missing": 1
+                        }
+                      },
+                      "user_id|cardinality": {
+                        "cardinality": {
+                          "field": "user_id.raw"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "dateRange": {
+        "from": "-7d",
+        "to": "now"
+      },
+      "view": "time",
+      "funnel_query": {},
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=e76aa628&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=59753cd6&evtcf[filtersGroups][0][filters][2][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=contains&evtcf[filtersGroups][0][filters][2][value][0]=AGENT&evtcf[filtersGroups][1][filters][0][id]=f44a8a2b&evtcf[filtersGroups][1][filters][0][field]=action_name.raw&evtcf[filtersGroups][1][filters][0][name]=&evtcf[filtersGroups][1][filters][0][op]=contains&evtcf[filtersGroups][1][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][1][filters][1][id]=a1e663e3&evtcf[filtersGroups][1][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][1][filters][1][name]=&evtcf[filtersGroups][1][filters][1][op]=contains&evtcf[filtersGroups][1][filters][1][value][0]=step&evtcf[filtersGroups][1][filters][2][id]=096cebdf&evtcf[filtersGroups][1][filters][2][field]=metadata.authStepSuccess&evtcf[filtersGroups][1][filters][2][name]=&evtcf[filtersGroups][1][filters][2][op]=eq&evtcf[filtersGroups][1][filters][2][value][0]=false&evtcf[filtersGroups][1][filters][3][id]=02faa08b&evtcf[filtersGroups][1][filters][3][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][1][filters][3][name]=&evtcf[filtersGroups][1][filters][3][op]=contains&evtcf[filtersGroups][1][filters][3][value][0]=AGENT&evt_ts[metrics][0][metricName]=sum%28events%29&evt_ts[metrics][0][customName]=Total%20Agents&evt_ts[metrics][1][i]=d12efaf0&evt_ts[metrics][1][metricName]=count%28distinct%28user_id%29%29&evt_ts[metrics][1][customName]=Unique%20Agents&evt_ts[interval]=1d&evt_ts[segments][0][name]=Login%20Success&evt_ts[segments][0][filterGroups][0][id]=70dbdc13&evt_ts[segments][0][filterGroups][0][filters][0][id]=1d0d6468&evt_ts[segments][0][filterGroups][0][filters][0][field]=metadata.eventType.raw&evt_ts[segments][0][filterGroups][0][filters][0][name]=&evt_ts[segments][0][filterGroups][0][filters][0][op]=contains&evt_ts[segments][0][filterGroups][0][filters][0][value][0]=overall&evt_ts[segments][1][name]=Login%20Fail&evt_ts[segments][1][filterGroups][0][id]=b0bf4013&evt_ts[segments][1][filterGroups][0][filters][0][id]=52a2bfd5&evt_ts[segments][1][filterGroups][0][filters][0][field]=metadata.eventType.raw&evt_ts[segments][1][filterGroups][0][filters][0][name]=&evt_ts[segments][1][filterGroups][0][filters][0][op]=contains&evt_ts[segments][1][filterGroups][0][filters][0][value][0]=step&evt_ts[segments][1][filterGroups][0][filters][1][id]=190d2f42&evt_ts[segments][1][filterGroups][0][filters][1][field]=metadata.authStepSuccess&evt_ts[segments][1][filterGroups][0][filters][1][name]=&evt_ts[segments][1][filterGroups][0][filters][1][op]=eq&evt_ts[segments][1][filterGroups][0][filters][1][value][0]=false",
+      "analyticType": "entTmSrs",
+      "chartType": "line",
+      "settings": {
+        "metrics": [
+          {
+            "metricName": "sum(events)",
+            "customName": "Total Agents"
+          },
+          {
+            "i": "d12efaf0",
+            "metricName": "count(distinct(user_id))",
+            "customName": "Unique Agents"
+          }
+        ],
+        "interval": "1d",
+        "segments": [
+          {
+            "name": "Login Success",
+            "filterGroups": [
+              {
+                "id": "70dbdc13",
+                "filters": [
+                  {
+                    "id": "1d0d6468",
+                    "field": "metadata.eventType.raw",
+                    "name": "",
+                    "op": "contains",
+                    "value": [
+                      "overall"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Login Fail",
+            "filterGroups": [
+              {
+                "id": "b0bf4013",
+                "filters": [
+                  {
+                    "id": "52a2bfd5",
+                    "field": "metadata.eventType.raw",
+                    "name": "",
+                    "op": "contains",
+                    "value": [
+                      "step"
+                    ]
+                  },
+                  {
+                    "id": "190d2f42",
+                    "field": "metadata.authStepSuccess",
+                    "name": "",
+                    "op": "eq",
+                    "value": [
+                      "false"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "_id": "6a5e36ee8473bc558cd9b196",
+      "type": "events",
+      "name": "Agent Tokens",
+      "args": "",
+      "es_query": {
+        "post_filter": {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "terms": {
+                        "action_name.raw": [
+                          "OAuth-Token-Issuance"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.existingTokenUsed": [
+                          "false"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.userStoreDomain.raw": [
+                          "AGENT"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "terms": {
+                        "action_name.raw": [
+                          "OAuth-Token-Issuance"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.existingTokenUsed": [
+                          "false"
+                        ]
+                      }
+                    },
+                    {
+                      "bool": {
+                        "should": [
+                          {
+                            "exists": {
+                              "field": "metadata.actor.raw"
+                            }
+                          },
+                          {
+                            "exists": {
+                              "field": "metadata.actor"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "bool": {
+                        "must_not": {
+                          "terms": {
+                            "metadata.actor.raw": [
+                              "NOT_AVAILABLE"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "size": 0,
+        "aggs": {
+          "seg": {
+            "filter": {
+              "bool": {
+                "should": [
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "terms": {
+                            "action_name.raw": [
+                              "OAuth-Token-Issuance"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.existingTokenUsed": [
+                              "false"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.userStoreDomain.raw": [
+                              "AGENT"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "terms": {
+                            "action_name.raw": [
+                              "OAuth-Token-Issuance"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.existingTokenUsed": [
+                              "false"
+                            ]
+                          }
+                        },
+                        {
+                          "bool": {
+                            "should": [
+                              {
+                                "exists": {
+                                  "field": "metadata.actor.raw"
+                                }
+                              },
+                              {
+                                "exists": {
+                                  "field": "metadata.actor"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "bool": {
+                            "must_not": {
+                              "terms": {
+                                "metadata.actor.raw": [
+                                  "NOT_AVAILABLE"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            "aggs": {
+              "_id|cardinality": {
+                "cardinality": {
+                  "field": "_id"
+                }
+              }
+            }
+          }
+        }
+      },
+      "dateRange": {
+        "from": "-12w",
+        "to": "now"
+      },
+      "view": "segment",
+      "funnel_query": {},
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][0][filters][1][id]=2714f5ec&evtcf[filtersGroups][0][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=eq&evtcf[filtersGroups][0][filters][1][value][0]=false&evtcf[filtersGroups][0][filters][2][id]=b84a7b60&evtcf[filtersGroups][0][filters][2][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=contains&evtcf[filtersGroups][0][filters][2][value][0]=AGENT&evtcf[filtersGroups][1][filters][0][id]=ad5ef950&evtcf[filtersGroups][1][filters][0][field]=action_name.raw&evtcf[filtersGroups][1][filters][0][name]=&evtcf[filtersGroups][1][filters][0][op]=contains&evtcf[filtersGroups][1][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][1][filters][1][id]=0e44fc56&evtcf[filtersGroups][1][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][1][filters][1][name]=&evtcf[filtersGroups][1][filters][1][op]=eq&evtcf[filtersGroups][1][filters][1][value][0]=false&evtcf[filtersGroups][1][filters][2][id]=83cacaad&evtcf[filtersGroups][1][filters][2][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][2][name]=&evtcf[filtersGroups][1][filters][2][op]=exists&evtcf[filtersGroups][1][filters][2][value]=&evtcf[filtersGroups][1][filters][3][id]=c919c6ab&evtcf[filtersGroups][1][filters][3][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][3][name]=&evtcf[filtersGroups][1][filters][3][op]=not_contain&evtcf[filtersGroups][1][filters][3][value][0]=NOT_AVAILABLE&seg[metrics][0][metricName]=count%28event_id%29&seg[metrics][0][customName]=%20",
+      "analyticType": "seg",
+      "chartType": "bar",
+      "settings": {
+        "metrics": [
+          {
+            "metricName": "count(event_id)",
+            "customName": " "
+          }
+        ]
+      }
+    },
+    {
+      "_id": "6a5e2d4ce57d307b8ba6d53e",
+      "type": "events",
+      "name": "Active Agents",
+      "args": "",
+      "es_query": {
+        "post_filter": {
+          "bool": {
+            "must": [
+              {
+                "terms": {
+                  "action_name.raw": [
+                    "User-Authentication"
+                  ]
+                }
+              },
+              {
+                "terms": {
+                  "metadata.eventType.raw": [
+                    "overall"
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.serviceProvider.raw": [
+                        "Console"
+                      ]
+                    }
+                  }
+                }
+              },
+              {
+                "terms": {
+                  "metadata.userStoreDomain.raw": [
+                    "AGENT"
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "size": 0,
+        "aggs": {
+          "seg": {
+            "filter": {
+              "bool": {
+                "must": [
+                  {
+                    "terms": {
+                      "action_name.raw": [
+                        "User-Authentication"
+                      ]
+                    }
+                  },
+                  {
+                    "terms": {
+                      "metadata.eventType.raw": [
+                        "overall"
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.serviceProvider.raw": [
+                            "Console"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "terms": {
+                      "metadata.userStoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            "aggs": {
+              "user_id|cardinality": {
+                "cardinality": {
+                  "field": "user_id.raw"
+                }
+              }
+            }
+          }
+        }
+      },
+      "dateRange": {
+        "from": "-12w",
+        "to": "now"
+      },
+      "view": "segment",
+      "funnel_query": {},
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=e76aa628&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=698b6316&evtcf[filtersGroups][0][filters][2][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=Console&evtcf[filtersGroups][0][filters][3][id]=7a68f6a5&evtcf[filtersGroups][0][filters][3][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][3][name]=&evtcf[filtersGroups][0][filters][3][op]=contains&evtcf[filtersGroups][0][filters][3][value][0]=AGENT&seg[metrics][0][metricName]=count%28distinct%28user_id%29%29&seg[metrics][0][customName]=%20&seg[segments]=",
+      "analyticType": "seg",
+      "chartType": "bar",
+      "settings": {
+        "metrics": [
+          {
+            "metricName": "count(distinct(user_id))",
+            "customName": " "
+          }
+        ],
+        "segments": ""
+      }
+    },
+    {
+      "_id": "6a5e2d30e57d307b8ba6d53a",
+      "type": "events",
+      "name": "New Agents",
+      "args": "",
+      "es_query": {
+        "post_filter": {
+          "bool": {
+            "must": [
+              {
+                "terms": {
+                  "action_name.raw": [
+                    "User-Registration"
+                  ]
+                }
+              },
+              {
+                "terms": {
+                  "metadata.userstoreDomain.raw": [
+                    "AGENT"
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "size": 0,
+        "aggs": {
+          "seg": {
+            "filter": {
+              "bool": {
+                "must": [
+                  {
+                    "terms": {
+                      "action_name.raw": [
+                        "User-Registration"
+                      ]
+                    }
+                  },
+                  {
+                    "terms": {
+                      "metadata.userstoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            "aggs": {
+              "weight|sum": {
+                "sum": {
+                  "field": "weight",
+                  "missing": 1
+                }
+              }
+            }
+          }
+        }
+      },
+      "dateRange": {
+        "from": "-52w",
+        "to": "now"
+      },
+      "view": "segment",
+      "funnel_query": {},
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evtcf[filtersGroups][0][filters][1][id]=a2892735&evtcf[filtersGroups][0][filters][1][field]=metadata.userstoreDomain.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=AGENT&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=%20",
+      "analyticType": "seg",
+      "chartType": "bar",
+      "settings": {
+        "metrics": [
+          {
+            "metricName": "sum(events)",
+            "customName": " "
           }
         ]
       }

--- a/features/admin.analytics.v1/assets/moesif-dashboard-free.json
+++ b/features/admin.analytics.v1/assets/moesif-dashboard-free.json
@@ -7,13 +7,18 @@
             "workspace_ids": [
                 [
                     "6a1fac5668f9b5457fabcabb",
-                    "6a1fac9168f9b5457fabcabc"
+                    "6a1fac9168f9b5457fabcabc",
+                    "6a5e2e79e57d307b8ba6d549",
+                    "6a5e2d748473bc558cd9b16d"
                 ],
                 [
                     "6a1fad0868f9b5457fabcac5"
                 ],
                 [
                     "6a1fad328507014e56ac462e"
+                ],
+                [
+                    "6a5e45698473bc558cd9b202"
                 ]
             ],
             "parent": null,
@@ -54,6 +59,17 @@
                                         }
                                     }
                                 }
+                            },
+                            {
+                                "bool": {
+                                    "must_not": {
+                                        "terms": {
+                                            "metadata.userStoreDomain.raw": [
+                                                "AGENT"
+                                            ]
+                                        }
+                                    }
+                                }
                             }
                         ]
                     }
@@ -88,6 +104,17 @@
                                                 }
                                             }
                                         }
+                                    },
+                                    {
+                                        "bool": {
+                                            "must_not": {
+                                                "terms": {
+                                                    "metadata.userStoreDomain.raw": [
+                                                        "AGENT"
+                                                    ]
+                                                }
+                                            }
+                                        }
                                     }
                                 ]
                             }
@@ -108,7 +135,7 @@
             },
             "view": "segment",
             "funnel_query": {},
-            "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=e76aa628&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=698b6316&evtcf[filtersGroups][0][filters][2][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=Console&seg[metrics][0][metricName]=count%28distinct%28user_id%29%29&seg[metrics][0][customName]=%20",
+            "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=e76aa628&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=698b6316&evtcf[filtersGroups][0][filters][2][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=Console&evtcf[filtersGroups][0][filters][3][id]=3a5aa5df&evtcf[filtersGroups][0][filters][3][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][3][op]=not_contain&evtcf[filtersGroups][0][filters][3][value][0]=AGENT&seg[metrics][0][metricName]=count%28distinct%28user_id%29%29&seg[metrics][0][customName]=%20",
             "analyticType": "seg",
             "chartType": "bar",
             "settings": {
@@ -155,6 +182,17 @@
                                         "false"
                                     ]
                                 }
+                            },
+                            {
+                                "bool": {
+                                    "must_not": {
+                                        "terms": {
+                                            "metadata.userStoreDomain.raw": [
+                                                "AGENT"
+                                            ]
+                                        }
+                                    }
+                                }
                             }
                         ]
                     }
@@ -185,6 +223,17 @@
                                                 "false"
                                             ]
                                         }
+                                    },
+                                    {
+                                        "bool": {
+                                            "must_not": {
+                                                "terms": {
+                                                    "metadata.userStoreDomain.raw": [
+                                                        "AGENT"
+                                                    ]
+                                                }
+                                            }
+                                        }
                                     }
                                 ]
                             }
@@ -205,7 +254,7 @@
             },
             "view": "segment",
             "funnel_query": {},
-            "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][0][filters][1][id]=938597af&evtcf[filtersGroups][0][filters][1][field]=metadata.userType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=APPLICATION&evtcf[filtersGroups][0][filters][2][id]=2714f5ec&evtcf[filtersGroups][0][filters][2][field]=metadata.existingTokenUsed&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=eq&evtcf[filtersGroups][0][filters][2][value][0]=false&seg[metrics][0][metricName]=count%28event_id%29&seg[metrics][0][customName]=%20",
+            "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][0][filters][1][id]=938597af&evtcf[filtersGroups][0][filters][1][field]=metadata.userType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=APPLICATION&evtcf[filtersGroups][0][filters][2][id]=2714f5ec&evtcf[filtersGroups][0][filters][2][field]=metadata.existingTokenUsed&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=eq&evtcf[filtersGroups][0][filters][2][value][0]=false&evtcf[filtersGroups][0][filters][3][id]=57646124&evtcf[filtersGroups][0][filters][3][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][3][op]=not_contain&evtcf[filtersGroups][0][filters][3][value][0]=AGENT&seg[metrics][0][metricName]=count%28event_id%29&seg[metrics][0][customName]=%20",
             "analyticType": "seg",
             "chartType": "bar",
             "settings": {
@@ -259,6 +308,17 @@
                                                     }
                                                 }
                                             }
+                                        },
+                                        {
+                                            "bool": {
+                                                "must_not": {
+                                                    "terms": {
+                                                        "metadata.userStoreDomain.raw": [
+                                                            "AGENT"
+                                                        ]
+                                                    }
+                                                }
+                                            }
                                         }
                                     ]
                                 }
@@ -293,6 +353,17 @@
                                                     "terms": {
                                                         "metadata.serviceProvider.raw": [
                                                             "Console"
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "bool": {
+                                                "must_not": {
+                                                    "terms": {
+                                                        "metadata.userStoreDomain.raw": [
+                                                            "AGENT"
                                                         ]
                                                     }
                                                 }
@@ -337,6 +408,17 @@
                                                             }
                                                         }
                                                     }
+                                                },
+                                                {
+                                                    "bool": {
+                                                        "must_not": {
+                                                            "terms": {
+                                                                "metadata.userStoreDomain.raw": [
+                                                                    "AGENT"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
                                                 }
                                             ]
                                         }
@@ -371,6 +453,17 @@
                                                             "terms": {
                                                                 "metadata.serviceProvider.raw": [
                                                                     "Console"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "bool": {
+                                                        "must_not": {
+                                                            "terms": {
+                                                                "metadata.userStoreDomain.raw": [
+                                                                    "AGENT"
                                                                 ]
                                                             }
                                                         }
@@ -458,7 +551,7 @@
             },
             "view": "time",
             "funnel_query": {},
-            "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=31f53870&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=6af3bb9b&evtcf[filtersGroups][0][filters][2][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=Console&evtcf[filtersGroups][1][filters][0][id]=aa7f60c8&evtcf[filtersGroups][1][filters][0][field]=action_name.raw&evtcf[filtersGroups][1][filters][0][name]=&evtcf[filtersGroups][1][filters][0][op]=contains&evtcf[filtersGroups][1][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][1][filters][1][id]=cbb3b1c3&evtcf[filtersGroups][1][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][1][filters][1][name]=&evtcf[filtersGroups][1][filters][1][op]=contains&evtcf[filtersGroups][1][filters][1][value][0]=step&evtcf[filtersGroups][1][filters][2][id]=6a52100d&evtcf[filtersGroups][1][filters][2][field]=metadata.authStepSuccess&evtcf[filtersGroups][1][filters][2][name]=&evtcf[filtersGroups][1][filters][2][op]=eq&evtcf[filtersGroups][1][filters][2][value][0]=false&evtcf[filtersGroups][1][filters][3][id]=28fca1e7&evtcf[filtersGroups][1][filters][3][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][1][filters][3][name]=&evtcf[filtersGroups][1][filters][3][op]=not_contain&evtcf[filtersGroups][1][filters][3][value][0]=Console&evt_ts[metrics][0][metricName]=sum%28events%29&evt_ts[interval]=24h&evt_ts[segments][0][name]=Login%20Success&evt_ts[segments][0][filterGroups][0][id]=bf054cca&evt_ts[segments][0][filterGroups][0][filters][0][id]=2e2dc3c1&evt_ts[segments][0][filterGroups][0][filters][0][field]=metadata.eventType.raw&evt_ts[segments][0][filterGroups][0][filters][0][name]=&evt_ts[segments][0][filterGroups][0][filters][0][op]=contains&evt_ts[segments][0][filterGroups][0][filters][0][value][0]=overall&evt_ts[segments][1][name]=Login%20Failure&evt_ts[segments][1][filterGroups][0][id]=bb97e258&evt_ts[segments][1][filterGroups][0][filters][0][id]=52cd10d0&evt_ts[segments][1][filterGroups][0][filters][0][field]=metadata.eventType.raw&evt_ts[segments][1][filterGroups][0][filters][0][name]=&evt_ts[segments][1][filterGroups][0][filters][0][op]=contains&evt_ts[segments][1][filterGroups][0][filters][0][value][0]=step&evt_ts[segments][1][filterGroups][0][filters][1][id]=ab18b766&evt_ts[segments][1][filterGroups][0][filters][1][field]=metadata.authStepSuccess&evt_ts[segments][1][filterGroups][0][filters][1][name]=&evt_ts[segments][1][filterGroups][0][filters][1][op]=eq&evt_ts[segments][1][filterGroups][0][filters][1][value][0]=false",
+            "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=31f53870&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=6af3bb9b&evtcf[filtersGroups][0][filters][2][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=Console&evtcf[filtersGroups][0][filters][3][id]=45b814e1&evtcf[filtersGroups][0][filters][3][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][3][op]=not_contain&evtcf[filtersGroups][0][filters][3][value][0]=AGENT&evtcf[filtersGroups][1][filters][0][id]=aa7f60c8&evtcf[filtersGroups][1][filters][0][field]=action_name.raw&evtcf[filtersGroups][1][filters][0][name]=&evtcf[filtersGroups][1][filters][0][op]=contains&evtcf[filtersGroups][1][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][1][filters][1][id]=cbb3b1c3&evtcf[filtersGroups][1][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][1][filters][1][name]=&evtcf[filtersGroups][1][filters][1][op]=contains&evtcf[filtersGroups][1][filters][1][value][0]=step&evtcf[filtersGroups][1][filters][2][id]=6a52100d&evtcf[filtersGroups][1][filters][2][field]=metadata.authStepSuccess&evtcf[filtersGroups][1][filters][2][name]=&evtcf[filtersGroups][1][filters][2][op]=eq&evtcf[filtersGroups][1][filters][2][value][0]=false&evtcf[filtersGroups][1][filters][3][id]=28fca1e7&evtcf[filtersGroups][1][filters][3][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][1][filters][3][name]=&evtcf[filtersGroups][1][filters][3][op]=not_contain&evtcf[filtersGroups][1][filters][3][value][0]=Console&evtcf[filtersGroups][1][filters][4][id]=a6cbcbe4&evtcf[filtersGroups][1][filters][4][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][1][filters][4][op]=not_contain&evtcf[filtersGroups][1][filters][4][value][0]=AGENT&evt_ts[metrics][0][metricName]=sum%28events%29&evt_ts[interval]=24h&evt_ts[segments][0][name]=Login%20Success&evt_ts[segments][0][filterGroups][0][id]=bf054cca&evt_ts[segments][0][filterGroups][0][filters][0][id]=2e2dc3c1&evt_ts[segments][0][filterGroups][0][filters][0][field]=metadata.eventType.raw&evt_ts[segments][0][filterGroups][0][filters][0][name]=&evt_ts[segments][0][filterGroups][0][filters][0][op]=contains&evt_ts[segments][0][filterGroups][0][filters][0][value][0]=overall&evt_ts[segments][1][name]=Login%20Failure&evt_ts[segments][1][filterGroups][0][id]=bb97e258&evt_ts[segments][1][filterGroups][0][filters][0][id]=52cd10d0&evt_ts[segments][1][filterGroups][0][filters][0][field]=metadata.eventType.raw&evt_ts[segments][1][filterGroups][0][filters][0][name]=&evt_ts[segments][1][filterGroups][0][filters][0][op]=contains&evt_ts[segments][1][filterGroups][0][filters][0][value][0]=step&evt_ts[segments][1][filterGroups][0][filters][1][id]=ab18b766&evt_ts[segments][1][filterGroups][0][filters][1][field]=metadata.authStepSuccess&evt_ts[segments][1][filterGroups][0][filters][1][name]=&evt_ts[segments][1][filterGroups][0][filters][1][op]=eq&evt_ts[segments][1][filterGroups][0][filters][1][value][0]=false",
             "analyticType": "entTmSrs",
             "chartType": "line",
             "settings": {
@@ -526,9 +619,26 @@
             "args": "",
             "es_query": {
                 "post_filter": {
-                    "terms": {
-                        "action_name.raw": [
-                            "User-Registration"
+                    "bool": {
+                        "must": [
+                            {
+                                "terms": {
+                                    "action_name.raw": [
+                                        "User-Registration"
+                                    ]
+                                }
+                            },
+                            {
+                                "bool": {
+                                    "must_not": {
+                                        "terms": {
+                                            "metadata.userstoreDomain.raw": [
+                                                "AGENT"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
                         ]
                     }
                 },
@@ -536,9 +646,26 @@
                 "aggs": {
                     "entTmSrs": {
                         "filter": {
-                            "terms": {
-                                "action_name.raw": [
-                                    "User-Registration"
+                            "bool": {
+                                "must": [
+                                    {
+                                        "terms": {
+                                            "action_name.raw": [
+                                                "User-Registration"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "bool": {
+                                            "must_not": {
+                                                "terms": {
+                                                    "metadata.userstoreDomain.raw": [
+                                                        "AGENT"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    }
                                 ]
                             }
                         },
@@ -587,7 +714,7 @@
             },
             "view": "time",
             "funnel_query": {},
-            "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evt_ts[metrics][0][metricName]=sum%28events%29&evt_ts[interval]=1d&evt_ts[groups][0][field]=metadata.userOnboardedMethod.raw&evt_ts[groups][0][func]=terms&evt_ts[groups][0][by]=metric",
+            "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evtcf[filtersGroups][0][filters][1][id]=3586431c&evtcf[filtersGroups][0][filters][1][field]=metadata.userstoreDomain.raw&evtcf[filtersGroups][0][filters][1][op]=not_contain&evtcf[filtersGroups][0][filters][1][value][0]=AGENT&evt_ts[metrics][0][metricName]=sum%28events%29&evt_ts[interval]=1d&evt_ts[groups][0][field]=metadata.userOnboardedMethod.raw&evt_ts[groups][0][func]=terms&evt_ts[groups][0][by]=metric",
             "analyticType": "entTmSrs",
             "chartType": "line",
             "settings": {
@@ -603,6 +730,610 @@
                         "func": "terms",
                         "by": "metric"
                     }
+                ]
+            }
+        },
+        {
+            "_id": "6a5e2e79e57d307b8ba6d549",
+            "type": "events",
+            "name": "New Agents",
+            "args": "",
+            "es_query": {
+                "post_filter": {
+                    "bool": {
+                        "must": [
+                            {
+                                "terms": {
+                                    "action_name.raw": [
+                                        "User-Registration"
+                                    ]
+                                }
+                            },
+                            {
+                                "terms": {
+                                    "metadata.userstoreDomain.raw": [
+                                        "AGENT"
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                "size": 0,
+                "aggs": {
+                    "seg": {
+                        "filter": {
+                            "bool": {
+                                "must": [
+                                    {
+                                        "terms": {
+                                            "action_name.raw": [
+                                                "User-Registration"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "terms": {
+                                            "metadata.userstoreDomain.raw": [
+                                                "AGENT"
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "aggs": {
+                            "weight|sum": {
+                                "sum": {
+                                    "field": "weight",
+                                    "missing": 1
+                                }
+                            }
+                        }
+                    }
+                },
+                "track_total_hits": false
+            },
+            "dateRange": {
+                "from": "-52w",
+                "to": "now"
+            },
+            "view": "segment",
+            "funnel_query": {},
+            "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evtcf[filtersGroups][0][filters][1][id]=a2892735&evtcf[filtersGroups][0][filters][1][field]=metadata.userstoreDomain.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=AGENT&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=%20",
+            "analyticType": "seg",
+            "chartType": "bar",
+            "settings": {
+                "singleValueSettings": {
+                    "chartHeight": "80",
+                    "hideLabel": "true",
+                    "trendIndicator": {
+                        "isIncreasementGreen": "true"
+                    }
+                },
+                "metrics": [
+                    {
+                        "metricName": "sum(events)"
+                    }
+                ]
+            }
+        },
+        {
+            "_id": "6a5e2d748473bc558cd9b16d",
+            "type": "events",
+            "name": "Agent Tokens",
+            "args": "",
+            "es_query": {
+                "post_filter": {
+                    "bool": {
+                        "should": [
+                            {
+                                "bool": {
+                                    "must": [
+                                        {
+                                            "terms": {
+                                                "action_name.raw": [
+                                                    "OAuth-Token-Issuance"
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "terms": {
+                                                "metadata.existingTokenUsed": [
+                                                    "false"
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "terms": {
+                                                "metadata.userStoreDomain.raw": [
+                                                    "AGENT"
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "bool": {
+                                    "must": [
+                                        {
+                                            "terms": {
+                                                "action_name.raw": [
+                                                    "OAuth-Token-Issuance"
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "terms": {
+                                                "metadata.existingTokenUsed": [
+                                                    "false"
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "bool": {
+                                                "should": [
+                                                    {
+                                                        "exists": {
+                                                            "field": "metadata.actor.raw"
+                                                        }
+                                                    },
+                                                    {
+                                                        "exists": {
+                                                            "field": "metadata.actor"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "bool": {
+                                                "must_not": {
+                                                    "terms": {
+                                                        "metadata.actor.raw": [
+                                                            "NOT_AVAILABLE"
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                "size": 0,
+                "aggs": {
+                    "seg": {
+                        "filter": {
+                            "bool": {
+                                "should": [
+                                    {
+                                        "bool": {
+                                            "must": [
+                                                {
+                                                    "terms": {
+                                                        "action_name.raw": [
+                                                            "OAuth-Token-Issuance"
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "terms": {
+                                                        "metadata.existingTokenUsed": [
+                                                            "false"
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "terms": {
+                                                        "metadata.userStoreDomain.raw": [
+                                                            "AGENT"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "bool": {
+                                            "must": [
+                                                {
+                                                    "terms": {
+                                                        "action_name.raw": [
+                                                            "OAuth-Token-Issuance"
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "terms": {
+                                                        "metadata.existingTokenUsed": [
+                                                            "false"
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "bool": {
+                                                        "should": [
+                                                            {
+                                                                "exists": {
+                                                                    "field": "metadata.actor.raw"
+                                                                }
+                                                            },
+                                                            {
+                                                                "exists": {
+                                                                    "field": "metadata.actor"
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "bool": {
+                                                        "must_not": {
+                                                            "terms": {
+                                                                "metadata.actor.raw": [
+                                                                    "NOT_AVAILABLE"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "aggs": {
+                            "_id|cardinality": {
+                                "cardinality": {
+                                    "field": "_id"
+                                }
+                            }
+                        }
+                    }
+                },
+                "track_total_hits": false
+            },
+            "dateRange": {
+                "from": "-12w",
+                "to": "now"
+            },
+            "view": "segment",
+            "funnel_query": {},
+            "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][0][filters][1][id]=2714f5ec&evtcf[filtersGroups][0][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=eq&evtcf[filtersGroups][0][filters][1][value][0]=false&evtcf[filtersGroups][0][filters][2][id]=b84a7b60&evtcf[filtersGroups][0][filters][2][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=contains&evtcf[filtersGroups][0][filters][2][value][0]=AGENT&evtcf[filtersGroups][1][filters][0][id]=ad5ef950&evtcf[filtersGroups][1][filters][0][field]=action_name.raw&evtcf[filtersGroups][1][filters][0][name]=&evtcf[filtersGroups][1][filters][0][op]=contains&evtcf[filtersGroups][1][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][1][filters][1][id]=0e44fc56&evtcf[filtersGroups][1][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][1][filters][1][name]=&evtcf[filtersGroups][1][filters][1][op]=eq&evtcf[filtersGroups][1][filters][1][value][0]=false&evtcf[filtersGroups][1][filters][2][id]=32fc6113&evtcf[filtersGroups][1][filters][2][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][2][name]=&evtcf[filtersGroups][1][filters][2][op]=exists&evtcf[filtersGroups][1][filters][2][value]=&evtcf[filtersGroups][1][filters][3][id]=83cacaad&evtcf[filtersGroups][1][filters][3][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][3][name]=&evtcf[filtersGroups][1][filters][3][op]=not_contain&evtcf[filtersGroups][1][filters][3][value][0]=NOT_AVAILABLE&seg[metrics][0][metricName]=count%28event_id%29&seg[metrics][0][customName]=%20",
+            "analyticType": "seg",
+            "chartType": "bar",
+            "settings": {
+                "singleValueSettings": {
+                    "chartHeight": "80",
+                    "hideLabel": "true",
+                    "trendIndicator": {
+                        "isIncreasementGreen": "true"
+                    }
+                },
+                "metrics": [
+                    {
+                        "metricName": "count(event_id)"
+                    }
+                ]
+            }
+        },
+        {
+            "_id": "6a5e45698473bc558cd9b202",
+            "type": "events",
+            "name": "Agent Tokens Over Time",
+            "args": "",
+            "es_query": {
+                "post_filter": {
+                "bool": {
+                    "should": [
+                    {
+                        "bool": {
+                        "must": [
+                            {
+                            "terms": {
+                                "action_name.raw": [
+                                "OAuth-Token-Issuance"
+                                ]
+                            }
+                            },
+                            {
+                            "terms": {
+                                "metadata.existingTokenUsed": [
+                                "false"
+                                ]
+                            }
+                            },
+                            {
+                            "terms": {
+                                "metadata.userStoreDomain.raw": [
+                                "AGENT"
+                                ]
+                            }
+                            }
+                        ]
+                        }
+                    },
+                    {
+                        "bool": {
+                        "must": [
+                            {
+                            "terms": {
+                                "action_name.raw": [
+                                "OAuth-Token-Issuance"
+                                ]
+                            }
+                            },
+                            {
+                            "terms": {
+                                "metadata.existingTokenUsed": [
+                                "false"
+                                ]
+                            }
+                            },
+                            {
+                            "bool": {
+                                "should": [
+                                {
+                                    "exists": {
+                                    "field": "metadata.actor.raw"
+                                    }
+                                },
+                                {
+                                    "exists": {
+                                    "field": "metadata.actor"
+                                    }
+                                }
+                                ]
+                            }
+                            },
+                            {
+                            "bool": {
+                                "must_not": {
+                                "terms": {
+                                    "metadata.actor.raw": [
+                                    "NOT_AVAILABLE"
+                                    ]
+                                }
+                                }
+                            }
+                            }
+                        ]
+                        }
+                    }
+                    ]
+                }
+                },
+                "size": 0,
+                "aggs": {
+                "entTmSrs": {
+                    "filter": {
+                    "bool": {
+                        "should": [
+                        {
+                            "bool": {
+                            "must": [
+                                {
+                                "terms": {
+                                    "action_name.raw": [
+                                    "OAuth-Token-Issuance"
+                                    ]
+                                }
+                                },
+                                {
+                                "terms": {
+                                    "metadata.existingTokenUsed": [
+                                    "false"
+                                    ]
+                                }
+                                },
+                                {
+                                "terms": {
+                                    "metadata.userStoreDomain.raw": [
+                                    "AGENT"
+                                    ]
+                                }
+                                }
+                            ]
+                            }
+                        },
+                        {
+                            "bool": {
+                            "must": [
+                                {
+                                "terms": {
+                                    "action_name.raw": [
+                                    "OAuth-Token-Issuance"
+                                    ]
+                                }
+                                },
+                                {
+                                "terms": {
+                                    "metadata.existingTokenUsed": [
+                                    "false"
+                                    ]
+                                }
+                                },
+                                {
+                                "bool": {
+                                    "should": [
+                                    {
+                                        "exists": {
+                                        "field": "metadata.actor.raw"
+                                        }
+                                    },
+                                    {
+                                        "exists": {
+                                        "field": "metadata.actor"
+                                        }
+                                    }
+                                    ]
+                                }
+                                },
+                                {
+                                "bool": {
+                                    "must_not": {
+                                    "terms": {
+                                        "metadata.actor.raw": [
+                                        "NOT_AVAILABLE"
+                                        ]
+                                    }
+                                    }
+                                }
+                                }
+                            ]
+                            }
+                        }
+                        ]
+                    }
+                    },
+                    "aggs": {
+                    "segment__Direct Agent Logins": {
+                        "filter": {
+                        "terms": {
+                            "metadata.userStoreDomain.raw": [
+                            "AGENT"
+                            ]
+                        }
+                        },
+                        "aggs": {
+                        "request.time": {
+                            "date_histogram": {
+                            "field": "request.time",
+                            "interval": "1d",
+                            "time_zone": "Asia/Colombo"
+                            },
+                            "aggs": {
+                            "_id|cardinality": {
+                                "cardinality": {
+                                "field": "_id"
+                                }
+                            }
+                            }
+                        }
+                        }
+                    },
+                    "segment__Agent On Behalf of User": {
+                        "filter": {
+                        "bool": {
+                            "must": [
+                            {
+                                "bool": {
+                                "should": [
+                                    {
+                                    "exists": {
+                                        "field": "metadata.actor.raw"
+                                    }
+                                    },
+                                    {
+                                    "exists": {
+                                        "field": "metadata.actor"
+                                    }
+                                    }
+                                ]
+                                }
+                            },
+                            {
+                                "bool": {
+                                "must_not": {
+                                    "terms": {
+                                    "metadata.actor.raw": [
+                                        "NOT_AVAILABLE"
+                                    ]
+                                    }
+                                }
+                                }
+                            }
+                            ]
+                        }
+                        },
+                        "aggs": {
+                        "request.time": {
+                            "date_histogram": {
+                            "field": "request.time",
+                            "interval": "1d",
+                            "time_zone": "Asia/Colombo"
+                            },
+                            "aggs": {
+                            "_id|cardinality": {
+                                "cardinality": {
+                                "field": "_id"
+                                }
+                            }
+                            }
+                        }
+                        }
+                    }
+                    }
+                }
+                }
+            },
+            "dateRange": {
+                "from": "-12w",
+                "to": "now"
+            },
+            "view": "time",
+            "funnel_query": {},
+            "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][0][filters][1][id]=2714f5ec&evtcf[filtersGroups][0][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=eq&evtcf[filtersGroups][0][filters][1][value][0]=false&evtcf[filtersGroups][0][filters][2][id]=b84a7b60&evtcf[filtersGroups][0][filters][2][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=contains&evtcf[filtersGroups][0][filters][2][value][0]=AGENT&evtcf[filtersGroups][1][filters][0][id]=ad5ef950&evtcf[filtersGroups][1][filters][0][field]=action_name.raw&evtcf[filtersGroups][1][filters][0][name]=&evtcf[filtersGroups][1][filters][0][op]=contains&evtcf[filtersGroups][1][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][1][filters][1][id]=0e44fc56&evtcf[filtersGroups][1][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][1][filters][1][name]=&evtcf[filtersGroups][1][filters][1][op]=eq&evtcf[filtersGroups][1][filters][1][value][0]=false&evtcf[filtersGroups][1][filters][2][id]=83cacaad&evtcf[filtersGroups][1][filters][2][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][2][name]=&evtcf[filtersGroups][1][filters][2][op]=exists&evtcf[filtersGroups][1][filters][2][value]=&evtcf[filtersGroups][1][filters][3][id]=c919c6ab&evtcf[filtersGroups][1][filters][3][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][3][name]=&evtcf[filtersGroups][1][filters][3][op]=not_contain&evtcf[filtersGroups][1][filters][3][value][0]=NOT_AVAILABLE&evt_ts[metrics][0][metricName]=count%28event_id%29&evt_ts[metrics][0][customName]=%20&evt_ts[segments][0][name]=Direct%20Agent%20Logins&evt_ts[segments][0][filterGroups][0][id]=d306199d&evt_ts[segments][0][filterGroups][0][filters][0][id]=12a24629&evt_ts[segments][0][filterGroups][0][filters][0][field]=metadata.userStoreDomain.raw&evt_ts[segments][0][filterGroups][0][filters][0][name]=&evt_ts[segments][0][filterGroups][0][filters][0][op]=contains&evt_ts[segments][0][filterGroups][0][filters][0][value][0]=AGENT&evt_ts[segments][1][name]=Agent%20On%20Behalf%20of%20User&evt_ts[segments][1][filterGroups][0][id]=ec24a1bf&evt_ts[segments][1][filterGroups][0][filters][0][id]=b140ce64&evt_ts[segments][1][filterGroups][0][filters][0][field]=metadata.actor.raw&evt_ts[segments][1][filterGroups][0][filters][0][name]=&evt_ts[segments][1][filterGroups][0][filters][0][op]=exists&evt_ts[segments][1][filterGroups][0][filters][0][value]=&evt_ts[segments][1][filterGroups][0][filters][1][id]=ec5b72df&evt_ts[segments][1][filterGroups][0][filters][1][field]=metadata.actor.raw&evt_ts[segments][1][filterGroups][0][filters][1][name]=&evt_ts[segments][1][filterGroups][0][filters][1][op]=not_contain&evt_ts[segments][1][filterGroups][0][filters][1][value][0]=NOT_AVAILABLE",
+            "analyticType": "entTmSrs",
+            "chartType": "line",
+            "settings": {
+                "metrics": [
+                {
+                    "metricName": "count(event_id)",
+                    "customName": " "
+                }
+                ],
+                "segments": [
+                {
+                    "name": "Direct Agent Logins",
+                    "filterGroups": [
+                    {
+                        "id": "d306199d",
+                        "filters": [
+                        {
+                            "id": "12a24629",
+                            "field": "metadata.userStoreDomain.raw",
+                            "name": "",
+                            "op": "contains",
+                            "value": [
+                            "AGENT"
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                },
+                {
+                    "name": "Agent On Behalf of User",
+                    "filterGroups": [
+                    {
+                        "id": "ec24a1bf",
+                        "filters": [
+                        {
+                            "id": "b140ce64",
+                            "field": "metadata.actor.raw",
+                            "name": "",
+                            "op": "exists",
+                            "value": ""
+                        },
+                        {
+                            "id": "ec5b72df",
+                            "field": "metadata.actor.raw",
+                            "name": "",
+                            "op": "not_contain",
+                            "value": [
+                            "NOT_AVAILABLE"
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }
                 ]
             }
         }

--- a/features/admin.analytics.v1/assets/moesif-dashboard-premium.json
+++ b/features/admin.analytics.v1/assets/moesif-dashboard-premium.json
@@ -67,24 +67,52 @@
       "sort_order": 3
     },
     {
+      "_id": "6a5e2cd7e57d307b8ba6d537",
+      "name": "Agent",
+      "dashboard_ids": [],
+      "workspace_ids": [
+        [
+          "6a5e36ee8473bc558cd9b196",
+          "6a5e2d4ce57d307b8ba6d53e",
+          "6a5e2d30e57d307b8ba6d53a"
+        ],
+        [
+          "6a5e45698473bc558cd9b202"
+        ],
+        [
+          "6a5e435a8473bc558cd9b1de"
+        ]
+      ],
+      "parent": "6a0d5af342390139f7ac4a07",
+      "sort_order": 4
+    },
+    {
       "_id": "6a0d5af342390139f7ac4a07",
       "name": "Overview",
       "dashboard_ids": [
         "6a0d5b2842390139f7ac4a23",
         "6a0d5b3042390139f7ac4a26",
-        "6a1ea1475bc7c56efa5ea476"
+        "6a1ea1475bc7c56efa5ea476",
+        "6a5e2cd7e57d307b8ba6d537"
       ],
       "workspace_ids": [
         [
           "6a0db96342390139f7ac83e7",
+          "6a1e8f049ab5707f95230c0a",
+          "6a1e90c39ab5707f95230d67",
           "6a1ea2257f7e1a2185865daf",
           "6a1ea3e67f7e1a2185865dbb",
-          "6a1e8f049ab5707f95230c0a",
-          "6a1e90c39ab5707f95230d67"
+          "6a5e2e79e57d307b8ba6d549",
+          "6a5e2d748473bc558cd9b16d"
         ],
         [
-          "6a0db9f004a4ee1e28288627",
+          "6a0db9f004a4ee1e28288627"
+        ],
+        [
           "6a1e8fa55bc7c56efa5e9e89"
+        ],
+        [
+          "6a5e45698473bc558cd9b202"
         ]
       ],
       "parent": null,
@@ -125,6 +153,17 @@
                     }
                   }
                 }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.userStoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                }
               }
             ]
           }
@@ -159,6 +198,17 @@
                         }
                       }
                     }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.userStoreDomain.raw": [
+                            "AGENT"
+                          ]
+                        }
+                      }
+                    }
                   }
                 ]
               }
@@ -179,7 +229,7 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=e76aa628&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=698b6316&evtcf[filtersGroups][0][filters][2][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=Console&seg[metrics][0][metricName]=count%28distinct%28user_id%29%29&seg[metrics][0][customName]=%20",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=e76aa628&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=698b6316&evtcf[filtersGroups][0][filters][2][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=Console&evtcf[filtersGroups][0][filters][3][id]=8517df45&evtcf[filtersGroups][0][filters][3][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][3][op]=not_contain&evtcf[filtersGroups][0][filters][3][value][0]=AGENT&seg[metrics][0][metricName]=count%28distinct%28user_id%29%29&seg[metrics][0][customName]=%20",
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
@@ -222,6 +272,17 @@
                           "overall"
                         ]
                       }
+                    },
+                    {
+                      "bool": {
+                        "must_not": {
+                          "terms": {
+                            "metadata.userStoreDomain.raw": [
+                              "AGENT"
+                            ]
+                          }
+                        }
+                      }
                     }
                   ]
                 }
@@ -248,6 +309,17 @@
                         "metadata.authStepSuccess": [
                           "false"
                         ]
+                      }
+                    },
+                    {
+                      "bool": {
+                        "must_not": {
+                          "terms": {
+                            "metadata.userStoreDomain.raw": [
+                              "AGENT"
+                            ]
+                          }
+                        }
                       }
                     }
                   ]
@@ -278,6 +350,17 @@
                               "overall"
                             ]
                           }
+                        },
+                        {
+                          "bool": {
+                            "must_not": {
+                              "terms": {
+                                "metadata.userStoreDomain.raw": [
+                                  "AGENT"
+                                ]
+                              }
+                            }
+                          }
                         }
                       ]
                     }
@@ -304,6 +387,17 @@
                             "metadata.authStepSuccess": [
                               "false"
                             ]
+                          }
+                        },
+                        {
+                          "bool": {
+                            "must_not": {
+                              "terms": {
+                                "metadata.userStoreDomain.raw": [
+                                  "AGENT"
+                                ]
+                              }
+                            }
                           }
                         }
                       ]
@@ -376,7 +470,7 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=e76aa628&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][1][filters][0][id]=f44a8a2b&evtcf[filtersGroups][1][filters][0][field]=action_name.raw&evtcf[filtersGroups][1][filters][0][name]=&evtcf[filtersGroups][1][filters][0][op]=contains&evtcf[filtersGroups][1][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][1][filters][1][id]=a1e663e3&evtcf[filtersGroups][1][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][1][filters][1][name]=&evtcf[filtersGroups][1][filters][1][op]=contains&evtcf[filtersGroups][1][filters][1][value][0]=step&evtcf[filtersGroups][1][filters][2][id]=096cebdf&evtcf[filtersGroups][1][filters][2][field]=metadata.authStepSuccess&evtcf[filtersGroups][1][filters][2][name]=&evtcf[filtersGroups][1][filters][2][op]=eq&evtcf[filtersGroups][1][filters][2][value][0]=false&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=%20&seg[segments][0][name]=Login%20Success&seg[segments][0][filterGroups][0][id]=b73479b1&seg[segments][0][filterGroups][0][filters][0][id]=7939db5c&seg[segments][0][filterGroups][0][filters][0][field]=metadata.eventType.raw&seg[segments][0][filterGroups][0][filters][0][name]=&seg[segments][0][filterGroups][0][filters][0][op]=contains&seg[segments][0][filterGroups][0][filters][0][value][0]=overall&seg[segments][1][name]=Login%20Failure&seg[segments][1][filterGroups][0][id]=f45279f3&seg[segments][1][filterGroups][0][filters][0][id]=377b153b&seg[segments][1][filterGroups][0][filters][0][field]=metadata.eventType.raw&seg[segments][1][filterGroups][0][filters][0][name]=&seg[segments][1][filterGroups][0][filters][0][op]=contains&seg[segments][1][filterGroups][0][filters][0][value][0]=step&seg[segments][1][filterGroups][0][filters][1][id]=13c4b817&seg[segments][1][filterGroups][0][filters][1][field]=metadata.authStepSuccess&seg[segments][1][filterGroups][0][filters][1][name]=&seg[segments][1][filterGroups][0][filters][1][op]=eq&seg[segments][1][filterGroups][0][filters][1][value][0]=false&seg[chartType]=pie",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=e76aa628&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=3e4fa960&evtcf[filtersGroups][0][filters][2][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=AGENT&evtcf[filtersGroups][1][filters][0][id]=f44a8a2b&evtcf[filtersGroups][1][filters][0][field]=action_name.raw&evtcf[filtersGroups][1][filters][0][name]=&evtcf[filtersGroups][1][filters][0][op]=contains&evtcf[filtersGroups][1][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][1][filters][1][id]=a1e663e3&evtcf[filtersGroups][1][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][1][filters][1][name]=&evtcf[filtersGroups][1][filters][1][op]=contains&evtcf[filtersGroups][1][filters][1][value][0]=step&evtcf[filtersGroups][1][filters][2][id]=096cebdf&evtcf[filtersGroups][1][filters][2][field]=metadata.authStepSuccess&evtcf[filtersGroups][1][filters][2][name]=&evtcf[filtersGroups][1][filters][2][op]=eq&evtcf[filtersGroups][1][filters][2][value][0]=false&evtcf[filtersGroups][1][filters][3][id]=ee672ec4&evtcf[filtersGroups][1][filters][3][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][1][filters][3][op]=not_contain&evtcf[filtersGroups][1][filters][3][value][0]=AGENT&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=%20&seg[segments][0][name]=Login%20Success&seg[segments][0][filterGroups][0][id]=b73479b1&seg[segments][0][filterGroups][0][filters][0][id]=7939db5c&seg[segments][0][filterGroups][0][filters][0][field]=metadata.eventType.raw&seg[segments][0][filterGroups][0][filters][0][name]=&seg[segments][0][filterGroups][0][filters][0][op]=contains&seg[segments][0][filterGroups][0][filters][0][value][0]=overall&seg[segments][1][name]=Login%20Failure&seg[segments][1][filterGroups][0][id]=f45279f3&seg[segments][1][filterGroups][0][filters][0][id]=377b153b&seg[segments][1][filterGroups][0][filters][0][field]=metadata.eventType.raw&seg[segments][1][filterGroups][0][filters][0][name]=&seg[segments][1][filterGroups][0][filters][0][op]=contains&seg[segments][1][filterGroups][0][filters][0][value][0]=step&seg[segments][1][filterGroups][0][filters][1][id]=13c4b817&seg[segments][1][filterGroups][0][filters][1][field]=metadata.authStepSuccess&seg[segments][1][filterGroups][0][filters][1][name]=&seg[segments][1][filterGroups][0][filters][1][op]=eq&seg[segments][1][filterGroups][0][filters][1][value][0]=false&seg[chartType]=pie",
       "analyticType": "seg",
       "chartType": "pie",
       "settings": {
@@ -481,6 +575,17 @@
                     }
                   }
                 }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.userStoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                }
               }
             ]
           }
@@ -526,6 +631,17 @@
                         }
                       }
                     }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.userStoreDomain.raw": [
+                            "AGENT"
+                          ]
+                        }
+                      }
+                    }
                   }
                 ]
               }
@@ -566,7 +682,7 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=4b9d6fd9&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=3c6d0e27&evtcf[filtersGroups][0][filters][2][field]=metadata.authenticators.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=NOT_AVAILABLE&evtcf[filtersGroups][0][filters][3][id]=bf4b88a7&evtcf[filtersGroups][0][filters][3][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][0][filters][3][name]=&evtcf[filtersGroups][0][filters][3][op]=not_contain&evtcf[filtersGroups][0][filters][3][value][0]=Console&seg[groups][0][field]=metadata.authenticators.raw&seg[groups][0][func]=terms&seg[groups][0][by]=metric&seg[metrics][0][metricName]=sum%28events%29&seg[chartType]=pie",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=4b9d6fd9&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=3c6d0e27&evtcf[filtersGroups][0][filters][2][field]=metadata.authenticators.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=NOT_AVAILABLE&evtcf[filtersGroups][0][filters][3][id]=bf4b88a7&evtcf[filtersGroups][0][filters][3][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][0][filters][3][name]=&evtcf[filtersGroups][0][filters][3][op]=not_contain&evtcf[filtersGroups][0][filters][3][value][0]=Console&evtcf[filtersGroups][0][filters][4][id]=ee2b5fd5&evtcf[filtersGroups][0][filters][4][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][4][op]=not_contain&evtcf[filtersGroups][0][filters][4][value][0]=AGENT&seg[groups][0][field]=metadata.authenticators.raw&seg[groups][0][func]=terms&seg[groups][0][by]=metric&seg[metrics][0][metricName]=sum%28events%29&seg[chartType]=pie",
       "analyticType": "seg",
       "chartType": "pie",
       "settings": {
@@ -621,6 +737,17 @@
                           }
                         }
                       }
+                    },
+                    {
+                      "bool": {
+                        "must_not": {
+                          "terms": {
+                            "metadata.userStoreDomain.raw": [
+                              "AGENT"
+                            ]
+                          }
+                        }
+                      }
                     }
                   ]
                 }
@@ -655,6 +782,17 @@
                           "terms": {
                             "metadata.serviceProvider.raw": [
                               "Console"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "bool": {
+                        "must_not": {
+                          "terms": {
+                            "metadata.userStoreDomain.raw": [
+                              "AGENT"
                             ]
                           }
                         }
@@ -699,6 +837,17 @@
                               }
                             }
                           }
+                        },
+                        {
+                          "bool": {
+                            "must_not": {
+                              "terms": {
+                                "metadata.userStoreDomain.raw": [
+                                  "AGENT"
+                                ]
+                              }
+                            }
+                          }
                         }
                       ]
                     }
@@ -733,6 +882,17 @@
                               "terms": {
                                 "metadata.serviceProvider.raw": [
                                   "Console"
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "bool": {
+                            "must_not": {
+                              "terms": {
+                                "metadata.userStoreDomain.raw": [
+                                  "AGENT"
                                 ]
                               }
                             }
@@ -820,7 +980,7 @@
       },
       "view": "time",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=31f53870&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=6af3bb9b&evtcf[filtersGroups][0][filters][2][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=Console&evtcf[filtersGroups][1][filters][0][id]=aa7f60c8&evtcf[filtersGroups][1][filters][0][field]=action_name.raw&evtcf[filtersGroups][1][filters][0][name]=&evtcf[filtersGroups][1][filters][0][op]=contains&evtcf[filtersGroups][1][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][1][filters][1][id]=cbb3b1c3&evtcf[filtersGroups][1][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][1][filters][1][name]=&evtcf[filtersGroups][1][filters][1][op]=contains&evtcf[filtersGroups][1][filters][1][value][0]=step&evtcf[filtersGroups][1][filters][2][id]=6a52100d&evtcf[filtersGroups][1][filters][2][field]=metadata.authStepSuccess&evtcf[filtersGroups][1][filters][2][name]=&evtcf[filtersGroups][1][filters][2][op]=eq&evtcf[filtersGroups][1][filters][2][value][0]=false&evtcf[filtersGroups][1][filters][3][id]=28fca1e7&evtcf[filtersGroups][1][filters][3][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][1][filters][3][name]=&evtcf[filtersGroups][1][filters][3][op]=not_contain&evtcf[filtersGroups][1][filters][3][value][0]=Console&evt_ts[metrics][0][metricName]=sum%28events%29&evt_ts[interval]=24h&evt_ts[segments][0][name]=Login%20Success&evt_ts[segments][0][filterGroups][0][id]=bf054cca&evt_ts[segments][0][filterGroups][0][filters][0][id]=2e2dc3c1&evt_ts[segments][0][filterGroups][0][filters][0][field]=metadata.eventType.raw&evt_ts[segments][0][filterGroups][0][filters][0][name]=&evt_ts[segments][0][filterGroups][0][filters][0][op]=contains&evt_ts[segments][0][filterGroups][0][filters][0][value][0]=overall&evt_ts[segments][1][name]=Login%20Failure&evt_ts[segments][1][filterGroups][0][id]=bb97e258&evt_ts[segments][1][filterGroups][0][filters][0][id]=52cd10d0&evt_ts[segments][1][filterGroups][0][filters][0][field]=metadata.eventType.raw&evt_ts[segments][1][filterGroups][0][filters][0][name]=&evt_ts[segments][1][filterGroups][0][filters][0][op]=contains&evt_ts[segments][1][filterGroups][0][filters][0][value][0]=step&evt_ts[segments][1][filterGroups][0][filters][1][id]=ab18b766&evt_ts[segments][1][filterGroups][0][filters][1][field]=metadata.authStepSuccess&evt_ts[segments][1][filterGroups][0][filters][1][name]=&evt_ts[segments][1][filterGroups][0][filters][1][op]=eq&evt_ts[segments][1][filterGroups][0][filters][1][value][0]=false",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=31f53870&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=6af3bb9b&evtcf[filtersGroups][0][filters][2][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=Console&evtcf[filtersGroups][0][filters][3][id]=e4fa5862&evtcf[filtersGroups][0][filters][3][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][3][op]=not_contain&evtcf[filtersGroups][0][filters][3][value][0]=AGENT&evtcf[filtersGroups][1][filters][0][id]=aa7f60c8&evtcf[filtersGroups][1][filters][0][field]=action_name.raw&evtcf[filtersGroups][1][filters][0][name]=&evtcf[filtersGroups][1][filters][0][op]=contains&evtcf[filtersGroups][1][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][1][filters][1][id]=cbb3b1c3&evtcf[filtersGroups][1][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][1][filters][1][name]=&evtcf[filtersGroups][1][filters][1][op]=contains&evtcf[filtersGroups][1][filters][1][value][0]=step&evtcf[filtersGroups][1][filters][2][id]=6a52100d&evtcf[filtersGroups][1][filters][2][field]=metadata.authStepSuccess&evtcf[filtersGroups][1][filters][2][name]=&evtcf[filtersGroups][1][filters][2][op]=eq&evtcf[filtersGroups][1][filters][2][value][0]=false&evtcf[filtersGroups][1][filters][3][id]=28fca1e7&evtcf[filtersGroups][1][filters][3][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][1][filters][3][name]=&evtcf[filtersGroups][1][filters][3][op]=not_contain&evtcf[filtersGroups][1][filters][3][value][0]=Console&evtcf[filtersGroups][1][filters][4][id]=3f074353&evtcf[filtersGroups][1][filters][4][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][1][filters][4][op]=not_contain&evtcf[filtersGroups][1][filters][4][value][0]=AGENT&evt_ts[metrics][0][metricName]=sum%28events%29&evt_ts[interval]=24h&evt_ts[segments][0][name]=Login%20Success&evt_ts[segments][0][filterGroups][0][id]=bf054cca&evt_ts[segments][0][filterGroups][0][filters][0][id]=2e2dc3c1&evt_ts[segments][0][filterGroups][0][filters][0][field]=metadata.eventType.raw&evt_ts[segments][0][filterGroups][0][filters][0][name]=&evt_ts[segments][0][filterGroups][0][filters][0][op]=contains&evt_ts[segments][0][filterGroups][0][filters][0][value][0]=overall&evt_ts[segments][1][name]=Login%20Failure&evt_ts[segments][1][filterGroups][0][id]=bb97e258&evt_ts[segments][1][filterGroups][0][filters][0][id]=52cd10d0&evt_ts[segments][1][filterGroups][0][filters][0][field]=metadata.eventType.raw&evt_ts[segments][1][filterGroups][0][filters][0][name]=&evt_ts[segments][1][filterGroups][0][filters][0][op]=contains&evt_ts[segments][1][filterGroups][0][filters][0][value][0]=step&evt_ts[segments][1][filterGroups][0][filters][1][id]=ab18b766&evt_ts[segments][1][filterGroups][0][filters][1][field]=metadata.authStepSuccess&evt_ts[segments][1][filterGroups][0][filters][1][name]=&evt_ts[segments][1][filterGroups][0][filters][1][op]=eq&evt_ts[segments][1][filterGroups][0][filters][1][value][0]=false",
       "analyticType": "entTmSrs",
       "chartType": "line",
       "settings": {
@@ -903,6 +1063,17 @@
                     "overall"
                   ]
                 }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.userStoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                }
               }
             ]
           }
@@ -925,6 +1096,17 @@
                       "metadata.eventType.raw": [
                         "overall"
                       ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.userStoreDomain.raw": [
+                            "AGENT"
+                          ]
+                        }
+                      }
                     }
                   }
                 ]
@@ -961,7 +1143,7 @@
       },
       "view": "time",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=e76aa628&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evt_ts[metrics][0][metricName]=sum%28events%29&evt_ts[metrics][0][customName]=%20Total%20Succesfull%20Login&evt_ts[metrics][1][i]=641d37f2&evt_ts[metrics][1][metricName]=count%28distinct%28user_id%29%29&evt_ts[metrics][1][customName]=Total%20Unique%20Users&evt_ts[interval]=24h",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=e76aa628&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=269fd28b&evtcf[filtersGroups][0][filters][2][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=AGENT&evt_ts[metrics][0][metricName]=sum%28events%29&evt_ts[metrics][0][customName]=%20Total%20Succesfull%20Login&evt_ts[metrics][1][i]=641d37f2&evt_ts[metrics][1][metricName]=count%28distinct%28user_id%29%29&evt_ts[metrics][1][customName]=Total%20Unique%20Users&evt_ts[interval]=24h",
       "analyticType": "entTmSrs",
       "chartType": "line",
       "settings": {
@@ -1017,6 +1199,17 @@
                     }
                   ]
                 }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.userStoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                }
               }
             ]
           }
@@ -1055,6 +1248,17 @@
                           }
                         }
                       ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.userStoreDomain.raw": [
+                            "AGENT"
+                          ]
+                        }
+                      }
                     }
                   }
                 ]
@@ -1096,7 +1300,7 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=564bd5af&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=106390bd&evtcf[filtersGroups][0][filters][2][field]=request.user_agent.device.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=exists&evtcf[filtersGroups][0][filters][2][value]=&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=Logins%20By%20Device&seg[groups][0][field]=request.user_agent.device.raw&seg[groups][0][func]=terms&seg[groups][0][by]=metric",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=564bd5af&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=106390bd&evtcf[filtersGroups][0][filters][2][field]=request.user_agent.device.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=exists&evtcf[filtersGroups][0][filters][2][value]=&evtcf[filtersGroups][0][filters][3][id]=fd8e816d&evtcf[filtersGroups][0][filters][3][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][3][op]=not_contain&evtcf[filtersGroups][0][filters][3][value][0]=AGENT&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=Logins%20By%20Device&seg[groups][0][field]=request.user_agent.device.raw&seg[groups][0][func]=terms&seg[groups][0][by]=metric",
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
@@ -1148,6 +1352,17 @@
                     }
                   }
                 }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.userStoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                }
               }
             ]
           }
@@ -1178,6 +1393,17 @@
                         "terms": {
                           "metadata.serviceProvider.raw": [
                             "Console"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.userStoreDomain.raw": [
+                            "AGENT"
                           ]
                         }
                       }
@@ -1222,7 +1448,7 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=e76aa628&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=228de34f&evtcf[filtersGroups][0][filters][2][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=Console&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=Login%20By%20Application&seg[groups][0][field]=metadata.serviceProvider.raw&seg[groups][0][func]=terms&seg[groups][0][by]=metric",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=e76aa628&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=228de34f&evtcf[filtersGroups][0][filters][2][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=Console&evtcf[filtersGroups][0][filters][3][id]=1f11a71d&evtcf[filtersGroups][0][filters][3][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][3][op]=not_contain&evtcf[filtersGroups][0][filters][3][value][0]=AGENT&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=Login%20By%20Application&seg[groups][0][field]=metadata.serviceProvider.raw&seg[groups][0][func]=terms&seg[groups][0][by]=metric",
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
@@ -1262,6 +1488,17 @@
                   "metadata.eventType.raw": [
                     "overall"
                   ]
+                }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.userStoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
                 }
               }
             ]
@@ -1304,6 +1541,17 @@
                         "overall"
                       ]
                     }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.userStoreDomain.raw": [
+                            "AGENT"
+                          ]
+                        }
+                      }
+                    }
                   }
                 ]
               }
@@ -1343,7 +1591,7 @@
       },
       "view": "map",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=cc5e6918&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&mp[metrics][0][metricName]=sum%28events%29&mp[area][top_left][lat]=69.54987728327795&mp[area][top_left][lon]=-96.37207031250001&mp[area][bottom_right][lat]=53.14677033085084&mp[area][bottom_right][lon]=-38.49609375000001&mp[viewport][center][0]=62.44834907791381&mp[viewport][center][1]=-67.45056152343751&mp[viewport][zoom]=5"
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=cc5e6918&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=14da6720&evtcf[filtersGroups][0][filters][2][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=AGENT&mp[metrics][0][metricName]=sum%28events%29&mp[area][top_left][lat]=69.54987728327795&mp[area][top_left][lon]=-96.37207031250001&mp[area][bottom_right][lat]=53.14677033085084&mp[area][bottom_right][lon]=-38.49609375000001&mp[viewport][center][0]=62.44834907791381&mp[viewport][center][1]=-67.45056152343751&mp[viewport][zoom]=5"
     },
     {
       "_id": "6a1e90c39ab5707f95230d67",
@@ -1352,9 +1600,26 @@
       "args": "",
       "es_query": {
         "post_filter": {
-          "terms": {
-            "action_name.raw": [
-              "User-Registration"
+          "bool": {
+            "must": [
+              {
+                "terms": {
+                  "action_name.raw": [
+                    "User-Registration"
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.userstoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                }
+              }
             ]
           }
         },
@@ -1362,9 +1627,26 @@
         "aggs": {
           "seg": {
             "filter": {
-              "terms": {
-                "action_name.raw": [
-                  "User-Registration"
+              "bool": {
+                "must": [
+                  {
+                    "terms": {
+                      "action_name.raw": [
+                        "User-Registration"
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.userstoreDomain.raw": [
+                            "AGENT"
+                          ]
+                        }
+                      }
+                    }
+                  }
                 ]
               }
             },
@@ -1385,7 +1667,7 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=%20",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evtcf[filtersGroups][0][filters][1][id]=5d1d436a&evtcf[filtersGroups][0][filters][1][field]=metadata.userstoreDomain.raw&evtcf[filtersGroups][0][filters][1][op]=not_contain&evtcf[filtersGroups][0][filters][1][value][0]=AGENT&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=%20",
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
@@ -1425,6 +1707,17 @@
                     "SELF_SIGNUP"
                   ]
                 }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.userstoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                }
               }
             ]
           }
@@ -1448,6 +1741,17 @@
                         "SELF_SIGNUP"
                       ]
                     }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.userstoreDomain.raw": [
+                            "AGENT"
+                          ]
+                        }
+                      }
+                    }
                   }
                 ]
               }
@@ -1469,7 +1773,7 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evtcf[filtersGroups][0][filters][1][id]=17e73a23&evtcf[filtersGroups][0][filters][1][field]=metadata.userOnboardedMethod.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=SELF_SIGNUP&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=%20",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evtcf[filtersGroups][0][filters][1][id]=17e73a23&evtcf[filtersGroups][0][filters][1][field]=metadata.userOnboardedMethod.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=SELF_SIGNUP&evtcf[filtersGroups][0][filters][2][id]=f706448d&evtcf[filtersGroups][0][filters][2][field]=metadata.userstoreDomain.raw&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=AGENT&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=%20",
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
@@ -1494,9 +1798,26 @@
       "args": "",
       "es_query": {
         "post_filter": {
-          "terms": {
-            "action_name.raw": [
-              "User-Registration"
+          "bool": {
+            "must": [
+              {
+                "terms": {
+                  "action_name.raw": [
+                    "User-Registration"
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.userstoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                }
+              }
             ]
           }
         },
@@ -1504,9 +1825,26 @@
         "aggs": {
           "seg": {
             "filter": {
-              "terms": {
-                "action_name.raw": [
-                  "User-Registration"
+              "bool": {
+                "must": [
+                  {
+                    "terms": {
+                      "action_name.raw": [
+                        "User-Registration"
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.userstoreDomain.raw": [
+                            "AGENT"
+                          ]
+                        }
+                      }
+                    }
+                  }
                 ]
               }
             },
@@ -1546,7 +1884,7 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&seg[groups][0][field]=metadata.userOnboardedMethod.raw&seg[groups][0][func]=terms&seg[groups][0][by]=metric&seg[metrics][0][metricName]=sum%28events%29&seg[chartType]=pie",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evtcf[filtersGroups][0][filters][1][id]=c1838bf7&evtcf[filtersGroups][0][filters][1][field]=metadata.userstoreDomain.raw&evtcf[filtersGroups][0][filters][1][op]=not_contain&evtcf[filtersGroups][0][filters][1][value][0]=AGENT&seg[groups][0][field]=metadata.userOnboardedMethod.raw&seg[groups][0][func]=terms&seg[groups][0][by]=metric&seg[metrics][0][metricName]=sum%28events%29&seg[chartType]=pie",
       "analyticType": "seg",
       "chartType": "pie",
       "settings": {
@@ -1572,9 +1910,26 @@
       "args": "",
       "es_query": {
         "post_filter": {
-          "terms": {
-            "action_name.raw": [
-              "User-Registration"
+          "bool": {
+            "must": [
+              {
+                "terms": {
+                  "action_name.raw": [
+                    "User-Registration"
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.userstoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                }
+              }
             ]
           }
         },
@@ -1582,9 +1937,26 @@
         "aggs": {
           "entTmSrs": {
             "filter": {
-              "terms": {
-                "action_name.raw": [
-                  "User-Registration"
+              "bool": {
+                "must": [
+                  {
+                    "terms": {
+                      "action_name.raw": [
+                        "User-Registration"
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.userstoreDomain.raw": [
+                            "AGENT"
+                          ]
+                        }
+                      }
+                    }
+                  }
                 ]
               }
             },
@@ -1633,7 +2005,7 @@
       },
       "view": "time",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evt_ts[metrics][0][metricName]=sum%28events%29&evt_ts[interval]=1d&evt_ts[groups][0][field]=metadata.userOnboardedMethod.raw&evt_ts[groups][0][func]=terms&evt_ts[groups][0][by]=metric",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evtcf[filtersGroups][0][filters][1][id]=e092b4de&evtcf[filtersGroups][0][filters][1][field]=metadata.userstoreDomain.raw&evtcf[filtersGroups][0][filters][1][op]=not_contain&evtcf[filtersGroups][0][filters][1][value][0]=AGENT&evt_ts[metrics][0][metricName]=sum%28events%29&evt_ts[interval]=1d&evt_ts[groups][0][field]=metadata.userOnboardedMethod.raw&evt_ts[groups][0][func]=terms&evt_ts[groups][0][by]=metric",
       "analyticType": "entTmSrs",
       "chartType": "line",
       "settings": {
@@ -1674,6 +2046,17 @@
                     "END"
                   ]
                 }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.userStoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                }
               }
             ]
           }
@@ -1696,6 +2079,17 @@
                       "metadata.currentNodeId.raw": [
                         "END"
                       ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.userStoreDomain.raw": [
+                            "AGENT"
+                          ]
+                        }
+                      }
                     }
                   }
                 ]
@@ -1737,7 +2131,7 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration-Flow&evtcf[filtersGroups][0][filters][1][id]=0480937e&evtcf[filtersGroups][0][filters][1][field]=metadata.currentNodeId.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=END&seg[groups][0][field]=metadata.applicationId.raw&seg[groups][0][func]=terms&seg[groups][0][by]=metric&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=Registrations%20By%20Application&seg[chartType]=bar",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration-Flow&evtcf[filtersGroups][0][filters][1][id]=0480937e&evtcf[filtersGroups][0][filters][1][field]=metadata.currentNodeId.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=END&evtcf[filtersGroups][0][filters][2][id]=192589e3&evtcf[filtersGroups][0][filters][2][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=AGENT&seg[groups][0][field]=metadata.applicationId.raw&seg[groups][0][func]=terms&seg[groups][0][by]=metric&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=Registrations%20By%20Application&seg[chartType]=bar",
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
@@ -1786,6 +2180,17 @@
                     "false"
                   ]
                 }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.userStoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                }
               }
             ]
           }
@@ -1816,6 +2221,17 @@
                         "false"
                       ]
                     }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.userStoreDomain.raw": [
+                            "AGENT"
+                          ]
+                        }
+                      }
+                    }
                   }
                 ]
               }
@@ -1836,7 +2252,7 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][0][filters][1][id]=938597af&evtcf[filtersGroups][0][filters][1][field]=metadata.userType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=APPLICATION&evtcf[filtersGroups][0][filters][2][id]=2714f5ec&evtcf[filtersGroups][0][filters][2][field]=metadata.existingTokenUsed&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=eq&evtcf[filtersGroups][0][filters][2][value][0]=false&seg[metrics][0][metricName]=count%28event_id%29&seg[metrics][0][customName]=%20",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][0][filters][1][id]=938597af&evtcf[filtersGroups][0][filters][1][field]=metadata.userType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=APPLICATION&evtcf[filtersGroups][0][filters][2][id]=2714f5ec&evtcf[filtersGroups][0][filters][2][field]=metadata.existingTokenUsed&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=eq&evtcf[filtersGroups][0][filters][2][value][0]=false&evtcf[filtersGroups][0][filters][3][id]=9adf4672&evtcf[filtersGroups][0][filters][3][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][3][op]=not_contain&evtcf[filtersGroups][0][filters][3][value][0]=AGENT&seg[metrics][0][metricName]=count%28event_id%29&seg[metrics][0][customName]=%20",
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
@@ -2440,6 +2856,1295 @@
                 ]
               }
             ]
+          }
+        ]
+      }
+    },
+    {
+      "_id": "6a5e2e79e57d307b8ba6d549",
+      "type": "events",
+      "name": "New Agents",
+      "args": "",
+      "es_query": {
+        "post_filter": {
+          "bool": {
+            "must": [
+              {
+                "terms": {
+                  "action_name.raw": [
+                    "User-Registration"
+                  ]
+                }
+              },
+              {
+                "terms": {
+                  "metadata.userstoreDomain.raw": [
+                    "AGENT"
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "size": 0,
+        "aggs": {
+          "seg": {
+            "filter": {
+              "bool": {
+                "must": [
+                  {
+                    "terms": {
+                      "action_name.raw": [
+                        "User-Registration"
+                      ]
+                    }
+                  },
+                  {
+                    "terms": {
+                      "metadata.userstoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            "aggs": {
+              "weight|sum": {
+                "sum": {
+                  "field": "weight",
+                  "missing": 1
+                }
+              }
+            }
+          }
+        },
+        "track_total_hits": false
+      },
+      "dateRange": {
+        "from": "-52w",
+        "to": "now"
+      },
+      "view": "segment",
+      "funnel_query": {},
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evtcf[filtersGroups][0][filters][1][id]=a2892735&evtcf[filtersGroups][0][filters][1][field]=metadata.userstoreDomain.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=AGENT&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=%20",
+      "analyticType": "seg",
+      "chartType": "bar",
+      "settings": {
+        "singleValueSettings": {
+          "chartHeight": "80",
+          "hideLabel": "true",
+          "trendIndicator": {
+            "isIncreasementGreen": "true"
+          }
+        },
+        "metrics": [
+          {
+            "metricName": "sum(events)"
+          }
+        ]
+      }
+    },
+    {
+      "_id": "6a5e2d748473bc558cd9b16d",
+      "type": "events",
+      "name": "Agent Tokens",
+      "args": "",
+      "es_query": {
+        "post_filter": {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "terms": {
+                        "action_name.raw": [
+                          "OAuth-Token-Issuance"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.existingTokenUsed": [
+                          "false"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.userStoreDomain.raw": [
+                          "AGENT"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "terms": {
+                        "action_name.raw": [
+                          "OAuth-Token-Issuance"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.existingTokenUsed": [
+                          "false"
+                        ]
+                      }
+                    },
+                    {
+                      "bool": {
+                        "should": [
+                          {
+                            "exists": {
+                              "field": "metadata.actor.raw"
+                            }
+                          },
+                          {
+                            "exists": {
+                              "field": "metadata.actor"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "bool": {
+                        "must_not": {
+                          "terms": {
+                            "metadata.actor.raw": [
+                              "NOT_AVAILABLE"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "size": 0,
+        "aggs": {
+          "seg": {
+            "filter": {
+              "bool": {
+                "should": [
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "terms": {
+                            "action_name.raw": [
+                              "OAuth-Token-Issuance"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.existingTokenUsed": [
+                              "false"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.userStoreDomain.raw": [
+                              "AGENT"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "terms": {
+                            "action_name.raw": [
+                              "OAuth-Token-Issuance"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.existingTokenUsed": [
+                              "false"
+                            ]
+                          }
+                        },
+                        {
+                          "bool": {
+                            "should": [
+                              {
+                                "exists": {
+                                  "field": "metadata.actor.raw"
+                                }
+                              },
+                              {
+                                "exists": {
+                                  "field": "metadata.actor"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "bool": {
+                            "must_not": {
+                              "terms": {
+                                "metadata.actor.raw": [
+                                  "NOT_AVAILABLE"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            "aggs": {
+              "_id|cardinality": {
+                "cardinality": {
+                  "field": "_id"
+                }
+              }
+            }
+          }
+        },
+        "track_total_hits": false
+      },
+      "dateRange": {
+        "from": "-12w",
+        "to": "now"
+      },
+      "view": "segment",
+      "funnel_query": {},
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][0][filters][1][id]=2714f5ec&evtcf[filtersGroups][0][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=eq&evtcf[filtersGroups][0][filters][1][value][0]=false&evtcf[filtersGroups][0][filters][2][id]=b84a7b60&evtcf[filtersGroups][0][filters][2][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=contains&evtcf[filtersGroups][0][filters][2][value][0]=AGENT&evtcf[filtersGroups][1][filters][0][id]=ad5ef950&evtcf[filtersGroups][1][filters][0][field]=action_name.raw&evtcf[filtersGroups][1][filters][0][name]=&evtcf[filtersGroups][1][filters][0][op]=contains&evtcf[filtersGroups][1][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][1][filters][1][id]=0e44fc56&evtcf[filtersGroups][1][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][1][filters][1][name]=&evtcf[filtersGroups][1][filters][1][op]=eq&evtcf[filtersGroups][1][filters][1][value][0]=false&evtcf[filtersGroups][1][filters][2][id]=32fc6113&evtcf[filtersGroups][1][filters][2][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][2][name]=&evtcf[filtersGroups][1][filters][2][op]=exists&evtcf[filtersGroups][1][filters][2][value]=&evtcf[filtersGroups][1][filters][3][id]=83cacaad&evtcf[filtersGroups][1][filters][3][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][3][name]=&evtcf[filtersGroups][1][filters][3][op]=not_contain&evtcf[filtersGroups][1][filters][3][value][0]=NOT_AVAILABLE&seg[metrics][0][metricName]=count%28event_id%29&seg[metrics][0][customName]=%20",
+      "analyticType": "seg",
+      "chartType": "bar",
+      "settings": {
+        "singleValueSettings": {
+          "chartHeight": "80",
+          "hideLabel": "true",
+          "trendIndicator": {
+            "isIncreasementGreen": "true"
+          }
+        },
+        "metrics": [
+          {
+            "metricName": "count(event_id)"
+          }
+        ]
+      }
+    },
+    {
+      "_id": "6a5e45698473bc558cd9b202",
+      "type": "events",
+      "name": "Agent Tokens Over Time",
+      "args": "",
+      "es_query": {
+        "post_filter": {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "terms": {
+                        "action_name.raw": [
+                          "OAuth-Token-Issuance"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.existingTokenUsed": [
+                          "false"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.userStoreDomain.raw": [
+                          "AGENT"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "terms": {
+                        "action_name.raw": [
+                          "OAuth-Token-Issuance"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.existingTokenUsed": [
+                          "false"
+                        ]
+                      }
+                    },
+                    {
+                      "bool": {
+                        "should": [
+                          {
+                            "exists": {
+                              "field": "metadata.actor.raw"
+                            }
+                          },
+                          {
+                            "exists": {
+                              "field": "metadata.actor"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "bool": {
+                        "must_not": {
+                          "terms": {
+                            "metadata.actor.raw": [
+                              "NOT_AVAILABLE"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "size": 0,
+        "aggs": {
+          "entTmSrs": {
+            "filter": {
+              "bool": {
+                "should": [
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "terms": {
+                            "action_name.raw": [
+                              "OAuth-Token-Issuance"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.existingTokenUsed": [
+                              "false"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.userStoreDomain.raw": [
+                              "AGENT"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "terms": {
+                            "action_name.raw": [
+                              "OAuth-Token-Issuance"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.existingTokenUsed": [
+                              "false"
+                            ]
+                          }
+                        },
+                        {
+                          "bool": {
+                            "should": [
+                              {
+                                "exists": {
+                                  "field": "metadata.actor.raw"
+                                }
+                              },
+                              {
+                                "exists": {
+                                  "field": "metadata.actor"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "bool": {
+                            "must_not": {
+                              "terms": {
+                                "metadata.actor.raw": [
+                                  "NOT_AVAILABLE"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            "aggs": {
+              "segment__Direct Agent Logins": {
+                "filter": {
+                  "terms": {
+                    "metadata.userStoreDomain.raw": [
+                      "AGENT"
+                    ]
+                  }
+                },
+                "aggs": {
+                  "request.time": {
+                    "date_histogram": {
+                      "field": "request.time",
+                      "interval": "1d",
+                      "time_zone": "Asia/Colombo"
+                    },
+                    "aggs": {
+                      "_id|cardinality": {
+                        "cardinality": {
+                          "field": "_id"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "segment__Agent On Behalf of User": {
+                "filter": {
+                  "bool": {
+                    "must": [
+                      {
+                        "bool": {
+                          "should": [
+                            {
+                              "exists": {
+                                "field": "metadata.actor.raw"
+                              }
+                            },
+                            {
+                              "exists": {
+                                "field": "metadata.actor"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "bool": {
+                          "must_not": {
+                            "terms": {
+                              "metadata.actor.raw": [
+                                "NOT_AVAILABLE"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "aggs": {
+                  "request.time": {
+                    "date_histogram": {
+                      "field": "request.time",
+                      "interval": "1d",
+                      "time_zone": "Asia/Colombo"
+                    },
+                    "aggs": {
+                      "_id|cardinality": {
+                        "cardinality": {
+                          "field": "_id"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "dateRange": {
+        "from": "-12w",
+        "to": "now"
+      },
+      "view": "time",
+      "funnel_query": {},
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][0][filters][1][id]=2714f5ec&evtcf[filtersGroups][0][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=eq&evtcf[filtersGroups][0][filters][1][value][0]=false&evtcf[filtersGroups][0][filters][2][id]=b84a7b60&evtcf[filtersGroups][0][filters][2][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=contains&evtcf[filtersGroups][0][filters][2][value][0]=AGENT&evtcf[filtersGroups][1][filters][0][id]=ad5ef950&evtcf[filtersGroups][1][filters][0][field]=action_name.raw&evtcf[filtersGroups][1][filters][0][name]=&evtcf[filtersGroups][1][filters][0][op]=contains&evtcf[filtersGroups][1][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][1][filters][1][id]=0e44fc56&evtcf[filtersGroups][1][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][1][filters][1][name]=&evtcf[filtersGroups][1][filters][1][op]=eq&evtcf[filtersGroups][1][filters][1][value][0]=false&evtcf[filtersGroups][1][filters][2][id]=83cacaad&evtcf[filtersGroups][1][filters][2][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][2][name]=&evtcf[filtersGroups][1][filters][2][op]=exists&evtcf[filtersGroups][1][filters][2][value]=&evtcf[filtersGroups][1][filters][3][id]=c919c6ab&evtcf[filtersGroups][1][filters][3][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][3][name]=&evtcf[filtersGroups][1][filters][3][op]=not_contain&evtcf[filtersGroups][1][filters][3][value][0]=NOT_AVAILABLE&evt_ts[metrics][0][metricName]=count%28event_id%29&evt_ts[metrics][0][customName]=%20&evt_ts[segments][0][name]=Direct%20Agent%20Logins&evt_ts[segments][0][filterGroups][0][id]=d306199d&evt_ts[segments][0][filterGroups][0][filters][0][id]=12a24629&evt_ts[segments][0][filterGroups][0][filters][0][field]=metadata.userStoreDomain.raw&evt_ts[segments][0][filterGroups][0][filters][0][name]=&evt_ts[segments][0][filterGroups][0][filters][0][op]=contains&evt_ts[segments][0][filterGroups][0][filters][0][value][0]=AGENT&evt_ts[segments][1][name]=Agent%20On%20Behalf%20of%20User&evt_ts[segments][1][filterGroups][0][id]=ec24a1bf&evt_ts[segments][1][filterGroups][0][filters][0][id]=b140ce64&evt_ts[segments][1][filterGroups][0][filters][0][field]=metadata.actor.raw&evt_ts[segments][1][filterGroups][0][filters][0][name]=&evt_ts[segments][1][filterGroups][0][filters][0][op]=exists&evt_ts[segments][1][filterGroups][0][filters][0][value]=&evt_ts[segments][1][filterGroups][0][filters][1][id]=ec5b72df&evt_ts[segments][1][filterGroups][0][filters][1][field]=metadata.actor.raw&evt_ts[segments][1][filterGroups][0][filters][1][name]=&evt_ts[segments][1][filterGroups][0][filters][1][op]=not_contain&evt_ts[segments][1][filterGroups][0][filters][1][value][0]=NOT_AVAILABLE",
+      "analyticType": "entTmSrs",
+      "chartType": "line",
+      "settings": {
+        "metrics": [
+          {
+            "metricName": "count(event_id)",
+            "customName": " "
+          }
+        ],
+        "segments": [
+          {
+            "name": "Direct Agent Logins",
+            "filterGroups": [
+              {
+                "id": "d306199d",
+                "filters": [
+                  {
+                    "id": "12a24629",
+                    "field": "metadata.userStoreDomain.raw",
+                    "name": "",
+                    "op": "contains",
+                    "value": [
+                      "AGENT"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Agent On Behalf of User",
+            "filterGroups": [
+              {
+                "id": "ec24a1bf",
+                "filters": [
+                  {
+                    "id": "b140ce64",
+                    "field": "metadata.actor.raw",
+                    "name": "",
+                    "op": "exists",
+                    "value": ""
+                  },
+                  {
+                    "id": "ec5b72df",
+                    "field": "metadata.actor.raw",
+                    "name": "",
+                    "op": "not_contain",
+                    "value": [
+                      "NOT_AVAILABLE"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "_id": "6a5e435a8473bc558cd9b1de",
+      "type": "events",
+      "name": "Agent Logins Over Time",
+      "args": "",
+      "es_query": {
+        "post_filter": {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "terms": {
+                        "action_name.raw": [
+                          "User-Authentication"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.eventType.raw": [
+                          "overall"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.userStoreDomain.raw": [
+                          "AGENT"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "terms": {
+                        "action_name.raw": [
+                          "User-Authentication"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.eventType.raw": [
+                          "step"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.authStepSuccess": [
+                          "false"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.userStoreDomain.raw": [
+                          "AGENT"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "size": 0,
+        "aggs": {
+          "entTmSrs": {
+            "filter": {
+              "bool": {
+                "should": [
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "terms": {
+                            "action_name.raw": [
+                              "User-Authentication"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.eventType.raw": [
+                              "overall"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.userStoreDomain.raw": [
+                              "AGENT"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "terms": {
+                            "action_name.raw": [
+                              "User-Authentication"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.eventType.raw": [
+                              "step"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.authStepSuccess": [
+                              "false"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.userStoreDomain.raw": [
+                              "AGENT"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            "aggs": {
+              "segment__Login Success": {
+                "filter": {
+                  "terms": {
+                    "metadata.eventType.raw": [
+                      "overall"
+                    ]
+                  }
+                },
+                "aggs": {
+                  "request.time": {
+                    "date_histogram": {
+                      "field": "request.time",
+                      "interval": "1d",
+                      "time_zone": "Asia/Colombo"
+                    },
+                    "aggs": {
+                      "weight|sum": {
+                        "sum": {
+                          "field": "weight",
+                          "missing": 1
+                        }
+                      },
+                      "user_id|cardinality": {
+                        "cardinality": {
+                          "field": "user_id.raw"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "segment__Login Fail": {
+                "filter": {
+                  "bool": {
+                    "must": [
+                      {
+                        "terms": {
+                          "metadata.eventType.raw": [
+                            "step"
+                          ]
+                        }
+                      },
+                      {
+                        "terms": {
+                          "metadata.authStepSuccess": [
+                            "false"
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                },
+                "aggs": {
+                  "request.time": {
+                    "date_histogram": {
+                      "field": "request.time",
+                      "interval": "1d",
+                      "time_zone": "Asia/Colombo"
+                    },
+                    "aggs": {
+                      "weight|sum": {
+                        "sum": {
+                          "field": "weight",
+                          "missing": 1
+                        }
+                      },
+                      "user_id|cardinality": {
+                        "cardinality": {
+                          "field": "user_id.raw"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "dateRange": {
+        "from": "-7d",
+        "to": "now"
+      },
+      "view": "time",
+      "funnel_query": {},
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=e76aa628&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=59753cd6&evtcf[filtersGroups][0][filters][2][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=contains&evtcf[filtersGroups][0][filters][2][value][0]=AGENT&evtcf[filtersGroups][1][filters][0][id]=f44a8a2b&evtcf[filtersGroups][1][filters][0][field]=action_name.raw&evtcf[filtersGroups][1][filters][0][name]=&evtcf[filtersGroups][1][filters][0][op]=contains&evtcf[filtersGroups][1][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][1][filters][1][id]=a1e663e3&evtcf[filtersGroups][1][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][1][filters][1][name]=&evtcf[filtersGroups][1][filters][1][op]=contains&evtcf[filtersGroups][1][filters][1][value][0]=step&evtcf[filtersGroups][1][filters][2][id]=096cebdf&evtcf[filtersGroups][1][filters][2][field]=metadata.authStepSuccess&evtcf[filtersGroups][1][filters][2][name]=&evtcf[filtersGroups][1][filters][2][op]=eq&evtcf[filtersGroups][1][filters][2][value][0]=false&evtcf[filtersGroups][1][filters][3][id]=02faa08b&evtcf[filtersGroups][1][filters][3][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][1][filters][3][name]=&evtcf[filtersGroups][1][filters][3][op]=contains&evtcf[filtersGroups][1][filters][3][value][0]=AGENT&evt_ts[metrics][0][metricName]=sum%28events%29&evt_ts[metrics][0][customName]=Total%20Agents&evt_ts[metrics][1][i]=d12efaf0&evt_ts[metrics][1][metricName]=count%28distinct%28user_id%29%29&evt_ts[metrics][1][customName]=Unique%20Agents&evt_ts[interval]=1d&evt_ts[segments][0][name]=Login%20Success&evt_ts[segments][0][filterGroups][0][id]=70dbdc13&evt_ts[segments][0][filterGroups][0][filters][0][id]=1d0d6468&evt_ts[segments][0][filterGroups][0][filters][0][field]=metadata.eventType.raw&evt_ts[segments][0][filterGroups][0][filters][0][name]=&evt_ts[segments][0][filterGroups][0][filters][0][op]=contains&evt_ts[segments][0][filterGroups][0][filters][0][value][0]=overall&evt_ts[segments][1][name]=Login%20Fail&evt_ts[segments][1][filterGroups][0][id]=b0bf4013&evt_ts[segments][1][filterGroups][0][filters][0][id]=52a2bfd5&evt_ts[segments][1][filterGroups][0][filters][0][field]=metadata.eventType.raw&evt_ts[segments][1][filterGroups][0][filters][0][name]=&evt_ts[segments][1][filterGroups][0][filters][0][op]=contains&evt_ts[segments][1][filterGroups][0][filters][0][value][0]=step&evt_ts[segments][1][filterGroups][0][filters][1][id]=190d2f42&evt_ts[segments][1][filterGroups][0][filters][1][field]=metadata.authStepSuccess&evt_ts[segments][1][filterGroups][0][filters][1][name]=&evt_ts[segments][1][filterGroups][0][filters][1][op]=eq&evt_ts[segments][1][filterGroups][0][filters][1][value][0]=false",
+      "analyticType": "entTmSrs",
+      "chartType": "line",
+      "settings": {
+        "metrics": [
+          {
+            "metricName": "sum(events)",
+            "customName": "Total Agents"
+          },
+          {
+            "i": "d12efaf0",
+            "metricName": "count(distinct(user_id))",
+            "customName": "Unique Agents"
+          }
+        ],
+        "interval": "1d",
+        "segments": [
+          {
+            "name": "Login Success",
+            "filterGroups": [
+              {
+                "id": "70dbdc13",
+                "filters": [
+                  {
+                    "id": "1d0d6468",
+                    "field": "metadata.eventType.raw",
+                    "name": "",
+                    "op": "contains",
+                    "value": [
+                      "overall"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Login Fail",
+            "filterGroups": [
+              {
+                "id": "b0bf4013",
+                "filters": [
+                  {
+                    "id": "52a2bfd5",
+                    "field": "metadata.eventType.raw",
+                    "name": "",
+                    "op": "contains",
+                    "value": [
+                      "step"
+                    ]
+                  },
+                  {
+                    "id": "190d2f42",
+                    "field": "metadata.authStepSuccess",
+                    "name": "",
+                    "op": "eq",
+                    "value": [
+                      "false"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "_id": "6a5e36ee8473bc558cd9b196",
+      "type": "events",
+      "name": "Agent Tokens",
+      "args": "",
+      "es_query": {
+        "post_filter": {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "terms": {
+                        "action_name.raw": [
+                          "OAuth-Token-Issuance"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.existingTokenUsed": [
+                          "false"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.userStoreDomain.raw": [
+                          "AGENT"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "terms": {
+                        "action_name.raw": [
+                          "OAuth-Token-Issuance"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.existingTokenUsed": [
+                          "false"
+                        ]
+                      }
+                    },
+                    {
+                      "bool": {
+                        "should": [
+                          {
+                            "exists": {
+                              "field": "metadata.actor.raw"
+                            }
+                          },
+                          {
+                            "exists": {
+                              "field": "metadata.actor"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "bool": {
+                        "must_not": {
+                          "terms": {
+                            "metadata.actor.raw": [
+                              "NOT_AVAILABLE"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "size": 0,
+        "aggs": {
+          "seg": {
+            "filter": {
+              "bool": {
+                "should": [
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "terms": {
+                            "action_name.raw": [
+                              "OAuth-Token-Issuance"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.existingTokenUsed": [
+                              "false"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.userStoreDomain.raw": [
+                              "AGENT"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "terms": {
+                            "action_name.raw": [
+                              "OAuth-Token-Issuance"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.existingTokenUsed": [
+                              "false"
+                            ]
+                          }
+                        },
+                        {
+                          "bool": {
+                            "should": [
+                              {
+                                "exists": {
+                                  "field": "metadata.actor.raw"
+                                }
+                              },
+                              {
+                                "exists": {
+                                  "field": "metadata.actor"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "bool": {
+                            "must_not": {
+                              "terms": {
+                                "metadata.actor.raw": [
+                                  "NOT_AVAILABLE"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            "aggs": {
+              "_id|cardinality": {
+                "cardinality": {
+                  "field": "_id"
+                }
+              }
+            }
+          }
+        }
+      },
+      "dateRange": {
+        "from": "-12w",
+        "to": "now"
+      },
+      "view": "segment",
+      "funnel_query": {},
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][0][filters][1][id]=2714f5ec&evtcf[filtersGroups][0][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=eq&evtcf[filtersGroups][0][filters][1][value][0]=false&evtcf[filtersGroups][0][filters][2][id]=b84a7b60&evtcf[filtersGroups][0][filters][2][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=contains&evtcf[filtersGroups][0][filters][2][value][0]=AGENT&evtcf[filtersGroups][1][filters][0][id]=ad5ef950&evtcf[filtersGroups][1][filters][0][field]=action_name.raw&evtcf[filtersGroups][1][filters][0][name]=&evtcf[filtersGroups][1][filters][0][op]=contains&evtcf[filtersGroups][1][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][1][filters][1][id]=0e44fc56&evtcf[filtersGroups][1][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][1][filters][1][name]=&evtcf[filtersGroups][1][filters][1][op]=eq&evtcf[filtersGroups][1][filters][1][value][0]=false&evtcf[filtersGroups][1][filters][2][id]=83cacaad&evtcf[filtersGroups][1][filters][2][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][2][name]=&evtcf[filtersGroups][1][filters][2][op]=exists&evtcf[filtersGroups][1][filters][2][value]=&evtcf[filtersGroups][1][filters][3][id]=c919c6ab&evtcf[filtersGroups][1][filters][3][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][3][name]=&evtcf[filtersGroups][1][filters][3][op]=not_contain&evtcf[filtersGroups][1][filters][3][value][0]=NOT_AVAILABLE&seg[metrics][0][metricName]=count%28event_id%29&seg[metrics][0][customName]=%20",
+      "analyticType": "seg",
+      "chartType": "bar",
+      "settings": {
+        "metrics": [
+          {
+            "metricName": "count(event_id)",
+            "customName": " "
+          }
+        ]
+      }
+    },
+    {
+      "_id": "6a5e2d4ce57d307b8ba6d53e",
+      "type": "events",
+      "name": "Active Agents",
+      "args": "",
+      "es_query": {
+        "post_filter": {
+          "bool": {
+            "must": [
+              {
+                "terms": {
+                  "action_name.raw": [
+                    "User-Authentication"
+                  ]
+                }
+              },
+              {
+                "terms": {
+                  "metadata.eventType.raw": [
+                    "overall"
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.serviceProvider.raw": [
+                        "Console"
+                      ]
+                    }
+                  }
+                }
+              },
+              {
+                "terms": {
+                  "metadata.userStoreDomain.raw": [
+                    "AGENT"
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "size": 0,
+        "aggs": {
+          "seg": {
+            "filter": {
+              "bool": {
+                "must": [
+                  {
+                    "terms": {
+                      "action_name.raw": [
+                        "User-Authentication"
+                      ]
+                    }
+                  },
+                  {
+                    "terms": {
+                      "metadata.eventType.raw": [
+                        "overall"
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.serviceProvider.raw": [
+                            "Console"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "terms": {
+                      "metadata.userStoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            "aggs": {
+              "user_id|cardinality": {
+                "cardinality": {
+                  "field": "user_id.raw"
+                }
+              }
+            }
+          }
+        }
+      },
+      "dateRange": {
+        "from": "-12w",
+        "to": "now"
+      },
+      "view": "segment",
+      "funnel_query": {},
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Authentication&evtcf[filtersGroups][0][filters][1][id]=e76aa628&evtcf[filtersGroups][0][filters][1][field]=metadata.eventType.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=overall&evtcf[filtersGroups][0][filters][2][id]=698b6316&evtcf[filtersGroups][0][filters][2][field]=metadata.serviceProvider.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=not_contain&evtcf[filtersGroups][0][filters][2][value][0]=Console&evtcf[filtersGroups][0][filters][3][id]=7a68f6a5&evtcf[filtersGroups][0][filters][3][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][3][name]=&evtcf[filtersGroups][0][filters][3][op]=contains&evtcf[filtersGroups][0][filters][3][value][0]=AGENT&seg[metrics][0][metricName]=count%28distinct%28user_id%29%29&seg[metrics][0][customName]=%20&seg[segments]=",
+      "analyticType": "seg",
+      "chartType": "bar",
+      "settings": {
+        "metrics": [
+          {
+            "metricName": "count(distinct(user_id))",
+            "customName": " "
+          }
+        ],
+        "segments": ""
+      }
+    },
+    {
+      "_id": "6a5e2d30e57d307b8ba6d53a",
+      "type": "events",
+      "name": "New Agents",
+      "args": "",
+      "es_query": {
+        "post_filter": {
+          "bool": {
+            "must": [
+              {
+                "terms": {
+                  "action_name.raw": [
+                    "User-Registration"
+                  ]
+                }
+              },
+              {
+                "terms": {
+                  "metadata.userstoreDomain.raw": [
+                    "AGENT"
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "size": 0,
+        "aggs": {
+          "seg": {
+            "filter": {
+              "bool": {
+                "must": [
+                  {
+                    "terms": {
+                      "action_name.raw": [
+                        "User-Registration"
+                      ]
+                    }
+                  },
+                  {
+                    "terms": {
+                      "metadata.userstoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            "aggs": {
+              "weight|sum": {
+                "sum": {
+                  "field": "weight",
+                  "missing": 1
+                }
+              }
+            }
+          }
+        }
+      },
+      "dateRange": {
+        "from": "-52w",
+        "to": "now"
+      },
+      "view": "segment",
+      "funnel_query": {},
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evtcf[filtersGroups][0][filters][1][id]=a2892735&evtcf[filtersGroups][0][filters][1][field]=metadata.userstoreDomain.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=AGENT&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=%20",
+      "analyticType": "seg",
+      "chartType": "bar",
+      "settings": {
+        "metrics": [
+          {
+            "metricName": "sum(events)",
+            "customName": " "
           }
         ]
       }

--- a/features/admin.org-insights.v1/components/advanced-analytics-upgrade-card.tsx
+++ b/features/admin.org-insights.v1/components/advanced-analytics-upgrade-card.tsx
@@ -108,6 +108,9 @@ const AdvancedAnalyticsUpgradeCard: FunctionComponent<AdvancedAnalyticsUpgradeCa
                     <Typography variant="body1" color="text.secondary">
                         { t("insights:advancedAnalytics.card.description") }
                     </Typography>
+                    <Typography variant="body2" color="text.secondary" sx={ { mt: 0.5 } }>
+                        { t("insights:advancedAnalytics.card.dataRetentionHint") }
+                    </Typography>
                 </Box>
                 <Button
                     data-componentid={ `${ componentId }-open-dialog-btn` }

--- a/modules/i18n/src/models/namespaces/insights-ns.ts
+++ b/modules/i18n/src/models/namespaces/insights-ns.ts
@@ -21,6 +21,7 @@ export interface insightsNS {
     description: string;
     advancedAnalytics: {
         card: {
+            dataRetentionHint: string;
             description: string;
             enableButton: string;
             title: string;

--- a/modules/i18n/src/translations/en-US/portals/insights.ts
+++ b/modules/i18n/src/translations/en-US/portals/insights.ts
@@ -70,6 +70,8 @@ export const insights: insightsNS = {
     },
     advancedAnalytics: {
         card: {
+            dataRetentionHint: "Once enabled, your analytics journey begins new; your analytics " +
+                "history starts fresh and existing data won't carry over.",
             description: "Get a clearer picture of how your users sign in, sign up, and use tokens, " +
                 "with live dashboards that update as activity happens.",
             enableButton: "Enable Advanced Analytics",


### PR DESCRIPTION
## Purpose

Extends the Moesif analytics dashboards with agent-specific insights, excludes agent user-store traffic from the existing user-centric widgets, and fixes an on-premise routing issue where the Insights tab disappeared. Also surfaces the "fresh start" data-retention note on the advanced analytics enablement banner (previously only shown inside the confirmation dialog).

<img width="1404" height="808" alt="Screenshot 2026-07-22 at 15 16 22" src="https://github.com/user-attachments/assets/a8872153-335f-4571-bd0d-c903a8e2371c" />


## Dashboard template changes (`admin.analytics.v1/assets`)

Applied from an updated Moesif canvas export.

- **Exclude the `AGENT` user store from user-related widgets.** Every login (`User-Authentication`) and registration (`User-Registration`) widget, plus M2M Tokens, now carries a `must_not` filter on the agent user store, in both the `es_query` and the `urlQuery`. `Total Tokens` and the token-distribution widgets are intentionally left untouched so agent tokens still appear there as segments.
  - Field spelling is case sensitive and differs by event type, matching the canvas export exactly: registration widgets use `metadata.userstoreDomain.raw` (lowercase s), login and token widgets use `metadata.userStoreDomain.raw` (capital S). Value is always `AGENT`.
- **New Agent view** (premium and essentials) with Agent Tokens Over Time, Agent Logins Over Time, Agent Tokens, Active Agents and New Agents, added as the last sub-dashboard.
- **Agent cards on Overview** (all tiers, including free): New Agents count and Agent Tokens issued, using the same single-value card styling as the neighbouring cards.

## On-premise Insights tab fix (`routes.tsx`)

The Insights tab is gated by the `insights` feature, which is off for on-premise deployments. When that feature is disabled but analytics collector-key settings are enabled, the analytics settings page is now surfaced as the Insights tab so on-premise admins can reach it. When the insights feature is enabled, behaviour is unchanged.

## Enablement banner (`admin.org-insights.v1`)

Added a data-retention hint under the banner description so users know their analytics journey begins fresh the moment they enable advanced analytics, even before opening the confirmation dialog.

## Testing

- `eslint` passes on all changed TypeScript files.
- Dashboard JSON validated: no duplicate/dangling IDs, per-tier filter coverage, correct field spelling per event type, and agent widgets filter `AGENT` positively while user widgets exclude it
