### PR TITLE
Gate push device management config fetch and update on enabled features

### DIFF
--- a/.changeset/five-moose-invent.md
+++ b/.changeset/five-moose-invent.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.identity-providers.v1": patch
+---
+
+Gate push device management config fetch and update on enabled features

--- a/.changeset/five-moose-invent.md
+++ b/.changeset/five-moose-invent.md
@@ -1,5 +1,6 @@
 ---
 "@wso2is/admin.identity-providers.v1": patch
+"@wso2is/console": patch
 ---
 
 Gate push device management config fetch and update on enabled features

--- a/features/admin.identity-providers.v1/components/forms/authenticators/push-authenticator-form.tsx
+++ b/features/admin.identity-providers.v1/components/forms/authenticators/push-authenticator-form.tsx
@@ -271,12 +271,6 @@ export const PushAuthenticatorForm: FunctionComponent<PushAuthenticatorFormProps
 
     const isReadOnly: boolean = readOnly;
 
-    const {
-        data: pushDeviceMgtConfig,
-        isLoading: isPushDeviceMgtConfigLoading,
-        mutate: mutatePushDeviceMgtConfig
-    } = useGetPushDeviceMgtConfig();
-
     // Push device management settings are exposed as properties of the identity providers feature config.
     const identityProvidersFeatureConfig: FeatureAccessConfigInterface = useSelector(
         (state: AppState) => state?.config?.ui?.features?.identityProviders
@@ -296,6 +290,16 @@ export const PushAuthenticatorForm: FunctionComponent<PushAuthenticatorFormProps
     // Feature flag that gates the device registration notification UI sourced from the console deployment config.
     const isDeviceRegistrationNotificationsEnabled: boolean =
         Boolean(identityProvidersFeatureConfig?.properties?.pushDeviceRegistrationNotificationsEnabled);
+
+    // The push device management endpoint backs both feature sets, so only fetch it when either is enabled.
+    const shouldFetchPushDeviceMgtConfig: boolean =
+        isMultipleDeviceSupportEnabled || isDeviceRegistrationNotificationsEnabled;
+
+    const {
+        data: pushDeviceMgtConfig,
+        isLoading: isPushDeviceMgtConfigLoading,
+        mutate: mutatePushDeviceMgtConfig
+    } = useGetPushDeviceMgtConfig(shouldFetchPushDeviceMgtConfig);
 
     /**
      * Flattens and resolved form initial values and field metadata.
@@ -496,8 +500,18 @@ export const PushAuthenticatorForm: FunctionComponent<PushAuthenticatorFormProps
     const handleFormSubmit = (values: PushAuthenticatorFormInitialValuesInterface): void => {
         setIsSubmitting(true);
 
-        const deviceMgtConfig: PushDeviceMgtConfigInterface = getUpdatedPushDeviceMgtConfig(values);
         const authenticatorConfig: CommonAuthenticatorFormInitialValuesInterface = getUpdatedConfigurations(values);
+
+        // The device management config isn't fetched or editable when both features are disabled,
+        // so skip the update to avoid overwriting the server config with unfetched defaults.
+        if (!shouldFetchPushDeviceMgtConfig) {
+            onSubmit(authenticatorConfig);
+            setIsSubmitting(false);
+
+            return;
+        }
+
+        const deviceMgtConfig: PushDeviceMgtConfigInterface = getUpdatedPushDeviceMgtConfig(values);
 
         updatePushDeviceMgtConfig(deviceMgtConfig)
             .then(() => {


### PR DESCRIPTION


<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
Only call the push-device-mgt endpoint (GET on load, PUT on submit) when multiplePushDeviceSupportEnabled or pushDeviceRegistrationNotificationsEnabled is enabled, so a disabled feature never hits the endpoint or overwrites server config.


### Related Issues
- https://github.com/wso2/product-is/issues/27801

### Related PRs
- https://github.com/wso2/identity-apps/pull/10431

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
