### PR TITLE
[React Doctor] prefer-use-sync-external-store: useState "activeTab" is synchronized with an external store via useEffect — r... (2 occurrences)

### DIFF
--- a/features/admin.console-settings.v1/components/console-settings-tabs.tsx
+++ b/features/admin.console-settings.v1/components/console-settings-tabs.tsx
@@ -24,7 +24,8 @@ import { useGetCurrentOrganizationType } from "@wso2is/admin.organizations.v1/ho
 import useSubscription, { UseSubscriptionInterface } from "@wso2is/admin.subscription.v1/hooks/use-subscription";
 import { isFreeTier } from "@wso2is/admin.subscription.v1/models/tenant-tier";
 import { FeatureAccessConfigInterface, IdentifiableComponentInterface } from "@wso2is/core/models";
-import React, { FunctionComponent, ReactElement, SyntheticEvent, useEffect, useMemo, useState } from "react";
+import React, { FunctionComponent, ReactElement,
+    SyntheticEvent, useCallback, useMemo, useSyncExternalStore } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import ConsoleAdministrators from "./console-administrators/console-administrators";
@@ -199,24 +200,24 @@ const ConsoleSettingsTabs: FunctionComponent<ConsoleSettingsTabsInterface> = (
         return activeTabFromUrl ? activeTabFromUrl.value : consoleTabs[0].value;
     };
 
-    const [ activeTab, setActiveTab ] = useState<number>(getActiveTabFromUrl());
+    type SubscribeCallback = () => void;
+    type UnsubscribeFunction = () => void;
 
     /**
-     * Register a hash change listener to update the active tab.
+     * Subscribe to hash changes on the URL so React can re-render when the active tab changes.
      */
-    useEffect(() => {
-        const handleHashChange = (): void => {
-            setActiveTab(getActiveTabFromUrl());
-        };
+    const subscribeToHashChange: (_callback: SubscribeCallback) => UnsubscribeFunction = useCallback(
+        (callback: SubscribeCallback): UnsubscribeFunction => {
+            window.addEventListener("hashchange", callback);
 
-        // Listen for changes in the URL hash
-        window.addEventListener("hashchange", handleHashChange);
+            return () => {
+                window.removeEventListener("hashchange", callback);
+            };
+        },
+        []
+    );
 
-        return () => {
-            // Clean up the event listener when the component unmounts
-            window.removeEventListener("hashchange", handleHashChange);
-        };
-    }, []);
+    const activeTab: number = useSyncExternalStore<number>(subscribeToHashChange, getActiveTabFromUrl);
 
     /**
      * Callback to handle tab change.

--- a/features/admin.console-settings.v1/components/console-settings-tabs.tsx
+++ b/features/admin.console-settings.v1/components/console-settings-tabs.tsx
@@ -76,6 +76,15 @@ interface ConsoleSettingsTabInterface extends IdentifiableComponentInterface {
      */
     hidden?: boolean;
 }
+/**
+ * Callback type used to subscribe to an external store change.
+ */
+type SubscribeCallback = () => void;
+
+/**
+ * Cleanup function returned by a store subscription.
+ */
+type UnsubscribeFunction = () => void;
 
 /**
  * Tab component for the Console Settings page.
@@ -200,8 +209,7 @@ const ConsoleSettingsTabs: FunctionComponent<ConsoleSettingsTabsInterface> = (
         return activeTabFromUrl ? activeTabFromUrl.value : consoleTabs[0].value;
     };
 
-    type SubscribeCallback = () => void;
-    type UnsubscribeFunction = () => void;
+    
 
     /**
      * Subscribe to hash changes on the URL so React can re-render when the active tab changes.

--- a/features/admin.tenants.v1/components/system-settings/system-settings-tabs.tsx
+++ b/features/admin.tenants.v1/components/system-settings/system-settings-tabs.tsx
@@ -20,7 +20,8 @@ import Tab from "@oxygen-ui/react/Tab";
 import TabPanel from "@oxygen-ui/react/TabPanel";
 import Tabs from "@oxygen-ui/react/Tabs";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
-import React, { FunctionComponent, ReactElement, SyntheticEvent, useEffect, useMemo, useState } from "react";
+import React, { FunctionComponent, ReactElement,
+    SyntheticEvent, useCallback, useMemo, useSyncExternalStore } from "react";
 import { useTranslation } from "react-i18next";
 import AdminSessionAdvisoryBanner from "./admin-session-advisory-banner";
 import RemoteLogPublishing from "./remote-log-publishing";
@@ -103,6 +104,7 @@ const SystemSettingsTabs: FunctionComponent<SystemSettingsTabsInterface> = ({
      * Get the active tab index from the tab id defined in the URL params.
      * @returns Active tab.
      */
