### PR TITLE
Prevent future dates for Date of Birth in registration and user profile forms

### DIFF
--- a/.changeset/tidy-months-tell.md
+++ b/.changeset/tidy-months-tell.md
@@ -1,6 +1,7 @@
 ---
 "@wso2is/identity-apps-core": patch
 "@wso2is/admin.users.v1": patch
+"@wso2is/console": patch
 ---
 
 Prevent future dates from being accepted for the Date of Birth attribute in the self-registration page, the dynamic registration flow date field, and the Console user profile and add-user forms.

--- a/.changeset/tidy-months-tell.md
+++ b/.changeset/tidy-months-tell.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/identity-apps-core": patch
+"@wso2is/admin.users.v1": patch
+---
+
+Prevent future dates from being accepted for the Date of Birth attribute in the self-registration page, the dynamic registration flow date field, and the Console user profile and add-user forms.

--- a/features/admin.users.v1/components/user-profile/fields/form-field-renderer.tsx
+++ b/features/admin.users.v1/components/user-profile/fields/form-field-renderer.tsx
@@ -25,6 +25,7 @@ import {
 } from "@wso2is/core/models";
 import { CheckboxFieldAdapter, FinalFormField, SwitchFieldAdapter } from "@wso2is/forms";
 import dayjs, { Dayjs } from "dayjs";
+import customParseFormat from "dayjs/plugin/customParseFormat";
 import isEmpty from "lodash-es/isEmpty";
 import React, { FunctionComponent, ReactElement } from "react";
 import { useTranslation } from "react-i18next";
@@ -39,6 +40,8 @@ import MultiValuedTextField from "./multi-valued-text-field";
 import RadioGroupFormField from "./radio-group-form-field";
 import SingleValuedEmailMobileField from "./single-valued-email-mobile-field";
 import TextFormField from "./text-form-field";
+
+dayjs.extend(customParseFormat);
 
 /**
  * User profile form field renderer component props interface.
@@ -161,6 +164,34 @@ const ProfileFormFieldRenderer: FunctionComponent<ProfileFormFieldRendererPropsI
 
         return undefined;
     };
+
+    const dateOfBirthValidator = (value: unknown): string | undefined => {
+        const genericError: string = genericValidator(value);
+
+        if (genericError) {
+            return genericError;
+        }
+
+        if (isEmpty(value)) {
+            return undefined;
+        }
+
+        if (!dayjs(value as string, "YYYY-MM-DD", true).isValid()) {
+            return (
+                t("users:forms.validation.dateFormatError", { field: fieldLabel })
+            );
+        }
+
+        if (dayjs().isBefore(value as string)) {
+            return (
+                t("users:forms.validation.futureDateError", { field: fieldLabel })
+            );
+        }
+
+        return undefined;
+    };
+
+    const isDOBSchema: boolean = schema.name === ProfileConstants.SCIM2_SCHEMA_DICTIONARY.get("DOB");
 
     /**
      * Render multi-valued email addresses field.
@@ -327,14 +358,14 @@ const ProfileFormFieldRenderer: FunctionComponent<ProfileFormFieldRendererPropsI
     /**
      * Render date of birth field. Specially handled to use special validator.
      */
