### PR TITLE
[hotfix] Show Enforce Fapi checkbox in DCR settings only when fapi feature is disabled

### DIFF
--- a/.changeset/old-snails-sell.md
+++ b/.changeset/old-snails-sell.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/admin.application-templates.v1": patch
+---
+
+show Enforce Fapi checkbox only when fapi feature is disabled

--- a/features/admin.applications.v1/pages/applications-settings.tsx
+++ b/features/admin.applications.v1/pages/applications-settings.tsx
@@ -79,9 +79,12 @@ const ApplicationsSettingsForm: FunctionComponent<ApplicationsSettingsPropsInter
 
     const dynamicClientRegistrationFeatureConfig: FeatureAccessConfigInterface = useSelector(
         (state: AppState) => state.config.ui.features.dynamicClientRegistration);
+    const isFapiFeatureEnabled: boolean = useSelector(
+        (state: AppState): boolean => state.config.ui.features?.fapi?.enabled ?? false);
 
     const [ isAuthenticationRequired = true, setAuthenticationRequired ] = useState<boolean>(authenticationRequired);
     const [ isMandateSSA = !isAuthenticationRequired, setMandateSSA ] = useState<boolean>(mandateSSA);
+    const [ isEnableFapiEnforcement, setEnableFapiEnforcement ] = useState<boolean>(enableFapiEnforcement);
     const [ ssaJwksState, setSsaJwks ] = useState<string>(ssaJwks);
     const [ dcrEndpointState, setDCREndpoint ] = useState<string>(dcrEndpoint);
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
@@ -105,6 +108,7 @@ const ApplicationsSettingsForm: FunctionComponent<ApplicationsSettingsPropsInter
         if (dcrConfigs) {
             setMandateSSA(dcrConfigs?.mandateSSA);
             setAuthenticationRequired(dcrConfigs?.authenticationRequired);
+            setEnableFapiEnforcement(dcrConfigs?.enableFapiEnforcement);
             setSsaJwks(dcrConfigs?.ssaJwks);
         }
     }, [ dcrConfigs ]);
@@ -230,6 +234,11 @@ const ApplicationsSettingsForm: FunctionComponent<ApplicationsSettingsPropsInter
             },
             {
                 operation: "REPLACE",
+                path: "/enableFapiEnforcement",
+                value: values.enableFapiEnforcement
+            },
+            {
+                operation: "REPLACE",
                 path: "/mandateSSA",
                 value: values.mandateSSA
             }
@@ -326,6 +335,7 @@ const ApplicationsSettingsForm: FunctionComponent<ApplicationsSettingsPropsInter
                     initialValues={ {
                         authenticationRequired: isAuthenticationRequired,
                         dcrEndpoint: dcrEndpointState,
+                        enableFapiEnforcement: isEnableFapiEnforcement,
                         mandateSSA: isMandateSSA,
                         ssaJwks: ssaJwksState
                     } }
@@ -403,6 +413,19 @@ const ApplicationsSettingsForm: FunctionComponent<ApplicationsSettingsPropsInter
                         readOnly={ !hasDynamicClientRegistrationUpdatePermission }
                         data-componentid={ `${componentId}-ssaJwks-url` }
                     />
+                    { !isFapiFeatureEnabled && (
+                        <Field.Checkbox
+                            ariaLabel="Enforce Fapi"
+                            name="enableFapiEnforcement"
+                            label={ t("applications:forms.applicationsSettings.fields.enforceFapi.label") }
+                            hint={ t("applications:forms.applicationsSettings.fields.enforceFapi.hint") }
+                            tabIndex={ 3 }
+                            width={ 16 }
+                            listen={ (value: boolean) => setEnableFapiEnforcement(value) }
+                            readOnly={ !hasDynamicClientRegistrationUpdatePermission }
+                            data-componentid={ `${componentId}-enableFapiEnforcement-checkbox` }
+                        />
+                    ) }
                     <Field.Button
                         form={ FORM_ID }
                         size="small"

--- a/features/admin.applications.v1/pages/applications-settings.tsx
+++ b/features/admin.applications.v1/pages/applications-settings.tsx
@@ -234,15 +234,20 @@ const ApplicationsSettingsForm: FunctionComponent<ApplicationsSettingsPropsInter
             },
             {
                 operation: "REPLACE",
-                path: "/enableFapiEnforcement",
-                value: values.enableFapiEnforcement
-            },
-            {
-                operation: "REPLACE",
                 path: "/mandateSSA",
                 value: values.mandateSSA
             }
         ];
+
+        if (!isFapiFeatureEnabled) {
+            updateData.push(
+                {
+                    operation: "REPLACE",
+                    path: "/enableFapiEnforcement",
+                    value: values.enableFapiEnforcement
+                }
+            );
+        }
 
         if (values.ssaJwks != undefined) {
             updateData.push(


### PR DESCRIPTION
## Summary
- The "Enforce Fapi" checkbox in the DCR application settings page is now only shown/editable when the `fapi` feature flag is disabled.
- The `/enableFapiEnforcement` PATCH operation is now only submitted when the `fapi` feature is disabled, preventing an unrelated settings save from silently overwriting the hidden global setting.

## Test plan
- [ ] Verify the "Enforce Fapi" checkbox is visible in DCR application settings when the `fapi` feature flag is disabled
- [ ] Verify the checkbox is hidden when the `fapi` feature flag is enabled
- [ ] Verify saving other DCR settings while `fapi` is enabled does not alter `enableFapiEnforcement` on the backend