### PR TITLE
Preserve complex regex callback URLs in migrated applications

### DIFF
--- a/.changeset/complex-regex-callback-preserve.md
+++ b/.changeset/complex-regex-callback-preserve.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/react-components": patch
+"@wso2is/admin.applications.v1": patch
+---
+
+Preserve complex regex callback URLs in migrated applications. A single `regexp=(...)` callback whose pattern contains a literal comma (e.g. a `{0,4}` quantifier) is now kept as one atomic value across display, edit and save instead of being split as a comma-separated list. Adding across syntaxes combines all alternatives into one de-duplicated `regexp=(...)`, and an input mixing both syntaxes is rejected.

--- a/features/admin.applications.v1/utils/__tests__/application-management-utils.test.ts
+++ b/features/admin.applications.v1/utils/__tests__/application-management-utils.test.ts
@@ -34,4 +34,37 @@ describe("ApplicationManagementUtils", () => {
             expect(result).toBe("https://example.com");
         });
     });
+
+    describe("buildCallBackUrlWithRegExp", () => {
+        it("should return a single plain URL unchanged", () => {
+            const input: string = "https://example.com/cb";
+
+            expect(ApplicationManagementUtils.buildCallBackUrlWithRegExp(input)).toBe("https://example.com/cb");
+        });
+
+        it("should wrap a comma-separated list of URLs in a regexp", () => {
+            const input: string = "https://a.example.com/cb,https://b.example.com/cb";
+
+            expect(ApplicationManagementUtils.buildCallBackUrlWithRegExp(input))
+                .toBe("regexp=(https://a.example.com/cb|https://b.example.com/cb)");
+        });
+
+        it("should persist an already-wrapped regex verbatim", () => {
+            const input: string = "regexp=(https://(127.0.0.1|localhost)(:.[0-9]{0,4})?/cb)";
+
+            expect(ApplicationManagementUtils.buildCallBackUrlWithRegExp(input)).toBe(input);
+        });
+
+        it("should preserve quote characters inside a wrapped regex (no stripping)", () => {
+            const input: string = "regexp=(https://example.com/[\"'])";
+
+            expect(ApplicationManagementUtils.buildCallBackUrlWithRegExp(input)).toBe(input);
+        });
+
+        it("should strip surrounding quote literals from a non-wrapped value", () => {
+            const input: string = "\"https://example.com/cb\"";
+
+            expect(ApplicationManagementUtils.buildCallBackUrlWithRegExp(input)).toBe("https://example.com/cb");
+        });
+    });
 });

