### PR TITLE
Resolve flow extension read-only claims from server configuration

### DIFF
--- a/.changeset/flow-extension-readonly-claims.md
+++ b/.changeset/flow-extension-readonly-claims.md
@@ -1,0 +1,8 @@
+---
+"@wso2is/admin.flow-extensions.v1": patch
+"@wso2is/admin.claims.v1": patch
+"@wso2is/i18n": patch
+"@wso2is/console": patch
+---
+
+Resolve flow extension read-only claims from server configuration and list identity claims in the claim picker

--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -204,7 +204,7 @@
             {% if actions is defined %}
             {% for key, value in actions.items() %}
             {% if key != 'types' %}
-            "{{ key }}": {% if value is mapping %}{{ value | tojson }}{% elif value is number %}{{ value }}{% elif value is boolean %}{{ value }}{% else %}"{{ value }}"{% endif %},
+            "{{ key }}": {% if value is mapping %}{{ value | tojson }}{% elif value is boolean %}{{ value | tojson }}{% elif value is number %}{{ value }}{% else %}"{{ value }}"{% endif %},
             {% endif %}
             {% endfor %}
             {% endif %}
@@ -213,7 +213,7 @@
                 {% for type_name, type_config in actions.types.items() %}
                 "{{ type_name }}": {
                     {% for config_key, config_value in type_config.items() %}
-                    "{{ config_key }}": {% if config_value is mapping %}{{ config_value | tojson }}{% elif config_value is number %}{{ config_value }}{% elif config_value is boolean %}{{ config_value }}{% else %}"{{ config_value }}"{% endif %}{{ "," if not loop.last }}
+                    "{{ config_key }}": {% if config_value is mapping %}{{ config_value | tojson }}{% elif config_value is boolean %}{{ config_value | tojson }}{% elif config_value is number %}{{ config_value }}{% elif config_value is sequence and config_value is not string %}{{ config_value | tojson }}{% else %}"{{ config_value }}"{% endif %}{{ "," if not loop.last }}
                     {% endfor %}
                 }{{ "," if not loop.last }}
                 {% endfor %}
@@ -2746,6 +2746,9 @@
                 "enabled": {% if console.flow_extensions.enabled is defined %} {{ console.flow_extensions.enabled }},
                 {% else %} true,
                 {% endif %}
+                "properties": {
+                    "nonModifiablePaths": {% if actions is defined and actions.types is defined and actions.types.flow_extension is defined and actions.types.flow_extension.non_modifiable_paths is defined %}{{ actions.types.flow_extension.non_modifiable_paths | tojson }}{% else %}[]{% endif %}
+                },
                 "featureFlags": [
                     {% if console.flow_extensions.feature_flags is defined %}
                     {% for flag in console.flow_extensions.feature_flags %}

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -1176,6 +1176,12 @@
                         "flag": ""
                     }
                 ],
