### PR TITLE
Improve the group assigning section

### DIFF
--- a/.changeset/spicy-coats-hunt.md
+++ b/.changeset/spicy-coats-hunt.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.users.v1": patch
+"@wso2is/console": patch
+---
+
+Improve the group assigning section

--- a/features/admin.users.v1/components/user-groups-edit.tsx
+++ b/features/admin.users.v1/components/user-groups-edit.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2020-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -222,11 +222,13 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
     };
 
     const handleOpenAddNewGroupModal = () => {
+        setSearchQuery(null);
         setAddNewRoleModalView(true);
     };
 
     const handleCloseAddNewGroupModal = () => {
         setIsSelectAllGroupsChecked(false);
+        setSearchQuery(null);
         setAddNewRoleModalView(false);
     };
 
@@ -240,6 +242,12 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
             setSearchQuery(processedQuery);
         }
     }, 1000), []);
+
+    useEffect(() => {
+        return () => {
+            handleUnselectedListSearch.cancel();
+        };
+    }, [ handleUnselectedListSearch ]);
 
     /**
      * This function handles assigning the roles to the user.


### PR DESCRIPTION
### Issues fixed

**1. Stale search filter persisted across modal reopens.**
`searchQuery` was not reset when the group modal was opened or closed, so a `displayName co <value>` filter set in one session leaked into the next open — the user saw a filtered list without any query in the search box. `handleOpenAddNewGroupModal` and `handleCloseAddNewGroupModal` now reset `searchQuery` to `null`.

**2. Debounced search callback could fire after the modal unmounted.**
`handleUnselectedListSearch` is a `debounce(..., 1000)` — if the user typed and then closed the modal within the debounce window, the pending call still ran and updated `searchQuery` on an unmounted component. A cleanup `useEffect` now cancels the debounced function on unmount.

### Related Issue
- https://github.com/wso2/product-is/issues/28149