### PR TITLE
Gate banner upgrade CTA behind upgradeButtonEnabled config

### DIFF
--- a/.changeset/jolly-eyes-fly.md
+++ b/.changeset/jolly-eyes-fly.md
@@ -1,0 +1,8 @@
+---
+"@wso2is/admin.feature-gate.v1": patch
+"@wso2is/admin.subscription.v1": patch
+"@wso2is/console": patch
+"@wso2is/i18n": patch
+---
+
+Gate banner upgrade CTA behind upgradeButtonEnabled config

--- a/features/admin.feature-gate.v1/components/feature-locked-banner.tsx
+++ b/features/admin.feature-gate.v1/components/feature-locked-banner.tsx
@@ -47,15 +47,27 @@ const FeatureLockedBanner: FunctionComponent<FeatureLockedBannerPropsInterface> 
 
     const tenantDomain: string = useSelector((state: AppState) => state?.auth?.tenantDomain);
     const associatedTenants: unknown[] = useSelector((state: AppState) => state?.auth?.tenants);
+    const upgradeButtonEnabled: boolean = useSelector(
+        (state: AppState): boolean =>
+            (state?.config?.deployment?.extensions as { upgradeButtonEnabled?: boolean })?.upgradeButtonEnabled === true
+    );
+    const contactUsURL: string = useSelector(
+        (state: AppState): string =>
+            (state?.config?.deployment?.extensions as { contactUsUrl?: string })?.contactUsUrl ?? "https://wso2.com"
+    );
     const [ upgradeButtonURL, setUpgradeButtonURL ] = useState<string>("");
 
     useEffect(() => {
+        if (!upgradeButtonEnabled) {
+            return;
+        }
+
         CommonUtils.buildBillingURLs(tenantDomain, associatedTenants).then(
             ({ upgradeButtonURL }: { upgradeButtonURL: string }) => {
                 setUpgradeButtonURL(upgradeButtonURL);
             }
         );
-    }, [ tenantDomain, associatedTenants ]);
+    }, [ tenantDomain, associatedTenants, upgradeButtonEnabled ]);
 
     return (
         <Alert
@@ -77,11 +89,13 @@ const FeatureLockedBanner: FunctionComponent<FeatureLockedBannerPropsInterface> 
             { t("console:common.featureLockedBanner.prefix") }
             { " " }
             <Link
-                href={ upgradeButtonURL }
+                href={ upgradeButtonEnabled ? upgradeButtonURL : contactUsURL }
                 target="_blank"
                 rel="noreferrer"
             >
-                { t("console:common.featureLockedBanner.action") }
+                { upgradeButtonEnabled
+                    ? t("console:common.featureLockedBanner.action")
+                    : t("console:common.featureLockedBanner.contactAction") }
             </Link>
             { " " }
             { t("console:common.featureLockedBanner.suffix") }

--- a/features/admin.feature-gate.v1/components/feature-locked-banner.tsx
+++ b/features/admin.feature-gate.v1/components/feature-locked-banner.tsx
@@ -49,7 +49,7 @@ const FeatureLockedBanner: FunctionComponent<FeatureLockedBannerPropsInterface> 
     const associatedTenants: unknown[] = useSelector((state: AppState) => state?.auth?.tenants);
     const upgradeButtonEnabled: boolean = useSelector(
         (state: AppState): boolean =>
-            (state?.config?.deployment?.extensions as { upgradeButtonEnabled?: boolean })?.upgradeButtonEnabled === true
+            state?.config?.deployment?.extensions?.upgradeButtonEnabled === true
     );
     const contactUsURL: string = useSelector(
         (state: AppState): string =>

--- a/features/admin.subscription.v1/components/free-trial-banner.tsx
+++ b/features/admin.subscription.v1/components/free-trial-banner.tsx
@@ -26,6 +26,7 @@ import { CommonUtils } from "@wso2is/admin.core.v1/utils/common-utils";
 import FeatureGateConstants from "@wso2is/admin.feature-gate.v1/constants/feature-gate-constants";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { useTrialDetails } from "../hooks/use-trial-details";
 
@@ -48,6 +49,8 @@ const FreeTrialBanner: FunctionComponent<FreeTrialBannerPropsInterface> = (
         ["data-componentid"]: componentId = "free-trial-banner"
     } = props;
 
+    const { t } = useTranslation();
+
     const { tenantHasTrial, daysRemaining } = useTrialDetails();
     const saasFeatureStatus: FeatureStatus = useCheckFeatureStatus(FeatureGateConstants.SAAS_FEATURES_IDENTIFIER);
 
@@ -63,9 +66,17 @@ const FreeTrialBanner: FunctionComponent<FreeTrialBannerPropsInterface> = (
         (state: AppState) =>
             (state?.config?.deployment?.extensions as { pricingURL?: string })?.pricingURL ?? "https://wso2.com"
     );
+    const upgradeButtonEnabled: boolean = useSelector(
+        (state: AppState): boolean =>
+            (state?.config?.deployment?.extensions as { upgradeButtonEnabled?: boolean })?.upgradeButtonEnabled === true
+    );
+    const contactUsURL: string = useSelector(
+        (state: AppState): string =>
+            (state?.config?.deployment?.extensions as { contactUsUrl?: string })?.contactUsUrl ?? "https://wso2.com"
+    );
 
     useEffect(() => {
-        if (saasFeatureStatus === FeatureStatus.DISABLED) {
+        if (saasFeatureStatus === FeatureStatus.DISABLED || !upgradeButtonEnabled) {
             return;
         }
 
@@ -74,7 +85,7 @@ const FreeTrialBanner: FunctionComponent<FreeTrialBannerPropsInterface> = (
                 setUpgradeButtonURL(upgradeButtonURL);
             }
         );
-    }, [ tenantDomain, associatedTenants ]);
+    }, [ tenantDomain, associatedTenants, upgradeButtonEnabled ]);
 
     if (saasFeatureStatus === FeatureStatus.DISABLED || !tenantHasTrial) {
         return null;
@@ -106,12 +117,14 @@ const FreeTrialBanner: FunctionComponent<FreeTrialBannerPropsInterface> = (
                 { daysRemaining === 1 ? "day" : "days" } remaining. { " " }
                 Explore the additional capabilities { trialTierName } unlocks, and { " " }
                 <Link
-                    href={ upgradeButtonURL }
+                    href={ upgradeButtonEnabled ? upgradeButtonURL : contactUsURL }
                     target="_blank"
                     rel="noreferrer"
                     underline="always"
                 >
-                    upgrade
+                    { upgradeButtonEnabled
+                        ? t("console:common.freeTrialBanner.upgradeAction")
+                        : t("console:common.freeTrialBanner.contactAction") }
                 </Link>
                 { " " }when you&apos;re ready.
             </Typography>

--- a/features/admin.subscription.v1/components/free-trial-banner.tsx
+++ b/features/admin.subscription.v1/components/free-trial-banner.tsx
@@ -68,7 +68,7 @@ const FreeTrialBanner: FunctionComponent<FreeTrialBannerPropsInterface> = (
     );
     const upgradeButtonEnabled: boolean = useSelector(
         (state: AppState): boolean =>
-            (state?.config?.deployment?.extensions as { upgradeButtonEnabled?: boolean })?.upgradeButtonEnabled === true
+            state?.config?.deployment?.extensions?.upgradeButtonEnabled === true
     );
     const contactUsURL: string = useSelector(
         (state: AppState): string =>

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -395,7 +395,12 @@ export interface ConsoleNS {
         featureLockedBanner: {
             prefix: string;
             action: string;
+            contactAction: string;
             suffix: string;
+        };
+        freeTrialBanner: {
+            upgradeAction: string;
+            contactAction: string;
         };
         upgrade: string;
     };

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -447,7 +447,12 @@ export const console: ConsoleNS = {
         featureLockedBanner: {
             prefix: "This feature is only available on higher-tier plans.",
             action: "Upgrade your plan",
+            contactAction: "Contact us",
             suffix: "to get access."
+        },
+        freeTrialBanner: {
+            upgradeAction: "upgrade",
+            contactAction: "contact us"
         },
         upgrade: "Upgrade",
         validations: {


### PR DESCRIPTION
### Purpose

Gate the upgrade call-to-action in the free trial banner and the feature locked banner behind a new `extensions.upgradeButtonEnabled` config flag.

Previously both banners always rendered a self-serve upgrade link (built via `CommonUtils.buildBillingURLs`), and there was no way to disable it. With this change:

- When `upgradeButtonEnabled` is `true`, the banners behave as before (an "upgrade" / "Upgrade your plan" link pointing to the billing upgrade URL).
- When it is not `true`, the link is reworded to "contact us" / "Contact us" and points to `extensions.contactUsUrl`, and the billing URL lookup is skipped.

The "View Plans" button on the free trial banner is left unchanged.

**Changes**
- `admin.subscription.v1` — free trial banner: config-aware inline link, guarded billing URL effect.
- `admin.feature-gate.v1` — feature locked banner: config-aware link, guarded billing URL effect.
- `i18n` — added `console:common.featureLockedBanner.contactAction` ("Contact us").

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
