### PR TITLE
Honor configured favicon path in Console (app_favicon_path)

### DIFF
--- a/.changeset/tall-favicons-honor.md
+++ b/.changeset/tall-favicons-honor.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/admin.core.v1": patch
+---
+
+Honor the configured `console.ui.app_favicon_path` in the Console application. The favicon is now applied from the runtime config via react-helmet instead of the hardcoded build-time default.

--- a/apps/console/src/app.tsx
+++ b/apps/console/src/app.tsx
@@ -53,7 +53,12 @@ import { UserStoreListItem } from "@wso2is/admin.userstores.v1/models/user-store
 import UserStoresProvider from "@wso2is/admin.userstores.v1/providers/user-stores-provider";
 import { AppConstants as CommonAppConstants, CommonConstants } from "@wso2is/core/constants";
 import { IdentityAppsApiException } from "@wso2is/core/exceptions";
-import { CommonHelpers, isPortalAccessGranted } from "@wso2is/core/helpers";
+import {
+    CommonHelpers,
+    isPortalAccessGranted,
+    resolveAppLogoFilePath,
+    shouldResolveAppLogoFilePath
+} from "@wso2is/core/helpers";
 import { RouteInterface, StorageIdentityAppsSettingsInterface, emptyIdentityAppsSettings } from "@wso2is/core/models";
 import { setI18nConfigs, setServiceResourceEndpoints } from "@wso2is/core/store";
 import { AuthenticateUtils, LocalStorageUtils } from "@wso2is/core/utils";
@@ -186,6 +191,7 @@ const App = ({
     const loginInit: boolean = useSelector((state: AppState) => state.auth.loginInit);
     const isPrivilegedUser: boolean = useSelector((state: AppState) => state.auth.isPrivilegedUser);
     const config: ConfigReducerStateInterface = useSelector((state: AppState) => state.config);
+    const appFaviconPath: string = useSelector((state: AppState) => state?.config?.ui?.appFaviconPath);
     const appTitle: string = useSelector((state: AppState) => state?.config?.ui?.appTitle);
     const uuid: string = useSelector((state: AppState) => state.profile.profileInfo.id);
     const theme: string = useSelector((state: AppState) => state?.config?.ui?.theme?.name);
@@ -195,6 +201,29 @@ const App = ({
     const [ sessionTimedOut, setSessionTimedOut ] = useState<boolean>(false);
     const [ featureGateConfigData, setFeatureGateConfigData ] =
         useState<FeatureGateInterface | null>(featureGateConfigUpdated);
+
+    const faviconHref: string | undefined = useMemo(() => {
+        if (!appFaviconPath) {
+            return undefined;
+        }
+
+        if (!shouldResolveAppLogoFilePath(appFaviconPath)) {
+            return appFaviconPath;
+        }
+
+        if (!theme) {
+            return undefined;
+        }
+
+        // Resolve relative paths against the runtime clientOrigin/appBase (populated by AppUtils),
+        // mirroring how the branding subsystem builds its theme asset prefix. Avoids depending on
+        // window.publicPath, which is not set in the Console runtime.
+        const clientOrigin: string = (window[ "AppUtils" ]?.getConfig()?.clientOrigin ?? "").replace(/\/+$/, "");
+        const appBase: string = (window[ "AppUtils" ]?.getConfig()?.appBase ?? "").replace(/^\/+|\/+$/g, "");
+        const themePrefix: string = `${ clientOrigin }${ appBase ? "/" + appBase : "" }/libs/themes/${ theme }`;
+
+        return resolveAppLogoFilePath(appFaviconPath, themePrefix);
+    }, [ appFaviconPath, theme ]);
 
     const {
         data: allFeatures,
@@ -560,6 +589,11 @@ const App = ({
                                                                     type="text/css"
                                                                 />
                                                             )
+                                                            : null
+                                                    }
+                                                    {
+                                                        faviconHref
+                                                            ? <link rel="shortcut icon" href={ faviconHref } />
                                                             : null
                                                     }
                                                 </Helmet>

--- a/apps/console/src/home.jsp
+++ b/apps/console/src/home.jsp
@@ -40,7 +40,6 @@
         <!-- End of loading application configurations -->
 
         <link href="<%= buildOptions.publicPath %>libs/themes/<%= buildOptions.theme %>/theme.<%= buildOptions.themeHash %>.min.css" rel="stylesheet" type="text/css"/>
-        <link rel="shortcut icon" href="<%= buildOptions.publicPath %>libs/themes/<%= buildOptions.theme %>/assets/images/branding/favicon.ico" />
 
         <%= buildOptions.cookieproEnabledCheck %>
              <!-- CookiePro Cookies Consent Notice start for asgardeo.io -->

--- a/features/admin.core.v1/configs/app.ts
+++ b/features/admin.core.v1/configs/app.ts
@@ -456,6 +456,7 @@ export class Config {
             appCopyright: window[ "AppUtils" ]?.getConfig()?.ui?.appCopyright
                 .replace("${copyright}", "\u00A9")
                 .replace("${year}", new Date().getFullYear()),
+            appFaviconPath: window[ "AppUtils" ]?.getConfig()?.ui?.appFaviconPath,
             appLogo: {
                 defaultLogoPath: window[ "AppUtils" ]?.getConfig()?.ui?.appLogo?.defaultLogoPath
                     ?? window[ "AppUtils" ]?.getConfig()?.ui?.appLogoPath,

--- a/features/admin.core.v1/models/config.ts
+++ b/features/admin.core.v1/models/config.ts
@@ -492,6 +492,10 @@ export interface UIConfigInterface extends CommonUIConfigInterface<FeatureConfig
         plannedRollOutDate: string;
     };
     /**
+     * Path to the favicon of the application.
+     */
+    appFaviconPath?: string;
+    /**
      * How should the application templates be loaded.
      * If `LOCAL` is selected, app will resort to in app templates.
      * `REMOTE` will fetch templates from the template management REST API.


### PR DESCRIPTION
## Root cause
The Console's favicon `<link>` was a build-time default hardcoded in `apps/console/src/home.jsp` and never read the runtime `console.ui.app_favicon_path` configuration, so a configured custom favicon was ignored.

## Fix
- Surface `appFaviconPath` from the runtime app config into the config reducer (`admin.core.v1`).
- Apply the configured favicon via react-helmet in `apps/console/src/app.tsx`. Absolute/data URLs are used as-is; relative/default paths are resolved under the theme asset prefix (`clientOrigin`/`appBase` from `AppUtils`).
- Remove the hardcoded favicon `<link>` from `home.jsp` so react-helmet is the single source of truth.

## Related Issue
https://github.com/wso2/product-is/issues/28078