### PR TITLE
Show the subject attribute even if it is not a requested attribute

### DIFF
--- a/.changeset/subject-attribute-preserve.md
+++ b/.changeset/subject-attribute-preserve.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.applications.v1": patch
+"@wso2is/console": patch
+---
+
+Show the subject attribute even if it is not a requested attribute

--- a/features/admin.applications.v1/components/settings/attribute-management/attribute-list-item.tsx
+++ b/features/admin.applications.v1/components/settings/attribute-management/attribute-list-item.tsx
@@ -222,6 +222,17 @@ export const AttributeListItem: FunctionComponent<AttributeListItemPropInterface
         return subject || readOnly || isOIDCMapping;
     };
 
+    /**
+     * This function will resolve whether the requested checkbox should be read only or not.
+     */
+    const isRequestedCheckboxReadOnly = (): boolean => {
+        if (onlyOIDCConfigured) {
+            return (subject && requested) || readOnly || isOIDCMapping;
+        }
+
+        return subject || readOnly || isOIDCMapping;
+    };
+
     return (
         <Table.Row data-testid={ testId }>
             {
@@ -300,10 +311,10 @@ export const AttributeListItem: FunctionComponent<AttributeListItemPropInterface
                         { ...(!localDialect && { textAlign: "center" }) }
                     >
                         <Checkbox
-                            checked={ initialRequested || requested || subject }
-                            onClick={ (!readOnly && !subject) ? handleRequestedCheckChange : () => null }
+                            checked={ initialRequested || requested || (subject && !onlyOIDCConfigured) }
+                            onClick={ !isRequestedCheckboxReadOnly() ? handleRequestedCheckChange : () => null }
                             disabled={ mappingOn ? !mandatory : false }
-                            readOnly={ subject || readOnly || isOIDCMapping }
+                            readOnly={ isRequestedCheckboxReadOnly() }
                         />
                     </Table.Cell>
                 )

--- a/features/admin.applications.v1/components/settings/attribute-management/attribute-settings.tsx
+++ b/features/admin.applications.v1/components/settings/attribute-management/attribute-settings.tsx
@@ -747,10 +747,12 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
      */
     const createDropdownOption = (): DropdownOptionsInterface[] => {
         const options: DropdownOptionsInterface[] = [];
+        const currentSubjectUri: string = claimConfigurations?.subject?.claim?.uri;
 
         if (selectedDialect.localDialect) {
             if (claimMappingOn) {
                 let usernameAdded: boolean = false;
+                let subjectAdded: boolean = !currentSubjectUri || currentSubjectUri === DefaultSubjectAttribute;
                 const claimMappingOption: DropdownOptionsInterface[] = [];
                 const claimMappingList: ExtendedClaimMappingInterface[] = [ ...claimMapping ];
 
@@ -775,6 +777,9 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
                     if (element.localClaim.uri === DefaultSubjectAttribute) {
                         usernameAdded = true;
                     }
+                    if (element.applicationClaim === currentSubjectUri) {
+                        subjectAdded = true;
+                    }
                     claimMappingOption.push(option);
                 });
                 if (claimMappingList.length === 0 || !usernameAdded) {
@@ -798,10 +803,45 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
                         claimMappingOption.push(option);
                     }
                 }
+                if (!subjectAdded) {
+                    // Preserve a subject claim that isn't part of the current claim mappings so the dropdown
+                    // can render it and it survives round-trips through this form.
+                    const subjectClaim: ExtendedClaimInterface = claims.filter(
+                        (element: ExtendedClaimInterface) => element.claimURI === currentSubjectUri)[ 0 ];
+
+                    if (subjectClaim !== null && typeof subjectClaim !== "undefined") {
+                        claimMappingOption.push({
+                            key: subjectClaim.claimURI,
+                            text: (
+                                <SubjectAttributeListItem
+                                    key={ subjectClaim.id }
+                                    displayName={ subjectClaim.displayName }
+                                    claimURI={ subjectClaim.claimURI }
+                                    value={ subjectClaim.claimURI }
+                                />
+                            ),
+                            value: subjectClaim.claimURI
+                        });
+                    } else {
+                        claimMappingOption.push({
+                            key: currentSubjectUri,
+                            text: (
+                                <SubjectAttributeListItem
+                                    key={ currentSubjectUri }
+                                    displayName={ currentSubjectUri }
+                                    claimURI={ currentSubjectUri }
+                                    value={ currentSubjectUri }
+                                />
+                            ),
+                            value: currentSubjectUri
+                        });
+                    }
+                }
 
                 return sortBy(claimMappingOption, "key");
             } else {
                 let usernameAdded: boolean = false;
+                let subjectAdded: boolean = !currentSubjectUri || currentSubjectUri === DefaultSubjectAttribute;
 
                 selectedClaims.map((element: ExtendedClaimInterface) => {
                     const option: DropdownOptionsInterface = {
@@ -820,6 +860,9 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
                     options.push(option);
                     if (element.claimURI === DefaultSubjectAttribute) {
                         usernameAdded = true;
+                    }
+                    if (element.claimURI === currentSubjectUri) {
+                        subjectAdded = true;
                     }
                 });
                 if (!usernameAdded) {
@@ -843,9 +886,44 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
                         options.push(option);
                     }
                 }
+                if (!subjectAdded) {
+                    // Preserve a subject claim that isn't part of the currently selected claims so the dropdown
+                    // can render it and it survives round-trips through this form.
+                    const subjectClaim: ExtendedClaimInterface = claims.filter(
+                        (element: ExtendedClaimInterface) => element.claimURI === currentSubjectUri)[ 0 ];
+
+                    if (subjectClaim !== null && typeof subjectClaim !== "undefined") {
+                        options.push({
+                            key: subjectClaim.claimURI,
+                            text: (
+                                <SubjectAttributeListItem
+                                    key={ subjectClaim.id }
+                                    displayName={ subjectClaim.displayName }
+                                    claimURI={ subjectClaim.claimURI }
+                                    value={ subjectClaim.claimURI }
+                                />
+                            ),
+                            value: subjectClaim.claimURI
+                        });
+                    } else {
+                        options.push({
+                            key: currentSubjectUri,
+                            text: (
+                                <SubjectAttributeListItem
+                                    key={ currentSubjectUri }
+                                    displayName={ currentSubjectUri }
+                                    claimURI={ currentSubjectUri }
+                                    value={ currentSubjectUri }
+                                />
+                            ),
+                            value: currentSubjectUri
+                        });
+                    }
+                }
             }
         } else {
             let usernameAdded: boolean = false;
+            let subjectAdded: boolean = !currentSubjectUri || currentSubjectUri === DefaultSubjectAttribute;
 
             unfilteredExternalClaimsGroupedByScopes.map((scope: OIDCScopesClaimsListInterface) => {
                 scope?.claims.map((element: ExtendedExternalClaimInterface) => {
@@ -866,6 +944,9 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
                         options.push(option);
                         if (element.mappedLocalClaimURI === DefaultSubjectAttribute) {
                             usernameAdded = true;
+                        }
+                        if (element.mappedLocalClaimURI === currentSubjectUri) {
+                            subjectAdded = true;
                         }
                     }
                 });
@@ -893,6 +974,44 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
                     };
 
                     options.push(option);
+                }
+            }
+            if (!subjectAdded) {
+                // Preserve a subject claim that isn't in the currently requested claims so the dropdown
+                // can render it and it survives round-trips through this form.
+                const allExternalClaims: ExtendedExternalClaimInterface[] = [
+                    ...externalClaims, ...selectedExternalClaims
+                ];
+                const subjectExternalClaim: ExtendedExternalClaimInterface = allExternalClaims.filter(
+                    (element: ExtendedExternalClaimInterface) =>
+                        element.mappedLocalClaimURI === currentSubjectUri)[ 0 ];
+
+                if (subjectExternalClaim !== null && typeof subjectExternalClaim !== "undefined") {
+                    options.push({
+                        key: subjectExternalClaim.claimURI,
+                        text: (
+                            <SubjectAttributeListItem
+                                key={ subjectExternalClaim.id }
+                                displayName={ subjectExternalClaim.localClaimDisplayName }
+                                claimURI={ subjectExternalClaim.claimURI }
+                                value={ subjectExternalClaim.mappedLocalClaimURI }
+                            />
+                        ),
+                        value: subjectExternalClaim.mappedLocalClaimURI
+                    });
+                } else {
+                    options.push({
+                        key: currentSubjectUri,
+                        text: (
+                            <SubjectAttributeListItem
+                                key={ currentSubjectUri }
+                                displayName={ currentSubjectUri }
+                                claimURI={ currentSubjectUri }
+                                value={ currentSubjectUri }
+                            />
+                        ),
+                        value: currentSubjectUri
+                    });
                 }
             }
         }


### PR DESCRIPTION
## Purpose

Ensure the subject attribute is always surfaced in the application's attribute configuration UI, even when it is not part of the requested/selected/mapped claims. Previously, if the configured subject claim was not among the requested attributes, it would silently drop out of the subject-attribute dropdown and could be lost on subsequent saves.

### Changes

**`attribute-settings.tsx` — `createDropdownOption()`**
- Preserves the currently configured subject claim in the subject-attribute dropdown even when it is not present in the current claim set, across all three code paths:
  - Local dialect with claim mapping on
  - Local dialect with claim mapping off
  - External (OIDC) dialect
- If the corresponding claim object can be resolved, it is rendered with its display name; otherwise it falls back to rendering the raw claim URI so the value still survives round-trips through the form.

**`attribute-list-item.tsx` — `isRequestedCheckboxReadOnly()`**
- Introduced a helper to determine whether the "Requested" checkbox should be read-only.
- When only OIDC is configured, the subject attribute's "Requested" checkbox is no longer force-checked/read-only unless it is actually requested, allowing the subject attribute to be displayed without being marked as requested.

## Related Issue
- https://github.com/wso2/product-is/issues/28148