### PR TITLE
Fix duplicate Danger Zone header on user edit page

### DIFF
--- a/.changeset/fix-duplicate-danger-zone-header.md
+++ b/.changeset/fix-duplicate-danger-zone-header.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/admin.users.v1": patch
+---
+
+Fix duplicate "Danger Zone" header on the user edit page.

--- a/features/admin.users.v1/components/user-profile.tsx
+++ b/features/admin.users.v1/components/user-profile.tsx
@@ -1017,9 +1017,7 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                         hasUsersDeletePermissions
                         || hasUsersUpdatePermissions
                     ) ? (
-                            <DangerZoneGroup
-                                sectionHeader={ t("user:editUser.dangerZoneGroup.header") }
-                            >
+                            <>
                                 <UserImpersonationAction
                                     user={ user }
                                     isLocked={ accountLocked }
@@ -1178,7 +1176,7 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                                         ) }
                                     </DangerZoneGroup>
                                 ) }
-                            </DangerZoneGroup>
+                            </>
                         ) : null }
             </>
         );


### PR DESCRIPTION
## Purpose

Fix a UI regression on the user edit page where the "Danger Zone" section header renders twice.

## What changed

- `features/admin.users.v1/components/user-profile.tsx` → `resolveDangerActions()`: collapsed the outer `DangerZoneGroup` (introduced when the user impersonation action was moved under the danger zone) back to a `React.Fragment`, so only the inner `DangerZoneGroup` prints the "Danger Zone" h5. Per-action `<Show>` gates inside each `DangerZone` continue to enforce granular `users.scopes.update` / `users.scopes.delete` checks — no permission behavior is lost.

## Related Issues

- https://github.com/wso2/product-is/issues/28208

## Test plan

- [ ] With granular console permissions enabled and a user that has both `users.scopes.update` and `users.scopes.delete`: the user edit page's Danger Zone renders exactly one "Danger Zone" header.
- [ ] Reset password, Lock user, and Delete user actions still render and behave correctly.
- [ ] For a user managed by a parent org, only the impersonation action renders — no orphan "Danger Zone" header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)