+
     const getActiveTabFromUrl = (): number => {
         const activeTabFromUrl: SystemSettingsTabInterface | undefined = tabs.find(
             (tab: SystemSettingsTabInterface) => {
@@ -113,24 +115,24 @@ const SystemSettingsTabs: FunctionComponent<SystemSettingsTabsInterface> = ({
         return activeTabFromUrl ? activeTabFromUrl.value : tabs[0].value;
     };
 
-    const [ activeTab, setActiveTab ] = useState<number>(getActiveTabFromUrl());
+    type SubscribeCallback = () => void;
+    type UnsubscribeFunction = () => void;
 
     /**
-     * Register a hash change listener to update the active tab.
+     * Subscribe to hash changes on the URL so React can re-render when the active tab changes.
      */
-    useEffect(() => {
-        const handleHashChange = (): void => {
-            setActiveTab(getActiveTabFromUrl());
-        };
+    const subscribeToHashChange: (_callback: SubscribeCallback) => UnsubscribeFunction = useCallback(
+        (callback: SubscribeCallback): UnsubscribeFunction => {
+            window.addEventListener("hashchange", callback);
 
-        // Listen for changes in the URL hash
-        window.addEventListener("hashchange", handleHashChange);
+            return () => {
+                window.removeEventListener("hashchange", callback);
+            };
+        },
+        []
+    );
 
-        return () => {
-            // Clean up the event listener when the component unmounts
-            window.removeEventListener("hashchange", handleHashChange);
-        };
-    }, []);
+    const activeTab: number = useSyncExternalStore<number>(subscribeToHashChange, getActiveTabFromUrl);
 
     /**
      * Callback to handle tab change.

--- a/features/admin.tenants.v1/components/system-settings/system-settings-tabs.tsx
+++ b/features/admin.tenants.v1/components/system-settings/system-settings-tabs.tsx
@@ -63,6 +63,16 @@ interface SystemSettingsTabInterface extends IdentifiableComponentInterface {
 }
 
 /**
+ * Callback type used to subscribe to an external store change.
+ */
+type SubscribeCallback = () => void;
+
+/**
+ * Cleanup function returned by a store subscription.
+ */
+type UnsubscribeFunction = () => void;
+
+/**
  * Tab component for the System Settings applicable to all the root organizations.
  *
  * @param props - Props injected to the component.
@@ -115,8 +125,6 @@ const SystemSettingsTabs: FunctionComponent<SystemSettingsTabsInterface> = ({
         return activeTabFromUrl ? activeTabFromUrl.value : tabs[0].value;
     };
 
-    type SubscribeCallback = () => void;
-    type UnsubscribeFunction = () => void;
 
     /**
      * Subscribe to hash changes on the URL so React can re-render when the active tab changes.


### PR DESCRIPTION
…n tab components (fixes #27946)

<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
Replaces the manual `useState` + `useEffect` hash-change listener pattern with `useSyncExternalStore` in `ConsoleSettingsTabs` and `SystemSettingsTabs`. This resolves a React Doctor `prefer-use-sync-external-store` warning and avoids potential tearing during concurrent renders, since the active tab is now derived directly from the URL hash via React's render/commit cycle instead of being manually synced through a side effect.

No behavioral or visual changes — tab switching and URL hash syncing work exactly as before.


### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- Fixes wso2/product-is#27946

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [X] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [X] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [X] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