--- a/features/admin.applications.v1/utils/application-management-utils.ts
+++ b/features/admin.applications.v1/utils/application-management-utils.ts
@@ -401,12 +401,13 @@ export class ApplicationManagementUtils {
      */
     public static buildCallBackUrlWithRegExp = (urls: string): string => {
 
-        let callbackURL = urls.replace(/['"]+/g, "");
-
-        // Persist an already-wrapped regex verbatim.
-        if (/^regexp=\(.+\)$/.test(callbackURL.trim())) {
-            return callbackURL;
+        // Persist an already-wrapped regex verbatim, before any quote stripping, so
+        // patterns that legitimately contain quote characters are not corrupted.
+        if (/^regexp=\(.+\)$/.test(urls.trim())) {
+            return urls;
         }
+
+        let callbackURL = urls.replace(/['"]+/g, "");
 
         if (callbackURL.split(",").length > 1) {
             callbackURL = "regexp=(" + callbackURL.split(",").join("|") + ")";

--- a/features/admin.applications.v1/utils/application-management-utils.ts
+++ b/features/admin.applications.v1/utils/application-management-utils.ts
@@ -403,6 +403,11 @@ export class ApplicationManagementUtils {
 
         let callbackURL = urls.replace(/['"]+/g, "");
 
+        // Persist an already-wrapped regex verbatim.
+        if (/^regexp=\(.+\)$/.test(callbackURL.trim())) {
+            return callbackURL;
+        }
+
         if (callbackURL.split(",").length > 1) {
             callbackURL = "regexp=(" + callbackURL.split(",").join("|") + ")";
         }

--- a/modules/react-components/src/components/input/url-input-utils.test.ts
+++ b/modules/react-components/src/components/input/url-input-utils.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+    combineRegexCallbackUrls,
+    isMixedRegexInput,
+    isSingleRegexValue,
+    splitURLState
+} from "./url-input-utils";
+
+describe("url-input-utils", () => {
+    describe("isSingleRegexValue", () => {
+        it("returns true for a single wrapped regex", () => {
+            expect(isSingleRegexValue("regexp=(https://(a|b)/cb)")).toBe(true);
+        });
+
+        it("returns false for empty, plain URLs and empty regex wrappers", () => {
+            expect(isSingleRegexValue("")).toBe(false);
+            expect(isSingleRegexValue("https://example.com/cb")).toBe(false);
+            expect(isSingleRegexValue("regexp=()")).toBe(false);
+        });
+
+        it("returns false when a regex is mixed with a comma list", () => {
+            expect(isSingleRegexValue("regexp=(https://a.example.com/cb),https://b.example.com/cb")).toBe(false);
+        });
+    });
+
+    describe("splitURLState", () => {
+        it("returns an empty array for an empty value", () => {
+            expect(splitURLState("")).toEqual([]);
+        });
+
+        it("keeps a single complex regex (with commas inside) as one chip", () => {
+            const value: string = "regexp=(https://(127.0.0.1|localhost)(:.[0-9]{0,4})?/cb)";
+
+            expect(splitURLState(value)).toEqual([ value ]);
+        });
+
+        it("splits a comma-separated list of plain URLs", () => {
+            expect(splitURLState("https://a.example.com/cb,https://b.example.com/cb"))
+                .toEqual([ "https://a.example.com/cb", "https://b.example.com/cb" ]);
+        });
+    });
+
+    describe("isMixedRegexInput", () => {
+        it("flags a regex followed by a comma-separated URL", () => {
+            expect(isMixedRegexInput("regexp=(https://a.example.com/cb),https://b.example.com/cb")).toBe(true);
+        });
+
+        it("flags a URL followed by a regex", () => {
+            expect(isMixedRegexInput("https://a.example.com/cb,regexp=(https://b.example.com/cb)")).toBe(true);
+        });
+
+        it("does not flag a lone regex, a plain URL, or a pure comma list", () => {
+            expect(isMixedRegexInput("regexp=(https://a.example.com/cb|https://b.example.com/cb)")).toBe(false);
+            expect(isMixedRegexInput("https://a.example.com/cb")).toBe(false);
+            expect(isMixedRegexInput("https://a.example.com/cb,https://b.example.com/cb")).toBe(false);
+        });
+    });
+
+    describe("combineRegexCallbackUrls", () => {
+        it("merges a comma list of URLs and an added URL into one regex", () => {
+            const existing: string = "https://a.example.com/cb,https://b.example.com/cb";
+
+            expect(combineRegexCallbackUrls(existing, "https://c.example.com/cb"))
+                .toBe("regexp=(https://a.example.com/cb|https://b.example.com/cb|https://c.example.com/cb)");
+        });
+
+        it("expands an all-URL regex and appends the added URL", () => {
+            const existing: string = "regexp=(https://a.example.com/cb|https://b.example.com/cb)";
+
+            expect(combineRegexCallbackUrls(existing, "https://c.example.com/cb"))
+                .toBe("regexp=(https://a.example.com/cb|https://b.example.com/cb|https://c.example.com/cb)");
+        });
+
+        it("keeps a complex (non-all-URL) regex opaque when merging", () => {
+            const existing: string = "regexp=(https://combine.example.com/cb|internal-host/cb)";
+
+            expect(combineRegexCallbackUrls(existing, "https://added.example.com/cb"))
+                .toBe("regexp=(https://combine.example.com/cb|internal-host/cb|https://added.example.com/cb)");
+        });
+
+        it("de-duplicates shared alternatives across two regexes", () => {
+            expect(combineRegexCallbackUrls(
+                "regexp=(https://d1.example.com/cb|https://d2.example.com/cb)",
+                "regexp=(https://d2.example.com/cb|https://d3.example.com/cb)"
+            )).toBe("regexp=(https://d1.example.com/cb|https://d2.example.com/cb|https://d3.example.com/cb)");
+        });
+    });
+});

--- a/modules/react-components/src/components/input/url-input-utils.test.ts
+++ b/modules/react-components/src/components/input/url-input-utils.test.ts
@@ -96,6 +96,13 @@ describe("url-input-utils", () => {
                 .toBe("regexp=(https://combine.example.com/cb|internal-host/cb|https://added.example.com/cb)");
         });
 
+        it("does not emit a blank alternative when the existing state is empty", () => {
+            expect(combineRegexCallbackUrls("", "regexp=(https://a.example.com/cb|https://b.example.com/cb)"))
+                .toBe("regexp=(https://a.example.com/cb|https://b.example.com/cb)");
+            expect(combineRegexCallbackUrls("", "https://a.example.com/cb"))
+                .toBe("regexp=(https://a.example.com/cb)");
+        });
+
         it("de-duplicates shared alternatives across two regexes", () => {
             expect(combineRegexCallbackUrls(
                 "regexp=(https://d1.example.com/cb|https://d2.example.com/cb)",

--- a/modules/react-components/src/components/input/url-input-utils.ts
+++ b/modules/react-components/src/components/input/url-input-utils.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { URLUtils } from "@wso2is/core/utils";
+
+/**
+ * Whether the whole value is a single atomic `regexp=(...)` pattern.
+ *
+ * @param value - Callback URL value.
+ * @returns `true` if the value is a single wrapped regex.
+ */
+export const isSingleRegexValue = (value: string): boolean => {
+    return !!value && /^regexp=\(.+\)$/.test(value.trim());
+};
+
+/**
+ * Splits the URL state into chips, keeping a single atomic regex as one chip
+ * instead of splitting it on the commas that may appear inside the pattern.
+ *
+ * @param urls - The stored callback URL state.
+ * @returns The list of chips to display.
+ */
+export const splitURLState = (urls: string): string[] => {
+    if (!urls) {
+        return [];
+    }
+
+    if (isSingleRegexValue(urls)) {
+        return [ urls ];
+    }
+
+    return urls.split(",");
+};
+
+/**
+ * Individual alternatives of a callback value: a comma list splits on commas;
+ * a regex splits on `|` only when every part is a plain URL, else is kept whole
+ * so a complex pattern is never corrupted.
+ *
+ * @param value - A callback value (comma list or wrapped regex).
+ * @returns The list of alternatives.
+ */
+const toRegexAlternatives = (value: string): string[] => {
+    if (isSingleRegexValue(value)) {
+        const inner: string = value.trim().replace(/^regexp=\(/, "").replace(/\)$/, "");
+        const parts: string[] = inner.split("|");
+
+        return parts.every((part: string): boolean => URLUtils.isHttpsOrHttpUrl(part)) ? parts : [ inner ];
+    }
+
+    return value.split(",");
+};
+
+/**
+ * A value that mixes regex and comma-list syntax (e.g. `regexp=(a),b`), which is not allowed.
+ *
+ * @param value - The entered value.
+ * @returns `true` if the value mixes both syntaxes.
+ */
+export const isMixedRegexInput = (value: string): boolean => {
+    const v: string = value.trim();
+
+    return v.includes("regexp=(") && !isSingleRegexValue(v) && v.includes(",");
+};
+
+/**
+ * Combines an existing URL-state value with a newly added entry when either side is a regex:
+ * flattens both to their alternatives, de-duplicates, and wraps them as a single `regexp=(...)`.
+ *
+ * @param existing - The current URL state.
+ * @param added - The newly added entry.
+ * @returns The combined, de-duplicated `regexp=(...)` value.
+ */
+export const combineRegexCallbackUrls = (existing: string, added: string): string => {
+    const alternatives: string[] = [ ...toRegexAlternatives(existing), ...toRegexAlternatives(added) ];
+    const unique: string[] = alternatives.filter(
+        (value: string, index: number): boolean => alternatives.indexOf(value) === index
+    );
+
+    return `regexp=(${ unique.join("|") })`;
+};

--- a/modules/react-components/src/components/input/url-input-utils.ts
+++ b/modules/react-components/src/components/input/url-input-utils.ts
@@ -87,10 +87,12 @@ export const isMixedRegexInput = (value: string): boolean => {
  * @returns The combined, de-duplicated `regexp=(...)` value.
  */
 export const combineRegexCallbackUrls = (existing: string, added: string): string => {
-    const alternatives: string[] = [ ...toRegexAlternatives(existing), ...toRegexAlternatives(added) ];
+    const alternatives: string[] = [ existing, added ]
+        .filter((value: string): boolean => value.trim().length > 0)
+        .flatMap((value: string): string[] => toRegexAlternatives(value));
     const unique: string[] = alternatives.filter(
         (value: string, index: number): boolean => alternatives.indexOf(value) === index
     );
 
-    return `regexp=(${ unique.join("|") })`;
+    return unique.length > 0 ? `regexp=(${ unique.join("|") })` : "";
 };

--- a/modules/react-components/src/components/input/url-input.test.tsx
+++ b/modules/react-components/src/components/input/url-input.test.tsx
@@ -40,24 +40,47 @@ const renderURLInput = (urlState: string): string => {
     return renderToStaticMarkup(element);
 };
 
+/**
+ * Extracts the callback chip values from rendered markup using their `data-componentid`
+ * (`url-input-<value>`), excluding the input's own container and the per-chip action buttons.
+ *
+ * @param html - The rendered markup.
+ * @returns The distinct chip values, one per rendered chip.
+ */
+const chipValues = (html: string): string[] => {
+    const container: HTMLDivElement = document.createElement("div");
+
+    container.innerHTML = html;
+
+    const ids: string[] = Array.from(container.querySelectorAll("[data-componentid]"))
+        .map((element: Element): string => element.getAttribute("data-componentid") ?? "")
+        .filter((id: string): boolean =>
+            id.startsWith("url-input-")
+            && id !== "url-input-add-button"
+            && !id.endsWith("-delete-button")
+            && !id.endsWith("-allow-button"));
+
+    return Array.from(new Set(ids)).map((id: string): string => id.replace(/^url-input-/, ""));
+};
+
 describe("URLInput", () => {
     it("renders a single complex regex callback as one chip, verbatim", () => {
         const value: string = "regexp=(https://(127.0.0.1|localhost)(:.[0-9]{0,4})?/cb)";
         const html: string = renderURLInput(value);
 
-        expect(html).toContain(value);
+        expect(chipValues(html)).toEqual([ value ]);
     });
 
     it("renders a comma-separated list as separate chips", () => {
         const html: string = renderURLInput("https://a.example.com/cb,https://b.example.com/cb");
+        const chips: string[] = chipValues(html);
 
-        expect(html).toContain("https://a.example.com/cb");
-        expect(html).toContain("https://b.example.com/cb");
+        expect(chips).toHaveLength(2);
+        expect(chips).toContain("https://a.example.com/cb");
+        expect(chips).toContain("https://b.example.com/cb");
     });
 
     it("renders without chips for an empty state", () => {
-        const html: string = renderURLInput("");
-
-        expect(typeof html).toBe("string");
+        expect(chipValues(renderURLInput(""))).toHaveLength(0);
     });
 });

--- a/modules/react-components/src/components/input/url-input.test.tsx
+++ b/modules/react-components/src/components/input/url-input.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// @vitest-environment jsdom
+
+import React, { ReactElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { URLInput } from "./url-input";
+
+const renderURLInput = (urlState: string): string => {
+    const element: ReactElement = (
+        <URLInput
+            data-componentid="url-input"
+            duplicateURLErrorMessage="This value is already added"
+            labelName="Authorized redirect URLs"
+            validationErrorMsg="Please enter a valid URI"
+            urlState={ urlState }
+            setURLState={ () => { /* no-op */ } }
+            handleAddAllowedOrigin={ () => { /* no-op */ } }
+            allowedOrigins={ [] }
+        />
+    );
+
+    return renderToStaticMarkup(element);
+};
+
+describe("URLInput", () => {
+    it("renders a single complex regex callback as one chip, verbatim", () => {
+        const value: string = "regexp=(https://(127.0.0.1|localhost)(:.[0-9]{0,4})?/cb)";
+        const html: string = renderURLInput(value);
+
+        expect(html).toContain(value);
+    });
+
+    it("renders a comma-separated list as separate chips", () => {
+        const html: string = renderURLInput("https://a.example.com/cb,https://b.example.com/cb");
+
+        expect(html).toContain("https://a.example.com/cb");
+        expect(html).toContain("https://b.example.com/cb");
+    });
+
+    it("renders without chips for an empty state", () => {
+        const html: string = renderURLInput("");
+
+        expect(typeof html).toBe("string");
+    });
+});

--- a/modules/react-components/src/components/input/url-input.tsx
+++ b/modules/react-components/src/components/input/url-input.tsx
@@ -34,6 +34,7 @@ export interface URLInputPropsInterface extends IdentifiableComponentInterface, 
     addURLTooltip?: string;
     duplicateURLErrorMessage: string;
     emptyErrorMessage?: string;
+    regexInputErrorMessage?: string;
     urlState: string;
     setURLState: any;
     placeholder?: string;
@@ -185,6 +186,7 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
         customLabel,
         duplicateURLErrorMessage,
         emptyErrorMessage,
+        regexInputErrorMessage,
         isAllowEnabled,
         allowedOrigins,
         handleAddAllowedOrigin,
@@ -233,9 +235,48 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
     const [ predictValue, setPredictValue ] = useState<string[]>([]);
     const [ validURL, setValidURL ] = useState<boolean>(true);
     const [ duplicateURL, setDuplicateURL ] = useState<boolean>(false);
+    const [ regexInputError, setRegexInputError ] = useState<boolean>(false);
     const [ keepFocus, setKeepFocus ] = useState<boolean>(false);
     const [ hideEntireComponent, setHideEntireComponent ] = useState<boolean>(false);
     const [ showMore, setShowMore ] = useState<boolean>(false);
+
+    // Whether the whole value is a single atomic `regexp=(...)`.
+    const isSingleRegexValue = (value: string): boolean => {
+        return !!value && /^regexp=\(.+\)$/.test(value.trim());
+    };
+
+    // Splits the URL state into chips, keeping a single atomic regex as one chip.
+    const splitURLState = (urls: string): string[] => {
+        if (!urls) {
+            return [];
+        }
+
+        if (isSingleRegexValue(urls)) {
+            return [ urls ];
+        }
+
+        return urls.split(",");
+    };
+
+    // Individual alternatives of a callback value: a comma list splits on commas;
+    // a regex splits on `|` only when every part is a plain URL, else is kept whole.
+    const toRegexAlternatives = (value: string): string[] => {
+        if (isSingleRegexValue(value)) {
+            const inner: string = value.trim().replace(/^regexp=\(/, "").replace(/\)$/, "");
+            const parts: string[] = inner.split("|");
+
+            return parts.every((part: string) => URLUtils.isHttpsOrHttpUrl(part)) ? parts : [ inner ];
+        }
+
+        return value.split(",");
+    };
+
+    // A value that mixes regex and comma-list syntax (e.g. `regexp=(a),b`), which is not allowed.
+    const isMixedRegexInput = (value: string): boolean => {
+        const v: string = value.trim();
+
+        return v.includes("regexp=(") && !isSingleRegexValue(v) && v.includes(",");
+    };
 
     /**
      * Add URL to the URL list.
@@ -246,19 +287,26 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
 
         let url: string = changeUrl;
 
+        if (isMixedRegexInput(url)) {
+            setRegexInputError(true);
+
+            return;
+        }
+
+        // A regex value is a valid callback entry, so it bypasses URL validation below.
+        const isRegexEntry: boolean = isSingleRegexValue(url);
+
         /**
          * If the entered URL is a invalid i.e not a standard URL input, then we won't add
          * the input to the state.
          */
-        if (!(skipValidation || skipInternalValidation) && !URLUtils.isURLValid(url, true)) {
+        if (!isRegexEntry && !(skipValidation || skipInternalValidation) && !URLUtils.isURLValid(url, true)) {
             setValidURL(false);
 
             return;
         }
 
-        const urlValid: boolean = skipValidation
-            ? true
-            : validation(url);
+        const urlValid: boolean = isRegexEntry || (skipValidation ? true : validation(url));
 
         setValidURL(urlValid);
 
@@ -266,13 +314,13 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
          * If the entered URL is valid and it is intended to be an origin URL,
          * and it has a trailing "/" at the end, it is sliced to get the valid origin.
         */
-        if (urlValid && onlyOrigin && url.charAt(url.length - 1) === "/") {
+        if (urlValid && !isRegexEntry && onlyOrigin && url.charAt(url.length - 1) === "/") {
             url = url.slice(0, -1);
         }
 
         if (urlValid && (urlState === "" || urlState === undefined)) {
             setURLState(url);
-            if (addOriginByDefault) {
+            if (addOriginByDefault && !isRegexEntry) {
                 const originOfURL: string = URLUtils.urlComponents(url).origin;
 
                 handleAddAllowedOrigin(originOfURL);
@@ -287,14 +335,27 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
             urlValid && setDuplicateURL(duplicate);
 
             if (urlValid && !duplicate) {
-                setURLState((url + "," + urlState));
-                if (addOriginByDefault) {
+                // When either side is a regex, combine all alternatives into one
+                // de-duplicated `regexp=(...)`; otherwise comma-join plain URLs.
+                let newURLState: string;
+
+                if (isRegexEntry || isSingleRegexValue(urlState)) {
+                    const alternatives: string[] = [ ...toRegexAlternatives(urlState), ...toRegexAlternatives(url) ];
+                    const unique: string[] = alternatives.filter((v, i) => alternatives.indexOf(v) === i);
+
+                    newURLState = `regexp=(${ unique.join("|") })`;
+                } else {
+                    newURLState = url + "," + urlState;
+                }
+
+                setURLState(newURLState);
+                if (addOriginByDefault && !isRegexEntry) {
                     handleAddAllowedOrigin(url);
                     allowedOrigins.push(url);
                 }
                 setChangeUrl("");
 
-                return url + "," + urlState;
+                return newURLState;
             }
         }
 
@@ -350,7 +411,7 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
      * @returns A boolean value denoting whether the URL is duplicated or not
      */
     const checkDuplicateUrl = useCallback((url: string): boolean => {
-        const availableURls: string[] = !urlState ? [] : urlState?.split(",");
+        const availableURls: string[] = splitURLState(urlState);
         const urls: Set<string> = new Set([
             ...(onlyOrigin ? (allowedOrigins ?? []) : []),
             ...(availableURls ?? [])
@@ -379,6 +440,10 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
 
         if (!validURL) {
             setValidURL(true);
+        }
+
+        if (regexInputError) {
+            setRegexInputError(false);
         }
 
         const isDuplicate: boolean = checkDuplicateUrl(changeValue);
@@ -421,8 +486,8 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
     const removeValue = (removeURL) => {
         let urlsAfterRemoved: string = urlState;
 
-        if (urlState.split(",").length > 1) {
-            const urls: string[] = urlsAfterRemoved.split(",");
+        if (splitURLState(urlState).length > 1) {
+            const urls: string[] = splitURLState(urlsAfterRemoved);
             const removeIndex: number = urls.findIndex((url) => url === removeURL);
 
             urls.splice(removeIndex, 1);
@@ -663,6 +728,20 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
             );
         }
 
+        if (regexInputError) {
+            return (
+                <Label
+                    data-componentid={ `${ componentId }-regex-input-error-message` }
+                    basic
+                    className="prompt"
+                    color="red"
+                    pointing
+                >
+                    { regexInputErrorMessage }
+                </Label>
+            );
+        }
+
         return customLabel;
     };
 
@@ -838,7 +917,7 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
                     <Grid.Column mobile={ 14 } tablet={ 14 } computer={ computerSize }>
                         <Input
                             fluid
-                            error={ !(validURL && !duplicateURL) }
+                            error={ !(validURL && !duplicateURL && !regexInputError) }
                             focus={ keepFocus }
                             value={ changeUrl }
                             onKeyDown={ keyPressed }
@@ -909,9 +988,9 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
                         </Grid.Column>
                     </Grid.Row>
                 ) }
-                { urlState && urlState.split(",").map((url) => {
+                { urlState && splitURLState(urlState).map((url) => {
                     if (url !== "") {
-                        const isRegexWrapper: boolean = /^regexp=\(.+\)$/.test(url);
+                        const isRegexWrapper: boolean = isSingleRegexValue(url);
 
                         if (skipValidation || skipInternalValidation || isRegexWrapper) {
                             return (
@@ -956,6 +1035,7 @@ URLInput.defaultProps = {
     isCustom: false,
     labelEnabled: false,
     onlyOrigin: false,
+    regexInputErrorMessage: "Enter either a single regexp=(…) pattern or individual URLs, not a combination of both.",
     restrictSecondaryContent: true,
     showPredictions: true
 };

--- a/modules/react-components/src/components/input/url-input.tsx
+++ b/modules/react-components/src/components/input/url-input.tsx
@@ -28,6 +28,12 @@ import { LinkButton } from "../button";
 import { LabelWithPopup } from "../label";
 import { Popup } from "../popup";
 import { Hint } from "../typography";
+import {
+    combineRegexCallbackUrls,
+    isMixedRegexInput,
+    isSingleRegexValue,
+    splitURLState
+} from "./url-input-utils";
 import "./url-input.scss";
 
 export interface URLInputPropsInterface extends IdentifiableComponentInterface, TestableComponentInterface {
@@ -240,44 +246,6 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
     const [ hideEntireComponent, setHideEntireComponent ] = useState<boolean>(false);
     const [ showMore, setShowMore ] = useState<boolean>(false);
 
-    // Whether the whole value is a single atomic `regexp=(...)`.
-    const isSingleRegexValue = (value: string): boolean => {
-        return !!value && /^regexp=\(.+\)$/.test(value.trim());
-    };
-
-    // Splits the URL state into chips, keeping a single atomic regex as one chip.
-    const splitURLState = (urls: string): string[] => {
-        if (!urls) {
-            return [];
-        }
-
-        if (isSingleRegexValue(urls)) {
-            return [ urls ];
-        }
-
-        return urls.split(",");
-    };
-
-    // Individual alternatives of a callback value: a comma list splits on commas;
-    // a regex splits on `|` only when every part is a plain URL, else is kept whole.
-    const toRegexAlternatives = (value: string): string[] => {
-        if (isSingleRegexValue(value)) {
-            const inner: string = value.trim().replace(/^regexp=\(/, "").replace(/\)$/, "");
-            const parts: string[] = inner.split("|");
-
-            return parts.every((part: string) => URLUtils.isHttpsOrHttpUrl(part)) ? parts : [ inner ];
-        }
-
-        return value.split(",");
-    };
-
-    // A value that mixes regex and comma-list syntax (e.g. `regexp=(a),b`), which is not allowed.
-    const isMixedRegexInput = (value: string): boolean => {
-        const v: string = value.trim();
-
-        return v.includes("regexp=(") && !isSingleRegexValue(v) && v.includes(",");
-    };
-
     /**
      * Add URL to the URL list.
      *
@@ -340,10 +308,7 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
                 let newURLState: string;
 
                 if (isRegexEntry || isSingleRegexValue(urlState)) {
-                    const alternatives: string[] = [ ...toRegexAlternatives(urlState), ...toRegexAlternatives(url) ];
-                    const unique: string[] = alternatives.filter((v, i) => alternatives.indexOf(v) === i);
-
-                    newURLState = `regexp=(${ unique.join("|") })`;
+                    newURLState = combineRegexCallbackUrls(urlState, url);
                 } else {
                     newURLState = url + "," + urlState;
                 }
@@ -988,7 +953,7 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
                         </Grid.Column>
                     </Grid.Row>
                 ) }
-                { urlState && splitURLState(urlState).map((url) => {
+                { urlState && splitURLState(urlState).map((url: string) => {
                     if (url !== "") {
                         const isRegexWrapper: boolean = isSingleRegexValue(url);
 


### PR DESCRIPTION
## Problem

Applications migrated from older IS versions can carry a single `regexp=(...)` callback URL whose pattern contains a literal comma (e.g. the `{0,4}` quantifier). The Console treated the callback field as a comma-separated list, so the pattern was split on that comma — corrupting both the display (shown as two chips) and the value persisted on a no-op **Update** (rewritten to `regexp=(regexp=(...{0|4}...))`), which then broke authentication at `/oauth2/authorize`.

## Fix

- Treat a callback value as **either** a comma-separated list of URLs **or** one atomic `regexp=(...)`, consistently across display, edit and save (`splitURLState` / `isSingleRegexValue` in `url-input.tsx`).
- `buildCallBackUrlWithRegExp` returns an already-wrapped `regexp=(...)` verbatim instead of re-wrapping it.
- Adding across syntaxes combines all alternatives into one de-duplicated `regexp=(a|b|…)`; an all-URL regex still expands to a URL list. An input that mixes both syntaxes (`regexp=(…),url`) is rejected with a clear message.

## Related Issue

- https://github.com/wso2/product-is/issues/28016