-    if (schema.name === ProfileConstants.SCIM2_SCHEMA_DICTIONARY.get("DOB")
+    if (isDOBSchema
         && schema.inputFormat?.inputType !== ClaimInputFormat.DATE_PICKER) {
         return (
             <TextFormField
                 fieldName={ `${encodedSchemaId}.${schema.name}` }
                 fieldLabel={ fieldLabel }
                 initialValue={ initialValues[encodedSchemaId][schema.name] as string }
-                validator={ genericValidator }
+                validator={ dateOfBirthValidator }
                 placeholder="YYYY-MM-DD"
                 maxLength={ maxLength }
                 isReadOnly={ isReadOnly }
@@ -508,6 +539,9 @@ const ProfileFormFieldRenderer: FunctionComponent<ProfileFormFieldRendererPropsI
 
         case ClaimInputFormat.DATE_PICKER:{
             const formattedInitialValue: Dayjs = dayjs(initialValue as string, "YYYY-MM-DD", true);
+            const dateValidator: (_value: unknown) => string | undefined = isDOBSchema
+                ? dateOfBirthValidator
+                : genericValidator;
 
             if (isEmpty(initialValue) || formattedInitialValue.isValid()) {
                 return (
@@ -519,7 +553,7 @@ const ProfileFormFieldRenderer: FunctionComponent<ProfileFormFieldRendererPropsI
                         isUpdating={ isUpdating }
                         isReadOnly={ isReadOnly }
                         isRequired={ isRequired }
-                        validator={ genericValidator }
+                        validator={ dateValidator }
                         data-componentid={ fieldComponentId }
                     />
                 );
@@ -530,7 +564,7 @@ const ProfileFormFieldRenderer: FunctionComponent<ProfileFormFieldRendererPropsI
                     fieldName={ fieldName }
                     fieldLabel={ fieldLabel }
                     initialValue={ initialValue as string }
-                    validator={ genericValidator }
+                    validator={ dateValidator }
                     maxLength={ maxLength }
                     isReadOnly={ isReadOnly }
                     isRequired={ isRequired }

--- a/features/admin.users.v1/components/user-profile/legacy-user-profile-form.tsx
+++ b/features/admin.users.v1/components/user-profile/legacy-user-profile-form.tsx
@@ -55,6 +55,7 @@ import { SupportedLanguagesMeta } from "@wso2is/i18n";
 import { Button, Popup } from "@wso2is/react-components";
 import { AxiosError } from "axios";
 import dayjs from "dayjs";
+import customParseFormat from "dayjs/plugin/customParseFormat";
 import isEmpty from "lodash-es/isEmpty";
 import React, { FunctionComponent, ReactElement, useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -79,6 +80,8 @@ import {
     isMultipleEmailsAndMobileNumbersEnabled,
     isSchemaReadOnly
 } from "../../utils/user-management-utils";
+
+dayjs.extend(customParseFormat);
 
 const EMAIL_ATTRIBUTE: string = ProfileConstants.SCIM2_SCHEMA_DICTIONARY.get("EMAILS");
 const MOBILE_ATTRIBUTE: string = ProfileConstants.SCIM2_SCHEMA_DICTIONARY.get("MOBILE");
@@ -1213,6 +1216,18 @@ const UserProfileForm: FunctionComponent<UserProfileFormPropsInterface> = (
                             validation.isValid = false;
                             validation.errorMessages
                                 .push(t("users:forms.validation.dateFormatError", {
+                                    field: fieldName
+                                }));
+                        } else if (!dayjs(value, "YYYY-MM-DD", true).isValid()) {
+                            validation.isValid = false;
+                            validation.errorMessages
+                                .push(t("users:forms.validation.dateFormatError", {
+                                    field: fieldName
+                                }));
+                        } else if (dayjs().isBefore(value)) {
+                            validation.isValid = false;
+                            validation.errorMessages
+                                .push(t("users:forms.validation.futureDateError", {
                                     field: fieldName
                                 }));
                         }

--- a/features/admin.users.v1/components/wizard/steps/legacy-add-user-basic.tsx
+++ b/features/admin.users.v1/components/wizard/steps/legacy-add-user-basic.tsx
@@ -65,6 +65,8 @@ import { Field, FormValue, Forms, Validation } from "@wso2is/forms/legacy";
 import { SupportedLanguagesMeta } from "@wso2is/i18n";
 import { Button, Hint, Link, PasswordValidation, Popup } from "@wso2is/react-components";
 import { FormValidation } from "@wso2is/validation";
+import dayjs from "dayjs";
+import customParseFormat from "dayjs/plugin/customParseFormat";
 import isEmpty from "lodash-es/isEmpty";
 import React, {
     MutableRefObject,
@@ -105,6 +107,8 @@ import {
     normalizeLocaleFormat
 } from "../../../utils";
 import "./add-user-basic/add-user-basic.scss";
+
+dayjs.extend(customParseFormat);
 
 /**
  * Proptypes for the add user component.
@@ -1873,6 +1877,18 @@ export const LegacyAddUser: React.FunctionComponent<LegacyAddUserProps> = (
                             validation.isValid = false;
                             validation.errorMessages
                                 .push(t("users:forms.validation.dateFormatError", {
+                                    field: fieldName
+                                }));
+                        } else if (!dayjs(value, "YYYY-MM-DD", true).isValid()) {
+                            validation.isValid = false;
+                            validation.errorMessages
+                                .push(t("users:forms.validation.dateFormatError", {
+                                    field: fieldName
+                                }));
+                        } else if (dayjs().isBefore(value)) {
+                            validation.isValid = false;
+                            validation.errorMessages
+                                .push(t("users:forms.validation.futureDateError", {
                                     field: fieldName
                                 }));
                         }

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources.properties
@@ -352,6 +352,7 @@ username=Username
 when.you.click.sign.up.you.are.agreeing=When you click Sign Up, you are agreeing to our
 when.you.continue.you.are.agreeing=When you continue, you are agreeing to our
 dob.must.in.correct.format=Date of Birth is not in the correct format of YYYY-MM-DD
+dob.cannot.be.future.date=Date of Birth cannot be a future date
 mobile.number.format.error=The format of the Mobile Number entered is incorrect. Valid format is [+][country code][area code][local phone number]
 please.contact.administrator.to.fix.issue=To fix this issue, please contact the administrator.
 maxium.length.cannot.exceed=Maximum length of the fields cannot exceed

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
@@ -3094,6 +3094,34 @@
 
                     return false;
                 }
+
+                var dobParts = birthOfDate.value.split("-");
+                var dobDate = new Date(parseInt(dobParts[0], 10), parseInt(dobParts[1], 10) - 1,
+                    parseInt(dobParts[2], 10));
+                var isExistingDate = dobDate.getFullYear() === parseInt(dobParts[0], 10)
+                    && (dobDate.getMonth() + 1) === parseInt(dobParts[1], 10)
+                    && dobDate.getDate() === parseInt(dobParts[2], 10);
+
+                if (!isExistingDate) {
+                    dob_error_text.text("<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "dob.must.in.correct.format")%>")
+                    dob_error_msg.show();
+                    dob_field.addClass("error");
+                    $("html, body").animate({scrollTop: dob_error_text.offset().top}, 'slow');
+
+                    return false;
+                }
+
+                var today = new Date();
+                today.setHours(0, 0, 0, 0);
+
+                if (dobDate > today) {
+                    dob_error_text.text("<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "dob.cannot.be.future.date")%>")
+                    dob_error_msg.show();
+                    dob_field.addClass("error");
+                    $("html, body").animate({scrollTop: dob_error_text.offset().top}, 'slow');
+
+                    return false;
+                }
             } else if (birthOfDate != null && birthOfDate.required && birthOfDate.value.trim() == "") {
                 dob_error_text.text("<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "For.required.fields.cannot.be.empty")%>")
                 dob_error_msg.show();

--- a/identity-apps-core/react-ui-core/src/components/adapters/date-field-adapter.js
+++ b/identity-apps-core/react-ui-core/src/components/adapters/date-field-adapter.js
@@ -26,34 +26,14 @@ import Hint from "../hint";
 import ValidationCriteria from "../validation-criteria";
 import ValidationError from "../validation-error";
 
-const DOB_CLAIM_IDENTIFIER = "http://wso2.org/claims/dob";
-const DOB_DATE_FORMAT = "YYYY-MM-DD";
-const DOB_VALUE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
-const DOB_FORMAT_ERROR = "Date of Birth is not in the correct format of YYYY-MM-DD.";
-const DOB_FUTURE_DATE_ERROR = "Date of Birth cannot be a future date.";
+const DATE_VALIDATOR = "DateValidator";
+const ISO_DATE_FORMAT = "YYYY-MM-DD";
 
 /**
- * Parse a YYYY-MM-DD string into a Date. Returns null if the string
- * does not represent an existing calendar date (e.g. 2025-02-30).
+ * Format today's date as a YYYY-MM-DD string.
  */
-const parseDateString = (value) => {
-    const parts = value.split("-").map((part) => parseInt(part, 10));
-    const date = new Date(parts[0], parts[1] - 1, parts[2]);
-
-    if (date.getFullYear() !== parts[0]
-        || (date.getMonth() + 1) !== parts[1]
-        || date.getDate() !== parts[2]) {
-
-        return null;
-    }
-
-    return date;
-};
-
-/**
- * Format a Date as a YYYY-MM-DD string.
- */
-const formatDateString = (date) => {
+const formatToday = () => {
+    const date = new Date();
     const pad = (num) => String(num).padStart(2, "0");
 
     return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
@@ -68,58 +48,22 @@ const DateFieldAdapter = ({ component, formState, formStateHandler, fieldErrorHa
 
     const [ value, setValue ] = useState("");
 
-    const isDOBField = identifier === DOB_CLAIM_IDENTIFIER;
+    // Derive calendar constraints from the configured DateValidator rule, so the picker
+    // matches the validation rule the field was given (no field-specific logic here).
+    const dateValidatorRule = Array.isArray(validations)
+        ? validations.find((rule) => rule?.name === DATE_VALIDATOR)
+        : undefined;
+    const disallowFuture = Boolean(dateValidatorRule?.conditions?.some(
+        (condition) => condition.key === "disallow.future" && condition.value === "true"));
 
     useEffect(() => {
         formStateHandler(component.config.identifier, value);
     }, [ value ]);
 
-    /**
-     * Validate a date of birth value. Returns an error message or null.
-     */
-    const validateDateOfBirth = (value) => {
-        if (!value) {
-
-            return null;
-        }
-
-        if (!DOB_VALUE_PATTERN.test(value)) {
-
-            return DOB_FORMAT_ERROR;
-        }
-
-        const date = parseDateString(value);
-
-        if (!date) {
-
-            return DOB_FORMAT_ERROR;
-        }
-
-        const today = new Date();
-
-        today.setHours(0, 0, 0, 0);
-
-        if (date > today) {
-
-            return DOB_FUTURE_DATE_ERROR;
-        }
-
-        return null;
-    };
-
     const handleFieldValidation = (value) => {
-        const { errors } = validate({ identifier, required }, value);
-        const combinedErrors = [ ...errors ];
+        const { errors, isValid } = validate({ identifier, required }, value);
 
-        if (isDOBField) {
-            const dobError = validateDateOfBirth(value);
-
-            if (dobError) {
-                combinedErrors.push(dobError);
-            }
-        }
-
-        fieldErrorHandler(identifier, combinedErrors.length > 0 ? combinedErrors : null);
+        fieldErrorHandler(identifier, isValid ? null : errors);
     };
 
     return (
@@ -135,8 +79,8 @@ const DateFieldAdapter = ({ component, formState, formStateHandler, fieldErrorHa
                 } }
                 value={ value }
                 required={ required }
-                dateFormat={ isDOBField ? DOB_DATE_FORMAT : undefined }
-                maxDate={ isDOBField ? formatDateString(new Date()) : undefined }
+                dateFormat={ dateValidatorRule ? ISO_DATE_FORMAT : undefined }
+                maxDate={ disallowFuture ? formatToday() : undefined }
                 clearable
                 closeOnMouseLeave
                 closable

--- a/identity-apps-core/react-ui-core/src/components/adapters/date-field-adapter.js
+++ b/identity-apps-core/react-ui-core/src/components/adapters/date-field-adapter.js
@@ -26,6 +26,39 @@ import Hint from "../hint";
 import ValidationCriteria from "../validation-criteria";
 import ValidationError from "../validation-error";
 
+const DOB_CLAIM_IDENTIFIER = "http://wso2.org/claims/dob";
+const DOB_DATE_FORMAT = "YYYY-MM-DD";
+const DOB_VALUE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const DOB_FORMAT_ERROR = "Date of Birth is not in the correct format of YYYY-MM-DD.";
+const DOB_FUTURE_DATE_ERROR = "Date of Birth cannot be a future date.";
+
+/**
+ * Parse a YYYY-MM-DD string into a Date. Returns null if the string
+ * does not represent an existing calendar date (e.g. 2025-02-30).
+ */
+const parseDateString = (value) => {
+    const parts = value.split("-").map((part) => parseInt(part, 10));
+    const date = new Date(parts[0], parts[1] - 1, parts[2]);
+
+    if (date.getFullYear() !== parts[0]
+        || (date.getMonth() + 1) !== parts[1]
+        || date.getDate() !== parts[2]) {
+
+        return null;
+    }
+
+    return date;
+};
+
+/**
+ * Format a Date as a YYYY-MM-DD string.
+ */
+const formatDateString = (date) => {
+    const pad = (num) => String(num).padStart(2, "0");
+
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+};
+
 const DateFieldAdapter = ({ component, formState, formStateHandler, fieldErrorHandler }) => {
 
     const { identifier, required, label, placeholder, validations, hint } = component.config;
@@ -35,14 +68,58 @@ const DateFieldAdapter = ({ component, formState, formStateHandler, fieldErrorHa
 
     const [ value, setValue ] = useState("");
 
+    const isDOBField = identifier === DOB_CLAIM_IDENTIFIER;
+
     useEffect(() => {
         formStateHandler(component.config.identifier, value);
     }, [ value ]);
 
-    const handleFieldValidation = (value) => {
-        const { errors, isValid } = validate({ identifier, required }, value);
+    /**
+     * Validate a date of birth value. Returns an error message or null.
+     */
+    const validateDateOfBirth = (value) => {
+        if (!value) {
 
-        fieldErrorHandler(identifier, isValid ? null : errors);
+            return null;
+        }
+
+        if (!DOB_VALUE_PATTERN.test(value)) {
+
+            return DOB_FORMAT_ERROR;
+        }
+
+        const date = parseDateString(value);
+
+        if (!date) {
+
+            return DOB_FORMAT_ERROR;
+        }
+
+        const today = new Date();
+
+        today.setHours(0, 0, 0, 0);
+
+        if (date > today) {
+
+            return DOB_FUTURE_DATE_ERROR;
+        }
+
+        return null;
+    };
+
+    const handleFieldValidation = (value) => {
+        const { errors } = validate({ identifier, required }, value);
+        const combinedErrors = [ ...errors ];
+
+        if (isDOBField) {
+            const dobError = validateDateOfBirth(value);
+
+            if (dobError) {
+                combinedErrors.push(dobError);
+            }
+        }
+
+        fieldErrorHandler(identifier, combinedErrors.length > 0 ? combinedErrors : null);
     };
 
     return (
@@ -58,6 +135,8 @@ const DateFieldAdapter = ({ component, formState, formStateHandler, fieldErrorHa
                 } }
                 value={ value }
                 required={ required }
+                dateFormat={ isDOBField ? DOB_DATE_FORMAT : undefined }
+                maxDate={ isDOBField ? formatDateString(new Date()) : undefined }
                 clearable
                 closeOnMouseLeave
                 closable

--- a/identity-apps-core/react-ui-core/src/components/validation-criteria.js
+++ b/identity-apps-core/react-ui-core/src/components/validation-criteria.js
@@ -142,6 +142,13 @@ export const getRuleLabel = (rule) => {
 
             return null;
 
+        case "DateValidator":
+            if (getConditionValue(rule, "disallow.future")) {
+                return "Cannot be a future date.";
+            }
+
+            return null;
+
         default:
             return null;
     }

--- a/identity-apps-core/react-ui-core/src/hooks/use-field-validations.js
+++ b/identity-apps-core/react-ui-core/src/hooks/use-field-validations.js
@@ -18,7 +18,7 @@
 
 import { useCallback, useState } from "react";
 import { DEFAULT_ALPHANUMERIC_REGEX, DEFAULT_EMAIL_REGEX } from "../constants/validation-constants";
-import { validateWithRegex } from "../utils/validation-utils";
+import { isFutureDate, parseIsoDate, validateWithRegex } from "../utils/validation-utils";
 
 /**
  * A custom hook for validating form fields using a flexible “rules” approach.
@@ -186,6 +186,24 @@ const useFieldValidation = (validationConfig) => {
             case "AlphanumericValidator": {
                 if (!validateWithRegex(value, DEFAULT_ALPHANUMERIC_REGEX)) {
                     return "Must contain only alphanumeric characters.";
+                }
+
+                break;
+            }
+
+            case "DateValidator": {
+                if (!value) {
+                    break;
+                }
+
+                if (!parseIsoDate(value)) {
+                    return "Must be a valid date in the format YYYY-MM-DD.";
+                }
+
+                const disallowFuture = getStrCondition(conditions, "disallow.future") === "true";
+
+                if (disallowFuture && isFutureDate(value)) {
+                    return "Cannot be a future date.";
                 }
 
                 break;

--- a/identity-apps-core/react-ui-core/src/utils/validation-utils.js
+++ b/identity-apps-core/react-ui-core/src/utils/validation-utils.js
@@ -42,7 +42,13 @@ export const parseIsoDate = (value) => {
     }
 
     const [ year, month, day ] = value.split("-").map((part) => parseInt(part, 10));
-    const date = new Date(year, month - 1, day);
+
+    // new Date(year, month, day) maps a year in [0, 99] to 1900 + year, so setFullYear is used
+    // instead to preserve four-digit years below 0100 (e.g. "0099-01-01").
+    const date = new Date(0);
+
+    date.setFullYear(year, month - 1, day);
+    date.setHours(0, 0, 0, 0);
 
     if (date.getFullYear() !== year || (date.getMonth() + 1) !== month || date.getDate() !== day) {
 

--- a/identity-apps-core/react-ui-core/src/utils/validation-utils.js
+++ b/identity-apps-core/react-ui-core/src/utils/validation-utils.js
@@ -28,3 +28,44 @@ export const validateWithRegex = (value, regex) => {
 
     return pattern.test(value);
 };
+
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Parse a YYYY-MM-DD string into a Date.
+ * Returns null when the string is not an existing calendar date (e.g. "2025-02-30").
+ */
+export const parseIsoDate = (value) => {
+    if (!value || !ISO_DATE_PATTERN.test(value)) {
+
+        return null;
+    }
+
+    const [ year, month, day ] = value.split("-").map((part) => parseInt(part, 10));
+    const date = new Date(year, month - 1, day);
+
+    if (date.getFullYear() !== year || (date.getMonth() + 1) !== month || date.getDate() !== day) {
+
+        return null;
+    }
+
+    return date;
+};
+
+/**
+ * Whether the given YYYY-MM-DD string represents a date after today.
+ */
+export const isFutureDate = (value) => {
+    const date = parseIsoDate(value);
+
+    if (!date) {
+
+        return false;
+    }
+
+    const today = new Date();
+
+    today.setHours(0, 0, 0, 0);
+
+    return date > today;
+};


### PR DESCRIPTION
## Purpose

The Date of Birth (`http://wso2.org/claims/dob`) attribute accepts a future date during self-registration and during admin user creation/editing, but the My Account profile page rejects future dates. This inconsistency lets invalid DOB values (for example `2027-04-20`) be stored, while the same value is blocked when the user later edits their profile in My Account.

This PR makes the Date of Birth validation consistent across all end-user and admin UIs by rejecting:
1. Values that match the `YYYY-MM-DD` pattern but are not real calendar dates (for example `2025-02-30`).
2. Future dates.

## Changes

1. Classic self-registration page — `identity-apps-core/apps/recovery-portal/.../self-registration-username-request.jsp`
   - `showDateOfBirthValidationStatus()` now checks, after the existing format regex, that the value is an existing calendar date and is not in the future.
   - Added the i18n key `dob.cannot.be.future.date` to the base resource bundle.

2. Dynamic registration flow date field — `identity-apps-core/react-ui-core`
   - Rather than special-casing the DOB claim URI, `use-field-validations.js` gained a generic `DateValidator` rule case (real-date + `disallow.future` conditions), with a matching label in `validation-criteria.js` and shared date helpers in `validation-utils.js`.
   - `date-field-adapter.js` no longer knows about DOB at all — it derives `maxDate` and `dateFormat` from whichever `DateValidator` rule the field's `validations` config carries, so the calendar and inline error activate for any date claim configured this way, not just DOB.
   - This only activates when the server actually attaches a `DateValidator` rule to the field, which is what the companion carbon-identity-framework change does for the DOB claim (see Related PRs).

3. Console user management — `features/admin.users.v1/...`
   - `form-field-renderer.tsx`: added a dedicated DOB validator (required → regex → strict date parse → future check) used by both the text and date-picker branches. The DOB branch previously used the generic validator despite a comment claiming a special one.
   - `legacy-user-profile-form.tsx` and `wizard/steps/legacy-add-user-basic.tsx`: extended the DOB validation callbacks with the strict-parse and future-date checks.
   - Hardened strict date parsing with the `dayjs/plugin/customParseFormat` plugin so impossible dates are rejected.

## Related PRs

- Backend enforcement (all create/update paths): wso2-extensions/identity-inbound-provisioning-scim2#800
- Dynamic-flow server-side rule authoring, needed for the inline error on the dynamic registration flow's date field: wso2/carbon-identity-framework#8212

## Testing

- ESLint clean on the changed lines (pre-existing warnings only).
- The self-registration JSP validation was exercised against the real rendered page in jsdom across 11 cases: the reported `2027-04-20`, tomorrow, today (allowed), valid/invalid leap days, impossible dates, and wrong-order formats — all behave as expected.

