### PR TITLE
fix: add sandbox attributes to iframes

### DIFF
--- a/.changeset/secure-iframe-sandboxes.md
+++ b/.changeset/secure-iframe-sandboxes.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.email-templates.v1": patch
+"@wso2is/admin.users.v1": patch
+---
+
+Add sandbox attributes to email template and user impersonation iframes.

--- a/features/admin.email-templates.v1/components/email-template-editor.tsx
+++ b/features/admin.email-templates.v1/components/email-template-editor.tsx
@@ -108,6 +108,7 @@ export const EmailTemplateEditor: FunctionComponent<EmailTemplateEditorPropsInte
                         <div className="render-view" data-testid={ `${ testId }-preview-only-render-view` }>
                             <iframe
                                 id="iframe"
+                                sandbox="allow-same-origin"
                                 ref={ (ref) => {
                                     iframe.current = ref;
                                     iframe.current && writeToIframe();
@@ -137,6 +138,7 @@ export const EmailTemplateEditor: FunctionComponent<EmailTemplateEditorPropsInte
                                         >
                                             <iframe
                                                 id="iframe"
+                                                sandbox="allow-same-origin"
                                                 ref={ (ref) => {
                                                     iframe.current = ref;
                                                     iframe.current && writeToIframe();

--- a/features/admin.users.v1/components/user-impersonation-action.tsx
+++ b/features/admin.users.v1/components/user-impersonation-action.tsx
@@ -452,6 +452,7 @@ export const UserImpersonationAction: FunctionComponent<UserImpersonationActionI
             return (
                 <iframe
                     hidden
+                    sandbox="allow-scripts allow-same-origin"
                     src={ `${getBasePath(consoleUrl)}/resources/users/init-impersonate.html`
                         + `?userId=${encodeURIComponent(user.id)}`
                         + `&codeChallenge=${encodeURIComponent(codeChallenge)}`


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose

Adds curated `sandbox` attributes to the three iframe elements reported by React Doctor.

The email-template preview iframes allow same-origin access required for rendering preview content while keeping scripts restricted. The user-impersonation iframe allows scripts and same-origin access required by the existing impersonation flow.

#### Testing

- Targeted ESLint completed with 0 errors.
- TypeScript check for `admin.email-templates.v1` passed.
- `git diff --check` passed.
- Verified that all three reported iframe elements contain curated `sandbox` attributes.

### Related Issues

- Fixes https://github.com/wso2/product-is/issues/27886

### Related PRs

- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks

- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)

- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.