+                "properties": {
+                    "nonModifiablePaths": [
+                        "/user/claims[uri=http://wso2.org/claims/userid]",
+                        "/user/claims[uri=http://wso2.org/claims/created]"
+                    ]
+                },
                 "scopes": {
                     "create": [
                         "internal_flow_extension_create"

--- a/features/admin.claims.v1/constants/claim-management-constants.ts
+++ b/features/admin.claims.v1/constants/claim-management-constants.ts
@@ -172,6 +172,8 @@ export class ClaimManagementConstants {
         "http://wso2.org/vc/claim"
     ];
 
+    public static readonly IDENTITY_CLAIM_URI_PREFIX: string = "http://wso2.org/claims/identity/";
+
     public static readonly AXSCHEMA_MAPPING: string = "http://axschema.org";
 
     public static readonly OIDC: string = "oidc";

--- a/features/admin.flow-extensions.v1/components/flow-context-tree/add-claim-modal.tsx
+++ b/features/admin.flow-extensions.v1/components/flow-context-tree/add-claim-modal.tsx
@@ -41,6 +41,7 @@ import React, {
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { Dispatch } from "redux";
+import { FlowExtensionConstants } from "../../constants/flow-extension-constants";
 import { TreeNodeStateInterface } from "./models";
 
 interface AddClaimModalProps {
@@ -48,11 +49,6 @@ interface AddClaimModalProps {
     parentNode: TreeNodeStateInterface | null;
     existingClaimURIs: string[];
     externalClaims?: Claim[];
-    /**
-     * Whether the active flow type permits MODIFY on read-only claims. Drives the
-     * informational badge per claim row. Defaults to true.
-     */
-    allowReadOnlyClaimsModification?: boolean;
     onClose: () => void;
     onSubmit: (claims: Claim[]) => void;
     "data-componentid"?: string;
@@ -71,7 +67,6 @@ const AddClaimModal: FunctionComponent<AddClaimModalProps> = ({
     parentNode: _parentNode,
     existingClaimURIs,
     externalClaims,
-    allowReadOnlyClaimsModification = true,
     onClose,
     onSubmit,
     "data-componentid": componentId = "add-claim-modal"
@@ -99,7 +94,6 @@ const AddClaimModal: FunctionComponent<AddClaimModalProps> = ({
 
         const params: ClaimsGetParams = {
             "exclude-hidden-claims": true,
-            "exclude-identity-claims": true,
             filter: null,
             limit: null,
             offset: null,
@@ -192,7 +186,7 @@ const AddClaimModal: FunctionComponent<AddClaimModalProps> = ({
                                     <Typography variant="body2" sx={ { fontWeight: 500 } }>
                                         { claim.displayName }
                                     </Typography>
-                                    { claim.readOnly && !allowReadOnlyClaimsModification && (
+                                    { FlowExtensionConstants.isReadOnlyClaim(claim.claimURI) && (
                                         <Typography
                                             variant="caption"
                                             sx={ {

--- a/features/admin.flow-extensions.v1/components/flow-context-tree/flow-context-tree.tsx
+++ b/features/admin.flow-extensions.v1/components/flow-context-tree/flow-context-tree.tsx
@@ -17,6 +17,7 @@
  */
 
 import { Theme, styled } from "@mui/material/styles";
+import Alert from "@oxygen-ui/react/Alert";
 import Box from "@oxygen-ui/react/Box";
 import Chip from "@oxygen-ui/react/Chip";
 import IconButton from "@oxygen-ui/react/IconButton";
@@ -25,7 +26,9 @@ import Tooltip from "@oxygen-ui/react/Tooltip";
 import Typography from "@oxygen-ui/react/Typography";
 import { TrashIcon } from "@oxygen-ui/react-icons";
 import { getAllLocalClaims } from "@wso2is/admin.claims.v1/api";
+import { ClaimManagementConstants } from "@wso2is/admin.claims.v1/constants/claim-management-constants";
 import { Claim, ClaimsGetParams } from "@wso2is/core/models";
+import { ContentLoader } from "@wso2is/react-components";
 import classNames from "classnames";
 import React, {
     FunctionComponent,
@@ -36,11 +39,13 @@ import React, {
     useState
 } from "react";
 import { useTranslation } from "react-i18next";
+import { FlowExtensionConstants } from "../../constants/flow-extension-constants";
 import { ReactComponent as LockIcon } from "../../resources/assets/images/icons/lock.svg";
 import AddClaimModal from "./add-claim-modal";
 import FlowContextTreeNode from "./flow-context-tree-node";
 import {
     AddEntryModalStateInterface,
+    ContextPathOutputInterface,
     FlowContextTreePropsInterface,
     FlowExtensionAccessConfigInterface,
     NodeType,
@@ -180,6 +185,16 @@ const FieldConfigPanel: FunctionComponent<FieldConfigPanelProps> = ({
     const canModifyOp: boolean = !!selectedNode?.allowedOperations.includes("MODIFY")
         && isLeaf
         && !selectedNode?.readOnly;
+
+    const claimURI: string = selectedNode?.isClaim
+        ? selectedNode?.path?.replace(/^\/user\/claims\//, "")
+        : "";
+
+    const isUsernameClaim: boolean = claimURI === ClaimManagementConstants.USER_NAME_CLAIM_URI;
+    const showUsernameWriteWarning: boolean = isUsernameClaim && !!selectedNode?.modify;
+
+    const isIdentityClaim: boolean = claimURI.startsWith(ClaimManagementConstants.IDENTITY_CLAIM_URI_PREFIX);
+    const showIdentityClaimWriteWarning: boolean = isIdentityClaim && !!selectedNode?.modify;
 
     const getExposeEncryptionDisabledReason: () => string = (): string => {
         if (!canExposeOp) {
@@ -332,6 +347,26 @@ const FieldConfigPanel: FunctionComponent<FieldConfigPanelProps> = ({
                         ) }
                     </Box>
 
+                    { showUsernameWriteWarning && (
+                        <Alert
+                            severity="info"
+                            sx={ { mt: 2 } }
+                            data-componentid={ `${componentId}-username-write-warning` }
+                        >
+                            { t("flowExtension:contextTree.fieldConfig.usernameWriteWarning") }
+                        </Alert>
+                    ) }
+
+                    { showIdentityClaimWriteWarning && (
+                        <Alert
+                            severity="warning"
+                            sx={ { mt: 2 } }
+                            data-componentid={ `${componentId}-identity-claim-write-warning` }
+                        >
+                            { t("flowExtension:contextTree.fieldConfig.identityClaimWriteWarning") }
+                        </Alert>
+                    ) }
+
                     { /* ── Encryption section ── */ }
                     <Typography
                         variant="subtitle2"
@@ -387,6 +422,7 @@ const FlowContextTree: FunctionComponent<FlowContextTreePropsInterface> = ({
 }: FlowContextTreePropsInterface): ReactElement => {
 
     const [ allClaims, setAllClaims ] = useState<Claim[]>([]);
+    const [ isClaimsLoading, setIsClaimsLoading ] = useState<boolean>(true);
 
     const claimDisplayNames: Map<string, string> = useMemo(() => {
         const map: Map<string, string> = new Map();
@@ -400,23 +436,10 @@ const FlowContextTree: FunctionComponent<FlowContextTreePropsInterface> = ({
         return map;
     }, [ allClaims ]);
 
-    const claimReadOnlyMap: Map<string, boolean> = useMemo(() => {
-        const map: Map<string, boolean> = new Map();
-
-        allClaims.forEach((c: Claim) => {
-            if (c.claimURI) {
-                map.set(c.claimURI, !!c.readOnly);
-            }
-        });
-
-        return map;
-    }, [ allClaims ]);
-
     const [ tree, setTree ] = useState<TreeNodeStateInterface[]>(() =>
         initialAccessConfig
             ? mapMetadataToStateWithAccessConfig(contextTree, initialAccessConfig, undefined, {
-                allowReadOnlyClaimsModification,
-                claimReadOnlyMap: undefined
+                allowReadOnlyClaimsModification
             })
             : mapMetadataToState(contextTree)
     );
@@ -442,7 +465,6 @@ const FlowContextTree: FunctionComponent<FlowContextTreePropsInterface> = ({
     useEffect(() => {
         const params: ClaimsGetParams = {
             "exclude-hidden-claims": true,
-            "exclude-identity-claims": true,
             filter: null,
             limit: null,
             offset: null,
@@ -459,6 +481,9 @@ const FlowContextTree: FunctionComponent<FlowContextTreePropsInterface> = ({
             })
             .catch(() => {
                 // Silently fail — claims are optional for display name resolution.
+            })
+            .finally(() => {
+                setIsClaimsLoading(false);
             });
     }, []);
 
@@ -467,12 +492,11 @@ const FlowContextTree: FunctionComponent<FlowContextTreePropsInterface> = ({
         setTree(
             initialAccessConfig
                 ? mapMetadataToStateWithAccessConfig(contextTree, initialAccessConfig, claimDisplayNames, {
-                    allowReadOnlyClaimsModification,
-                    claimReadOnlyMap
+                    allowReadOnlyClaimsModification
                 })
                 : mapMetadataToState(contextTree)
         );
-    }, [ contextTree, initialAccessConfig, claimDisplayNames, claimReadOnlyMap, allowReadOnlyClaimsModification ]);
+    }, [ contextTree, initialAccessConfig, claimDisplayNames, allowReadOnlyClaimsModification ]);
 
     // Default-select the first leaf once the tree is populated, and re-target if
     // the current selection no longer resolves (e.g. after a delete).
@@ -551,11 +575,8 @@ const FlowContextTree: FunctionComponent<FlowContextTreePropsInterface> = ({
             let updated: TreeNodeStateInterface[] = prev;
 
             claims.forEach((claim: Claim, idx: number) => {
-                // When the flow type permits modifying read-only claims, the claim's
-                // read-only flag is ignored entirely — it's treated as a normal writable
-                // entry. Only when modification is disallowed do we honour the flag.
-                const treatAsReadOnly: boolean = !!claim.readOnly && !allowReadOnlyClaimsModification;
-                const allowedOps: string[] = treatAsReadOnly
+                const isReadOnlyClaim: boolean = FlowExtensionConstants.isReadOnlyClaim(claim.claimURI);
+                const allowedOps: string[] = isReadOnlyClaim
                     ? [ "EXPOSE" ]
                     : [ "EXPOSE", "MODIFY" ];
 
@@ -577,7 +598,7 @@ const FlowContextTree: FunctionComponent<FlowContextTreePropsInterface> = ({
                     // trailing one, so the internal form is always `/user/claims/<uri>` — the shape
                     // the access-config serialiser expects to bracket-encode.
                     path: `${parentNode.path.replace(/\/+$/, "")}/${claim.claimURI}`,
-                    readOnly: treatAsReadOnly,
+                    readOnly: isReadOnlyClaim,
                     replaceable: false,
                     title: claim.displayName
                 };
@@ -588,11 +609,21 @@ const FlowContextTree: FunctionComponent<FlowContextTreePropsInterface> = ({
             return updated;
         });
         setClaimModal({ open: false, parentNode: null });
-    }, [ claimModal, allowReadOnlyClaimsModification ]);
+    }, [ claimModal ]);
 
     const handleClaimModalClose = useCallback((): void => {
         setClaimModal({ open: false, parentNode: null });
     }, []);
+
+    const hasConfiguredClaims: boolean = useMemo(
+        () => [ ...initialAccessConfig?.expose ?? [], ...initialAccessConfig?.modify ?? [] ]
+            .some((entry: ContextPathOutputInterface) => entry.path?.startsWith("/user/claims[")),
+        [ initialAccessConfig ]
+    );
+
+    if (isClaimsLoading && hasConfiguredClaims) {
+        return <ContentLoader data-componentid={ `${componentId}-loader` } />;
+    }
 
     return (
         <Box
@@ -653,7 +684,6 @@ const FlowContextTree: FunctionComponent<FlowContextTreePropsInterface> = ({
                     ) || []
                 }
                 externalClaims={ allClaims }
-                allowReadOnlyClaimsModification={ allowReadOnlyClaimsModification }
                 onClose={ handleClaimModalClose }
                 onSubmit={ handleClaimModalSubmit }
                 data-componentid={ `${componentId}-add-claim-modal` }

--- a/features/admin.flow-extensions.v1/components/flow-context-tree/utils.ts
+++ b/features/admin.flow-extensions.v1/components/flow-context-tree/utils.ts
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import { FlowExtensionConstants } from "../../constants/flow-extension-constants";
 import {
     ContextPathOutputInterface,
     ContextTreeNodeMetadataInterface,
@@ -186,16 +187,11 @@ export const mapMetadataToStateWithAccessConfig = (
     options: {
         /** Whether the active flow type permits MODIFY on read-only nodes. Defaults to true. */
         allowReadOnlyClaimsModification?: boolean;
-        /** claimURI → readOnly map; used when synthesising claim leaves to inherit per-claim
-         *  read-only status from the Claims API. Without this every synthesised claim is
-         *  treated as not-readOnly and the modify-drop rule below cannot fire on it. */
-        claimReadOnlyMap?: Map<string, boolean>;
     } = {}
 ): TreeNodeStateInterface[] => {
 
     const allowReadOnlyClaimsModification: boolean =
         options.allowReadOnlyClaimsModification !== false;
-    const claimReadOnlyMap: Map<string, boolean> = options.claimReadOnlyMap ?? new Map();
     // path → encrypted flag. The encrypted bit round-trips the per-field encryption
     // marks saved on the access config.
     const exposePaths: Map<string, boolean> = new Map();
@@ -359,18 +355,21 @@ export const mapMetadataToStateWithAccessConfig = (
                     let isModify: boolean = modifyPaths.has(synthPath);
                     let synthModEnc: boolean = modifyPaths.get(synthPath) ?? false;
                     const displayName: string = claimDisplayNames?.get(key) ?? key;
-                    // For dynamic entries under a claims map, prefer the per-claim readOnly
-                    // status (from the Claims API) over the parent container's flag. Falls
-                    // back to the parent's flag if the map doesn't carry the URI.
-                    const claimReadOnly: boolean | undefined = claimReadOnlyMap.get(key);
-                    const synthReadOnly: boolean = claimReadOnly ?? (node.readOnly ?? false);
+                    
+                    // For dynamic entries under a claims map, read-only status comes from the
+                    // fixed READ_ONLY_CLAIM_URIS list. Other containers fall back to the
+                    // parent's flag.
+                    const synthReadOnly: boolean = containerPrefix === "/user/claims/"
+                        ? FlowExtensionConstants.isReadOnlyClaim(key)
+                        : (node.readOnly ?? false);
 
-                    // Drop a previously-saved MODIFY when this flow type forbids modifying
-                    // read-only nodes (e.g., PASSWORD_RECOVERY). The saved access config still
-                    // carries it; the cleanup commits on the next save.
-                    if (synthReadOnly && !allowReadOnlyClaimsModification) {
+                    if (synthReadOnly) {
                         isModify = false;
                         synthModEnc = false;
+                    }
+
+                    if (!isExposed && !isModify) {
+                        return;
                     }
 
                     const isUnderClaims: boolean = containerPrefix === "/user/claims/";

--- a/features/admin.flow-extensions.v1/constants/flow-extension-constants.ts
+++ b/features/admin.flow-extensions.v1/constants/flow-extension-constants.ts
@@ -82,4 +82,33 @@ export class FlowExtensionConstants {
      */
     public static readonly FLOW_EXTENSION_DEFAULT_DESCRIPTION: string =
         "Extend flows with external services.";
+
+    /**
+     * Matches a bracket-encoded claim entry in a non-modifiable path, capturing the claim URI.
+     */
+    private static readonly NON_MODIFIABLE_CLAIM_PATH_REGEX: RegExp =
+        /^\/user\/claims\[uri=(.*)\](?:\{[^}]+\})?$/;
+
+    /**
+     * Claims that a flow extension may only read, never write. Read from
+     * `Actions.Types.FlowExtension.NonModifiablePaths` in the `identity.xml`.
+     */
+    public static get READ_ONLY_CLAIM_URIS(): string[] {
+        const nonModifiablePaths: string[] = window[ "AppUtils" ]?.getConfig()?.ui?.features
+            ?.flowExtensions?.properties?.nonModifiablePaths ?? [];
+
+        return nonModifiablePaths
+            .map((path: string) => path.match(FlowExtensionConstants.NON_MODIFIABLE_CLAIM_PATH_REGEX)?.[1])
+            .filter((claimURI: string | undefined): claimURI is string => !!claimURI);
+    }
+
+    /**
+     * Whether the given claim URI is read-only inside a flow extension.
+     *
+     * @param claimURI - Claim URI to test.
+     * @returns `true` when the claim may only be read.
+     */
+    public static isReadOnlyClaim(claimURI: string): boolean {
+        return FlowExtensionConstants.READ_ONLY_CLAIM_URIS.includes(claimURI);
+    }
 }

--- a/modules/i18n/src/models/namespaces/flow-extension-ns.ts
+++ b/modules/i18n/src/models/namespaces/flow-extension-ns.ts
@@ -174,6 +174,8 @@ export interface flowExtensionNS {
             readOnlyBadge: string;
             editTooltip: string;
             deleteTooltip: string;
+            usernameWriteWarning: string;
+            identityClaimWriteWarning: string;
             encryption: {
                 title: string;
                 formReadOnly: string;

--- a/modules/i18n/src/translations/en-US/portals/flow-extension.ts
+++ b/modules/i18n/src/translations/en-US/portals/flow-extension.ts
@@ -236,8 +236,11 @@ export const flowExtension: flowExtensionNS = {
                     title: "Write encrypted"
                 }
             },
+            identityClaimWriteWarning: "Modifying this system maintained attribute may cause unexpected behavior.",
             readOnlyBadge: "Read-Only",
-            title: "Field Configuration"
+            title: "Field Configuration",
+            usernameWriteWarning: "Write access to the username is only applied in the Self Registration " +
+                "flow."
         },
         node: {
             addEntryChip: "+ ADD ENTRY",


### PR DESCRIPTION
## Purpose

Read-only claims in the flow extension context tree were driven by each claim's userstore-level read-only marking, which does not reflect what a flow extension may actually write. Claims such as `accountState` were returned as read-only and locked to read, and identity claims were excluded from the claim picker entirely so they could not be selected at all.

Read-only claims are now determined solely by the paths configured on the server, and every other claim returned by the Claims API supports both read and write.

## Related Issue

- https://github.com/wso2/product-is/issues/28330

## Implementation

**Read-only claim resolution**

- `flow-extension-constants.ts`: `READ_ONLY_CLAIM_URIS` now reads `Actions.Types.FlowExtension.NonModifiablePaths` from the deployment config (`ui.actions.types.flow_extension.non_modifiable_paths`), extracting the claim URI out of each bracket-encoded path. Paths that are not claim entries are skipped. Exposed via `isReadOnlyClaim()`, and resolved on access rather than at module load since the deployment config is only populated once the app bootstraps.
- `flow-context-tree.tsx` and `utils.ts`: both the add path and the reload path now take a claim's read-only status from that list instead of the `readOnly` flag on the Claims API response. `claimReadOnlyMap` and the claim-specific `allowReadOnlyClaimsModification` gating are removed.
- `add-claim-modal.tsx`: the read-only badge is driven by the same list, and the `allowReadOnlyClaimsModification` prop is dropped.
- `utils.ts`: synthesised entries left with neither expose nor modify are dropped, keeping the rendered tree consistent with what a reload produces.

**Claim listing**

- Removed `exclude-identity-claims` from both local-claim fetches, so identity claims are listed in the picker and support read and write. `exclude-hidden-claims` is retained.

**Deployment config plumbing**

- `deployment.config.json.j2`: booleans are now serialised with `tojson` ahead of the number check — `bool` subclasses `int` in Python, so booleans were matching the number branch and rendering as `True`/`False`, which is not valid JSON. List values are also serialised with `tojson` so array config such as `non_modifiable_paths` renders as a JSON array rather than a stringified list.
- `deployment.config.json`: added `actions.types.flow_extension` so the value is available when running the dev server.
- `config.ts`: added `non_modifiable_paths` to `ActionsUIConfigInterface`.

**Field configuration panel**

- Added an info alert when write is enabled on the username claim, clarifying that it only takes effect in the Self Registration flow, along with the `usernameWriteWarning` translation key.
- The tree defers rendering until claim display names resolve, but only when the saved access config actually carries claim entries — an empty config, or one holding only non-claim paths, no longer waits on the claims request.
