### PR TITLE
Add multiple client secrets support for OAuth/OIDC applications

### DIFF
--- a/.changeset/rare-cities-eat.md
+++ b/.changeset/rare-cities-eat.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/admin.applications.v1": patch
+"@wso2is/console": patch
+"@wso2is/i18n": patch
+---
+
+Add multiple client secrets support for OAuth/OIDC application

--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -844,8 +844,10 @@
                 {% else %} true,
                 {% endif %}
                 "properties": {
+                    "isMultipleClientSecretsEnabled": {% if oauth.multiple_client_secrets.enable is defined %}{{ oauth.multiple_client_secrets.enable }}{% else %}false{% endif %},
                     "maxGracefulRefreshTokenReuseLimit": {% if oauth.graceful_refresh_token_rotation.maximum_reuse_limit is defined %}{{ oauth.graceful_refresh_token_rotation.maximum_reuse_limit }}{% else %}5{% endif %},
-                    "maxGracefulRefreshTokenRotationValidityPeriod": {% if oauth.graceful_refresh_token_rotation.maximum_validity_period is defined %}{{ oauth.graceful_refresh_token_rotation.maximum_validity_period }}{% else %}60{% endif %}
+                    "maxGracefulRefreshTokenRotationValidityPeriod": {% if oauth.graceful_refresh_token_rotation.maximum_validity_period is defined %}{{ oauth.graceful_refresh_token_rotation.maximum_validity_period }}{% else %}60{% endif %},
+                    "multipleClientSecretsMaxCount": {% if oauth.multiple_client_secrets.secret_count is defined %}{{ oauth.multiple_client_secrets.secret_count }}{% else %}5{% endif %}
                 },
                 "featureFlags": [
                     {% if console.applications.feature_flags is defined %}

--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -847,7 +847,7 @@
                     "isMultipleClientSecretsEnabled": {% if oauth.multiple_client_secrets.enable is defined %}{{ oauth.multiple_client_secrets.enable }}{% else %}false{% endif %},
                     "maxGracefulRefreshTokenReuseLimit": {% if oauth.graceful_refresh_token_rotation.maximum_reuse_limit is defined %}{{ oauth.graceful_refresh_token_rotation.maximum_reuse_limit }}{% else %}5{% endif %},
                     "maxGracefulRefreshTokenRotationValidityPeriod": {% if oauth.graceful_refresh_token_rotation.maximum_validity_period is defined %}{{ oauth.graceful_refresh_token_rotation.maximum_validity_period }}{% else %}60{% endif %},
-                    "multipleClientSecretsMaxCount": {% if oauth.multiple_client_secrets.secret_count is defined %}{{ oauth.multiple_client_secrets.secret_count }}{% else %}5{% endif %}
+                    "multipleClientSecretsMaxCount": {% if oauth.multiple_client_secrets.max_secret_count is defined %}{{ oauth.multiple_client_secrets.max_secret_count }}{% else %}2{% endif %}
                 },
                 "featureFlags": [
                     {% if console.applications.feature_flags is defined %}

--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -844,7 +844,6 @@
                 {% else %} true,
                 {% endif %}
                 "properties": {
-                    "isMultipleClientSecretsEnabled": {% if oauth.multiple_client_secrets.enable is defined %}{{ oauth.multiple_client_secrets.enable }}{% else %}false{% endif %},
                     "maxGracefulRefreshTokenReuseLimit": {% if oauth.graceful_refresh_token_rotation.maximum_reuse_limit is defined %}{{ oauth.graceful_refresh_token_rotation.maximum_reuse_limit }}{% else %}5{% endif %},
                     "maxGracefulRefreshTokenRotationValidityPeriod": {% if oauth.graceful_refresh_token_rotation.maximum_validity_period is defined %}{{ oauth.graceful_refresh_token_rotation.maximum_validity_period }}{% else %}60{% endif %},
                     "multipleClientSecretsMaxCount": {% if oauth.multiple_client_secrets.max_secret_count is defined %}{{ oauth.multiple_client_secrets.max_secret_count }}{% else %}2{% endif %}

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -589,8 +589,10 @@
                 ],
                 "enabled": true,
                 "properties": {
+                    "isMultipleClientSecretsEnabled": true,
                     "maxGracefulRefreshTokenReuseLimit": 5,
-                    "maxGracefulRefreshTokenRotationValidityPeriod": 60
+                    "maxGracefulRefreshTokenRotationValidityPeriod": 60,
+                    "multipleClientSecretsMaxCount": 5
                 },
                 "featureFlags": [
                     {

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -666,10 +666,10 @@
                         "featureFlags": [],
                         "scopes": {
                             "create": [ "internal_application_mgt_client_secret_create" ],
-                            "delete": [],
+                            "delete": [ "internal_application_mgt_client_secret_delete" ],
                             "feature": [],
                             "read": [ "internal_application_mgt_client_secret_view" ],
-                            "update": []
+                            "update": [ "internal_application_mgt_client_secret_regenerate" ]
                         }
                     },
                     "applicationInternalAPIAuthorization": {

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -592,7 +592,7 @@
                     "isMultipleClientSecretsEnabled": true,
                     "maxGracefulRefreshTokenReuseLimit": 5,
                     "maxGracefulRefreshTokenRotationValidityPeriod": 60,
-                    "multipleClientSecretsMaxCount": 5
+                    "multipleClientSecretsMaxCount": 2
                 },
                 "featureFlags": [
                     {

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -589,7 +589,6 @@
                 ],
                 "enabled": true,
                 "properties": {
-                    "isMultipleClientSecretsEnabled": true,
                     "maxGracefulRefreshTokenReuseLimit": 5,
                     "maxGracefulRefreshTokenRotationValidityPeriod": 60,
                     "multipleClientSecretsMaxCount": 2
@@ -668,8 +667,7 @@
                             "create": [ "internal_application_mgt_client_secret_create" ],
                             "delete": [ "internal_application_mgt_client_secret_delete" ],
                             "feature": [],
-                            "read": [ "internal_application_mgt_client_secret_view" ],
-                            "update": [ "internal_application_mgt_client_secret_regenerate" ]
+                            "read": [ "internal_application_mgt_client_secret_view" ]
                         }
                     },
                     "applicationInternalAPIAuthorization": {

--- a/features/admin.applications.v1/api/application.ts
+++ b/features/admin.applications.v1/api/application.ts
@@ -46,6 +46,7 @@ import {
 } from "../models/application";
 import {
     AuthProtocolMetaListItemInterface,
+    ClientSecretCreationRequestInterface,
     OIDCDataInterface,
     SupportedAuthProtocolTypes
 } from "../models/application-inbound";
@@ -862,6 +863,72 @@ export const revokeClientSecret = (appId: string): Promise<any> => {
         .then((response: AxiosResponse) => {
             if ((response.status !== 200)) {
                 return Promise.reject(new Error("Failed to revoke the application secret."));
+            }
+
+            return Promise.resolve(response);
+        }).catch((error: AxiosError<HttpErrorResponseDataInterface>) => {
+            return Promise.reject(error);
+        });
+};
+
+/**
+ * Creates a new client secret for the application.
+ * Used only in the OIDC multiple client secrets flow.
+ *
+ * @param appId - Application ID.
+ * @param secret - Client secret creation request payload.
+ * @returns Response as a promise.
+ */
+export const createClientSecret = (
+    appId: string,
+    secret: ClientSecretCreationRequestInterface
+): Promise<AxiosResponse> => {
+    const requestConfig: AxiosRequestConfig = {
+        data: secret,
+        headers: {
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        },
+        method: HttpMethods.POST,
+        url: store.getState().config.endpoints.applications + "/" + appId +
+            "/inbound-protocols/oidc/secrets"
+    };
+
+    return httpClient(requestConfig)
+        .then((response: AxiosResponse) => {
+            if (response.status !== 201) {
+                return Promise.reject(new Error("Failed to create the client secret."));
+            }
+
+            return Promise.resolve(response);
+        }).catch((error: AxiosError<HttpErrorResponseDataInterface>) => {
+            return Promise.reject(error);
+        });
+};
+
+/**
+ * Deletes a specific client secret of the application.
+ * Used only in the OIDC multiple client secrets flow.
+ *
+ * @param appId - Application ID.
+ * @param secretId - ID of the client secret to delete.
+ * @returns Response as a promise.
+ */
+export const deleteClientSecretById = (appId: string, secretId: string): Promise<AxiosResponse> => {
+    const requestConfig: AxiosRequestConfig = {
+        headers: {
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        },
+        method: HttpMethods.DELETE,
+        url: store.getState().config.endpoints.applications + "/" + appId +
+            "/inbound-protocols/oidc/secrets/" + secretId
+    };
+
+    return httpClient(requestConfig)
+        .then((response: AxiosResponse) => {
+            if (response.status !== 204) {
+                return Promise.reject(new Error("Failed to delete the client secret."));
             }
 
             return Promise.resolve(response);

--- a/features/admin.applications.v1/api/use-get-oauth-client-secrets.ts
+++ b/features/admin.applications.v1/api/use-get-oauth-client-secrets.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import useRequest, { RequestErrorInterface, RequestResultInterface } from "@wso2is/admin.core.v1/hooks/use-request";
+import { store } from "@wso2is/admin.core.v1/store";
+import { HttpMethods } from "@wso2is/core/models";
+import { AxiosRequestConfig } from "axios";
+import { ClientSecretListInterface } from "../models/application-inbound";
+
+/**
+ * Hook to get the list of OAuth2/OIDC client secrets of an application.
+ *
+ * @param appId - ID of the application.
+ * @param shouldFetch - Condition to check if data should be fetched.
+ * @returns Response as a promise.
+ */
+const useGetOAuthClientSecrets = <Data = ClientSecretListInterface, Error = RequestErrorInterface>(
+    appId: string,
+    shouldFetch: boolean = true
+): RequestResultInterface<Data, Error> => {
+
+    const requestConfig: AxiosRequestConfig = {
+        headers: {
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        },
+        method: HttpMethods.GET,
+        url: `${ store.getState().config.endpoints.applications }/${ appId }/inbound-protocols/oidc/secrets`
+    };
+
+    const { data, error, isLoading, isValidating, mutate } = useRequest<Data, Error>(
+        shouldFetch && appId ? requestConfig : null
+    );
+
+    return {
+        data,
+        error,
+        isLoading,
+        isValidating,
+        mutate
+    };
+};
+
+export default useGetOAuthClientSecrets;

--- a/features/admin.applications.v1/components/banners/secret-expiry-banner.tsx
+++ b/features/admin.applications.v1/components/banners/secret-expiry-banner.tsx
@@ -18,7 +18,7 @@
 
 import Alert from "@oxygen-ui/react/Alert";
 import AlertTitle from "@oxygen-ui/react/AlertTitle";
-import Link from "@oxygen-ui/react/Link";
+import Button from "@oxygen-ui/react/Button";
 import { FeatureAccessConfigInterface, useRequiredScopes } from "@wso2is/access-control";
 import { AppState } from "@wso2is/admin.core.v1/store";
 import { ApplicationTabIDs } from "@wso2is/admin.extensions.v1";
@@ -99,14 +99,15 @@ const SecretExpiryBanner: FunctionComponent<SecretExpiryBannerPropsInterface> = 
             severity="warning"
             sx={ { marginBottom: 2 } }
             action={ (
-                <Link
+                <Button
+                    className="banner-view-hide-details"
                     onClick={ (): void => {
                         window.location.hash = TAB_URL_HASH_FRAGMENT + ApplicationTabIDs.PROTOCOL;
                     } }
-                    data-componentid={ `${ componentId }-view-details-link` }
+                    data-componentid={ `${ componentId }-view-secrets-button` }
                 >
-                    { t("applications:clientSecrets.expiryBanner.viewDetails") }
-                </Link>
+                    { t("applications:clientSecrets.expiryBanner.viewSecrets") }
+                </Button>
             ) }
             data-componentid={ componentId }
         >

--- a/features/admin.applications.v1/components/banners/secret-expiry-banner.tsx
+++ b/features/admin.applications.v1/components/banners/secret-expiry-banner.tsx
@@ -19,17 +19,15 @@
 import Alert from "@oxygen-ui/react/Alert";
 import AlertTitle from "@oxygen-ui/react/AlertTitle";
 import Button from "@oxygen-ui/react/Button";
-import { FeatureAccessConfigInterface, useRequiredScopes } from "@wso2is/access-control";
-import { AppState } from "@wso2is/admin.core.v1/store";
 import { ApplicationTabIDs } from "@wso2is/admin.extensions.v1";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import { TAB_URL_HASH_FRAGMENT } from "@wso2is/react-components";
-import React, { FunctionComponent, ReactElement } from "react";
+import React, { FunctionComponent, ReactElement, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { useSelector } from "react-redux";
 import useGetOAuthClientSecrets from "../../api/use-get-oauth-client-secrets";
+import useClientSecretManagement from "../../hooks/use-client-secret-management";
 import { ClientSecretListInterface } from "../../models/application-inbound";
-import { hasCriticallyExpiringSecret } from "../client-secrets/client-secret-utils";
+import { hasSecretsAboutToExpire } from "../client-secrets/client-secret-utils";
 
 /**
  * Props for the secret expiry banner component.
@@ -47,10 +45,18 @@ interface SecretExpiryBannerPropsInterface extends IdentifiableComponentInterfac
      * Whether the application is a public client (SPA/mobile), which has no client secret.
      */
     isPublicClient?: boolean;
+    /**
+     * Expiry of the latest client secret as Unix epoch seconds (0 when it does not expire).
+     */
+    latestClientSecretExpiresAt?: number;
+    /**
+     * Whether the application has more than one client secret configured.
+     */
+    multipleClientSecretsConfigured?: boolean;
 }
 
 /**
- * Banner that warns when a client secret is about to expire or has already expired.
+ * Banner that warns when a client secret is about to expire.
  *
  * @param props - Props injected to the component.
  * @returns Secret expiry banner or null when no secret needs attention.
@@ -63,34 +69,54 @@ const SecretExpiryBanner: FunctionComponent<SecretExpiryBannerPropsInterface> = 
         appId,
         isOIDCApplication,
         isPublicClient,
+        latestClientSecretExpiresAt,
+        multipleClientSecretsConfigured,
         [ "data-componentid" ]: componentId = "secret-expiry-banner"
     } = props;
 
     const { t } = useTranslation();
 
-    const isMultipleClientSecretsEnabled: boolean = useSelector((state: AppState) =>
-        Boolean(state?.config?.ui?.features?.applications?.properties?.isMultipleClientSecretsEnabled));
-    const applicationFeatureConfig: FeatureAccessConfigInterface = useSelector((state: AppState) =>
-        state?.config?.ui?.features?.applications);
-
-    const hasClientSecretViewPermission: boolean = useRequiredScopes(
-        applicationFeatureConfig?.subFeatures?.applicationClientSecretManagement?.scopes?.read ?? []);
+    const {
+        hasClientSecretReadPermission,
+        isEnforceClientSecretPermissionEnabled,
+        maxSecretCount
+    } = useClientSecretManagement();
 
     /*
-     * The banner only applies when multiple client secrets is enabled, so the GET /secrets view scope
-     * is always required (the skip-enforce flag governs only the legacy single-secret path).
+     * The latest secret's expiry is known from the loaded OIDC configuration regardless of the secret
+     * capacity, so the banner applies to single-secret deployments as well. Its visibility mirrors the
+     * protocol tab's latest secret display gate.
      */
-    const shouldFetch: boolean = isMultipleClientSecretsEnabled && isOIDCApplication && !isPublicClient
-        && hasClientSecretViewPermission && !!appId;
+    const isBannerApplicable: boolean = Boolean(
+        isOIDCApplication &&
+        !isPublicClient &&
+        appId &&
+        (!isEnforceClientSecretPermissionEnabled || hasClientSecretReadPermission)
+    );
+
+    const isLatestSecretAboutToExpire: boolean = isBannerApplicable && hasSecretsAboutToExpire([
+        { expiresAt: latestClientSecretExpiresAt }
+    ]);
+
+    const shouldFetch: boolean = isBannerApplicable
+        && (maxSecretCount > 1 && hasClientSecretReadPermission)
+        && Boolean(multipleClientSecretsConfigured)
+        && !isLatestSecretAboutToExpire;
 
     const { data: clientSecretList } = useGetOAuthClientSecrets<ClientSecretListInterface>(appId, shouldFetch);
 
-    if (!shouldFetch) {
+    const handleViewSecrets: () => void = useCallback((): void => {
+        window.location.hash = TAB_URL_HASH_FRAGMENT + ApplicationTabIDs.PROTOCOL;
+    }, []);
+
+    if (!isBannerApplicable) {
         return null;
     }
 
-    /* Show a single generic banner when at least one secret is within the critical expiry window. */
-    if (!hasCriticallyExpiringSecret(clientSecretList?.list ?? [])) {
+    const isPreviousSecretAboutToExpire: boolean =
+        !isLatestSecretAboutToExpire && hasSecretsAboutToExpire(clientSecretList?.list ?? []);
+
+    if (!isLatestSecretAboutToExpire && !isPreviousSecretAboutToExpire) {
         return null;
     }
 
@@ -101,9 +127,7 @@ const SecretExpiryBanner: FunctionComponent<SecretExpiryBannerPropsInterface> = 
             action={ (
                 <Button
                     className="banner-view-hide-details"
-                    onClick={ (): void => {
-                        window.location.hash = TAB_URL_HASH_FRAGMENT + ApplicationTabIDs.PROTOCOL;
-                    } }
+                    onClick={ handleViewSecrets }
                     data-componentid={ `${ componentId }-view-secrets-button` }
                 >
                     { t("applications:clientSecrets.expiryBanner.viewSecrets") }

--- a/features/admin.applications.v1/components/banners/secret-expiry-banner.tsx
+++ b/features/admin.applications.v1/components/banners/secret-expiry-banner.tsx
@@ -22,14 +22,12 @@ import Link from "@oxygen-ui/react/Link";
 import { FeatureAccessConfigInterface, useRequiredScopes } from "@wso2is/access-control";
 import { AppState } from "@wso2is/admin.core.v1/store";
 import { ApplicationTabIDs } from "@wso2is/admin.extensions.v1";
-import { isFeatureEnabled } from "@wso2is/core/helpers";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import { TAB_URL_HASH_FRAGMENT } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import useGetOAuthClientSecrets from "../../api/use-get-oauth-client-secrets";
-import { ApplicationFeatureDictionaryKeys, ApplicationManagementConstants } from "../../constants/application-management";
 import { ClientSecretListInterface } from "../../models/application-inbound";
 import { hasCriticallyExpiringSecret } from "../client-secrets/client-secret-utils";
 
@@ -59,7 +57,7 @@ interface SecretExpiryBannerPropsInterface extends IdentifiableComponentInterfac
  */
 const SecretExpiryBanner: FunctionComponent<SecretExpiryBannerPropsInterface> = (
     props: SecretExpiryBannerPropsInterface
-): ReactElement => {
+): ReactElement | null => {
 
     const {
         appId,
@@ -75,18 +73,15 @@ const SecretExpiryBanner: FunctionComponent<SecretExpiryBannerPropsInterface> = 
     const applicationFeatureConfig: FeatureAccessConfigInterface = useSelector((state: AppState) =>
         state?.config?.ui?.features?.applications);
 
-    const isEnforceClientSecretPermissionEnabled: boolean = isFeatureEnabled(
-        applicationFeatureConfig,
-        ApplicationManagementConstants.FEATURE_DICTIONARY.get(
-            ApplicationFeatureDictionaryKeys.ApplicationEditEnforceClientSecretPermission)
-    );
-    const hasClientSecretReadPermission: boolean = useRequiredScopes(
-        applicationFeatureConfig?.subFeatures?.applicationClientSecretManagement?.scopes?.read);
+    const hasClientSecretViewPermission: boolean = useRequiredScopes(
+        applicationFeatureConfig?.subFeatures?.applicationClientSecretManagement?.scopes?.read ?? []);
 
-    /* Suppress the banner (and the underlying secrets fetch) when the user lacks the view permission. */
-    const hasViewPermission: boolean = !isEnforceClientSecretPermissionEnabled || hasClientSecretReadPermission;
+    /*
+     * The banner only applies when multiple client secrets is enabled, so the GET /secrets view scope
+     * is always required (the skip-enforce flag governs only the legacy single-secret path).
+     */
     const shouldFetch: boolean = isMultipleClientSecretsEnabled && isOIDCApplication && !isPublicClient
-        && hasViewPermission && !!appId;
+        && hasClientSecretViewPermission && !!appId;
 
     const { data: clientSecretList } = useGetOAuthClientSecrets<ClientSecretListInterface>(appId, shouldFetch);
 

--- a/features/admin.applications.v1/components/banners/secret-expiry-banner.tsx
+++ b/features/admin.applications.v1/components/banners/secret-expiry-banner.tsx
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Alert from "@oxygen-ui/react/Alert";
+import AlertTitle from "@oxygen-ui/react/AlertTitle";
+import { FeatureAccessConfigInterface, useRequiredScopes } from "@wso2is/access-control";
+import { AppState } from "@wso2is/admin.core.v1/store";
+import { isFeatureEnabled } from "@wso2is/core/helpers";
+import { IdentifiableComponentInterface } from "@wso2is/core/models";
+import React, { FunctionComponent, ReactElement, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useSelector } from "react-redux";
+import useGetOAuthClientSecrets from "../../api/use-get-oauth-client-secrets";
+import { ApplicationFeatureDictionaryKeys, ApplicationManagementConstants } from "../../constants/application-management";
+import { ClientSecretListInterface } from "../../models/application-inbound";
+import { hasCriticallyExpiringSecret } from "../client-secrets/client-secret-utils";
+
+/**
+ * Props for the secret expiry banner component.
+ */
+interface SecretExpiryBannerPropsInterface extends IdentifiableComponentInterface {
+    /**
+     * ID of the application.
+     */
+    appId: string;
+    /**
+     * Whether the application has an OIDC inbound protocol configured.
+     */
+    isOIDCApplication: boolean;
+    /**
+     * Whether the application is a public client (SPA/mobile), which has no client secret.
+     */
+    isPublicClient?: boolean;
+}
+
+/**
+ * Banner that warns when a client secret is about to expire or has already expired.
+ *
+ * @param props - Props injected to the component.
+ * @returns Secret expiry banner or null when no secret needs attention.
+ */
+const SecretExpiryBanner: FunctionComponent<SecretExpiryBannerPropsInterface> = (
+    props: SecretExpiryBannerPropsInterface
+): ReactElement => {
+
+    const {
+        appId,
+        isOIDCApplication,
+        isPublicClient,
+        [ "data-componentid" ]: componentId = "secret-expiry-banner"
+    } = props;
+
+    const { t } = useTranslation();
+
+    const isMultipleClientSecretsEnabled: boolean = useSelector((state: AppState) =>
+        Boolean(state?.config?.ui?.features?.applications?.properties?.isMultipleClientSecretsEnabled));
+    const applicationFeatureConfig: FeatureAccessConfigInterface = useSelector((state: AppState) =>
+        state?.config?.ui?.features?.applications);
+
+    const isEnforceClientSecretPermissionEnabled: boolean = isFeatureEnabled(
+        applicationFeatureConfig,
+        ApplicationManagementConstants.FEATURE_DICTIONARY.get(
+            ApplicationFeatureDictionaryKeys.ApplicationEditEnforceClientSecretPermission)
+    );
+    const hasClientSecretReadPermission: boolean = useRequiredScopes(
+        applicationFeatureConfig?.subFeatures?.applicationClientSecretManagement?.scopes?.read);
+
+    const [ dismissed, setDismissed ] = useState<boolean>(false);
+
+    /* Suppress the banner (and the underlying secrets fetch) when the user lacks the view permission. */
+    const hasViewPermission: boolean = !isEnforceClientSecretPermissionEnabled || hasClientSecretReadPermission;
+    const shouldFetch: boolean = isMultipleClientSecretsEnabled && isOIDCApplication && !isPublicClient
+        && hasViewPermission && !!appId;
+
+    const { data: clientSecretList } = useGetOAuthClientSecrets<ClientSecretListInterface>(appId, shouldFetch);
+
+    if (dismissed || !shouldFetch) {
+        return null;
+    }
+
+    /* Show a single generic banner when at least one secret is within the critical expiry window. */
+    if (!hasCriticallyExpiringSecret(clientSecretList?.list ?? [])) {
+        return null;
+    }
+
+    return (
+        <Alert
+            severity="warning"
+            onClose={ (): void => setDismissed(true) }
+            sx={ { marginBottom: 2 } }
+            data-componentid={ componentId }
+        >
+            <AlertTitle>
+                { t("applications:clientSecrets.expiryBanner.title") }
+            </AlertTitle>
+            { t("applications:clientSecrets.expiryBanner.description") }
+        </Alert>
+    );
+};
+
+export default SecretExpiryBanner;

--- a/features/admin.applications.v1/components/banners/secret-expiry-banner.tsx
+++ b/features/admin.applications.v1/components/banners/secret-expiry-banner.tsx
@@ -18,11 +18,14 @@
 
 import Alert from "@oxygen-ui/react/Alert";
 import AlertTitle from "@oxygen-ui/react/AlertTitle";
+import Link from "@oxygen-ui/react/Link";
 import { FeatureAccessConfigInterface, useRequiredScopes } from "@wso2is/access-control";
 import { AppState } from "@wso2is/admin.core.v1/store";
+import { ApplicationTabIDs } from "@wso2is/admin.extensions.v1";
 import { isFeatureEnabled } from "@wso2is/core/helpers";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
-import React, { FunctionComponent, ReactElement, useState } from "react";
+import { TAB_URL_HASH_FRAGMENT } from "@wso2is/react-components";
+import React, { FunctionComponent, ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import useGetOAuthClientSecrets from "../../api/use-get-oauth-client-secrets";
@@ -80,8 +83,6 @@ const SecretExpiryBanner: FunctionComponent<SecretExpiryBannerPropsInterface> = 
     const hasClientSecretReadPermission: boolean = useRequiredScopes(
         applicationFeatureConfig?.subFeatures?.applicationClientSecretManagement?.scopes?.read);
 
-    const [ dismissed, setDismissed ] = useState<boolean>(false);
-
     /* Suppress the banner (and the underlying secrets fetch) when the user lacks the view permission. */
     const hasViewPermission: boolean = !isEnforceClientSecretPermissionEnabled || hasClientSecretReadPermission;
     const shouldFetch: boolean = isMultipleClientSecretsEnabled && isOIDCApplication && !isPublicClient
@@ -89,7 +90,7 @@ const SecretExpiryBanner: FunctionComponent<SecretExpiryBannerPropsInterface> = 
 
     const { data: clientSecretList } = useGetOAuthClientSecrets<ClientSecretListInterface>(appId, shouldFetch);
 
-    if (dismissed || !shouldFetch) {
+    if (!shouldFetch) {
         return null;
     }
 
@@ -101,8 +102,17 @@ const SecretExpiryBanner: FunctionComponent<SecretExpiryBannerPropsInterface> = 
     return (
         <Alert
             severity="warning"
-            onClose={ (): void => setDismissed(true) }
             sx={ { marginBottom: 2 } }
+            action={ (
+                <Link
+                    onClick={ (): void => {
+                        window.location.hash = TAB_URL_HASH_FRAGMENT + ApplicationTabIDs.PROTOCOL;
+                    } }
+                    data-componentid={ `${ componentId }-view-details-link` }
+                >
+                    { t("applications:clientSecrets.expiryBanner.viewDetails") }
+                </Link>
+            ) }
             data-componentid={ componentId }
         >
             <AlertTitle>

--- a/features/admin.applications.v1/components/client-secrets/client-secret-row.scss
+++ b/features/admin.applications.v1/components/client-secrets/client-secret-row.scss
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.client-secret-row {
+    margin-bottom: 1rem;
+
+    .client-secret-row-main {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+    }
+
+    .client-secret-row-action {
+        flex: 0 0 auto;
+        display: flex;
+        align-items: center;
+    }
+}

--- a/features/admin.applications.v1/components/client-secrets/client-secret-row.tsx
+++ b/features/admin.applications.v1/components/client-secrets/client-secret-row.tsx
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { IdentifiableComponentInterface } from "@wso2is/core/models";
+import React, { FunctionComponent, ReactElement, ReactNode } from "react";
+import ClientSecretStatus from "./client-secret-status";
+import ClientSecretValueField from "./client-secret-value-field";
+import "./client-secret-row.scss";
+import { ClientSecretInterface } from "../../models/application-inbound";
+
+/**
+ * Props for the client secret row.
+ */
+interface ClientSecretRowPropsInterface extends IdentifiableComponentInterface {
+    /**
+     * Client secret rendered by this row.
+     */
+    secret: ClientSecretInterface;
+    /**
+     * Whether the secret value is unavailable (client secret hashing enabled).
+     */
+    hideSecretValue?: boolean;
+    /**
+     * Action rendered beside the secret value — the "Generate New Secret" button for the current
+     * secret, or the delete icon for a previous secret.
+     */
+    action?: ReactNode;
+}
+
+/**
+ * A client secret row composed of two parts: the secret value field and an action (generate button
+ * or delete icon), with the coloured status line beneath.
+ *
+ * @param props - Props injected to the component.
+ * @returns Client secret row.
+ */
+const ClientSecretRow: FunctionComponent<ClientSecretRowPropsInterface> = (
+    props: ClientSecretRowPropsInterface
+): ReactElement => {
+
+    const {
+        secret,
+        hideSecretValue,
+        action,
+        [ "data-componentid" ]: componentId = "client-secret-row"
+    } = props;
+
+    return (
+        <div className="client-secret-row" data-componentid={ componentId }>
+            <div className="client-secret-row-main">
+                <ClientSecretValueField
+                    value={ secret?.secretValue }
+                    hideSecretValue={ hideSecretValue }
+                    data-componentid={ `${ componentId }-value` }
+                />
+                { action && (
+                    <div className="client-secret-row-action">
+                        { action }
+                    </div>
+                ) }
+            </div>
+            <ClientSecretStatus secret={ secret } data-componentid={ `${ componentId }-status` } />
+        </div>
+    );
+};
+
+export default ClientSecretRow;

--- a/features/admin.applications.v1/components/client-secrets/client-secret-status.scss
+++ b/features/admin.applications.v1/components/client-secrets/client-secret-status.scss
@@ -17,15 +17,22 @@
  */
 
 .client-secret-status {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
     margin-top: 0.4rem;
     font-size: 0.8125rem;
-    color: var(--oxygen-palette-text-secondary, #6d7175);
 
-    .client-secret-status-dot {
-        flex: 0 0 auto;
-        margin: 0;
+    .client-secret-status-text {
+        cursor: default;
+    }
+
+    .client-secret-status-active {
+        color: var(--oxygen-palette-text-secondary, #6d7175);
+    }
+
+    .client-secret-status-expiring {
+        color: var(--oxygen-palette-warning-main);
+    }
+
+    .client-secret-status-expired {
+        color: var(--oxygen-palette-error-main);
     }
 }

--- a/features/admin.applications.v1/components/client-secrets/client-secret-status.scss
+++ b/features/admin.applications.v1/components/client-secrets/client-secret-status.scss
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.client-secret-status {
+    display: flex;
+    align-items: center;
+    margin-top: 0.4rem;
+    font-size: 0.8125rem;
+    color: var(--oxygen-palette-text-secondary, #6d7175);
+
+    .client-secret-status-dot {
+        flex: 0 0 auto;
+    }
+}

--- a/features/admin.applications.v1/components/client-secrets/client-secret-status.scss
+++ b/features/admin.applications.v1/components/client-secrets/client-secret-status.scss
@@ -19,11 +19,13 @@
 .client-secret-status {
     display: flex;
     align-items: center;
+    gap: 0.5rem;
     margin-top: 0.4rem;
     font-size: 0.8125rem;
     color: var(--oxygen-palette-text-secondary, #6d7175);
 
     .client-secret-status-dot {
         flex: 0 0 auto;
+        margin: 0;
     }
 }

--- a/features/admin.applications.v1/components/client-secrets/client-secret-status.tsx
+++ b/features/admin.applications.v1/components/client-secrets/client-secret-status.tsx
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { IdentifiableComponentInterface } from "@wso2is/core/models";
+import React, { FunctionComponent, ReactElement } from "react";
+import { useTranslation } from "react-i18next";
+import { Label, SemanticCOLORS } from "semantic-ui-react";
+import { ClientSecretExpiryState, resolveClientSecretExpiry } from "./client-secret-utils";
+import "./client-secret-status.scss";
+import { ClientSecretInterface } from "../../models/application-inbound";
+
+/**
+ * Props for the client secret status line.
+ */
+interface ClientSecretStatusPropsInterface extends IdentifiableComponentInterface {
+    /**
+     * Client secret whose status is rendered.
+     */
+    secret: ClientSecretInterface;
+}
+
+/**
+ * Renders the coloured status line of a client secret — e.g. "● Active : Expires on Sat, Sep 1 2026".
+ *
+ * @param props - Props injected to the component.
+ * @returns Client secret status line.
+ */
+const ClientSecretStatus: FunctionComponent<ClientSecretStatusPropsInterface> = (
+    props: ClientSecretStatusPropsInterface
+): ReactElement => {
+
+    const {
+        secret,
+        [ "data-componentid" ]: componentId = "client-secret-status"
+    } = props;
+
+    const { t } = useTranslation();
+
+    const { state, formattedDate } = resolveClientSecretExpiry(secret);
+
+    const resolveLabel = (): string => {
+        switch (state) {
+            case ClientSecretExpiryState.EXPIRED:
+                return t("applications:clientSecrets.status.expired");
+            case ClientSecretExpiryState.EXPIRING_WARNING:
+            case ClientSecretExpiryState.EXPIRING_CRITICAL:
+                return t("applications:clientSecrets.status.expiresSoon");
+            default:
+                return t("applications:clientSecrets.status.active");
+        }
+    };
+
+    const resolveExpiryText = (): string => {
+        switch (state) {
+            case ClientSecretExpiryState.NEVER:
+                return t("applications:clientSecrets.expiry.neverExpires");
+            case ClientSecretExpiryState.EXPIRED:
+                return t("applications:clientSecrets.expiry.expiredOn", { date: formattedDate });
+            default:
+                return t("applications:clientSecrets.expiry.expiresOn", { date: formattedDate });
+        }
+    };
+
+    /* Colours match the connection status dot (LabelWithPopup) used across the console. */
+    const resolveColor = (): SemanticCOLORS => {
+        switch (state) {
+            case ClientSecretExpiryState.EXPIRED:
+                return "grey";
+            case ClientSecretExpiryState.EXPIRING_CRITICAL:
+                return "red";
+            case ClientSecretExpiryState.EXPIRING_WARNING:
+                return "yellow";
+            default:
+                return "green";
+        }
+    };
+
+    return (
+        <div className="client-secret-status" data-componentid={ componentId }>
+            <Label circular empty size="mini" color={ resolveColor() } className="client-secret-status-dot" />
+            <span className="client-secret-status-text">
+                { `${ resolveLabel() } : ${ resolveExpiryText() }` }
+            </span>
+        </div>
+    );
+};
+
+export default ClientSecretStatus;

--- a/features/admin.applications.v1/components/client-secrets/client-secret-status.tsx
+++ b/features/admin.applications.v1/components/client-secrets/client-secret-status.tsx
@@ -17,12 +17,23 @@
  */
 
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
+import { Popup } from "@wso2is/react-components";
+import classNames from "classnames";
 import React, { FunctionComponent, ReactElement } from "react";
 import { useTranslation } from "react-i18next";
-import { Label, SemanticCOLORS } from "semantic-ui-react";
 import { ClientSecretExpiryState, resolveClientSecretExpiry } from "./client-secret-utils";
 import "./client-secret-status.scss";
 import { ClientSecretInterface } from "../../models/application-inbound";
+
+/**
+ * Status text class name of each expiry state.
+ */
+const STATE_CLASS_NAMES: Record<ClientSecretExpiryState, string> = {
+    [ ClientSecretExpiryState.ACTIVE ]: "client-secret-status-active",
+    [ ClientSecretExpiryState.NEVER ]: "client-secret-status-active",
+    [ ClientSecretExpiryState.EXPIRING ]: "client-secret-status-expiring",
+    [ ClientSecretExpiryState.EXPIRED ]: "client-secret-status-expired"
+};
 
 /**
  * Props for the client secret status line.
@@ -35,7 +46,7 @@ interface ClientSecretStatusPropsInterface extends IdentifiableComponentInterfac
 }
 
 /**
- * Renders the coloured status line of a client secret — e.g. "● Active : Expires on Sat, Sep 1 2026".
+ * Renders the expiry status of a client secret as coloured text; hovering reveals the exact date.
  *
  * @param props - Props injected to the component.
  * @returns Client secret status line.
@@ -51,51 +62,50 @@ const ClientSecretStatus: FunctionComponent<ClientSecretStatusPropsInterface> = 
 
     const { t } = useTranslation();
 
-    const { state, formattedDate } = resolveClientSecretExpiry(secret);
+    const { state, humanizedExpiry, formattedDate } = resolveClientSecretExpiry(secret);
 
-    const resolveLabel = (): string => {
-        switch (state) {
-            case ClientSecretExpiryState.EXPIRED:
-                return t("applications:clientSecrets.status.expired");
-            case ClientSecretExpiryState.EXPIRING_WARNING:
-            case ClientSecretExpiryState.EXPIRING_CRITICAL:
-                return t("applications:clientSecrets.status.expiresSoon");
-            default:
-                return t("applications:clientSecrets.status.active");
-        }
-    };
+    let statusMessage: string;
 
-    const resolveExpiryText = (): string => {
-        switch (state) {
-            case ClientSecretExpiryState.NEVER:
-                return t("applications:clientSecrets.expiry.neverExpires");
-            case ClientSecretExpiryState.EXPIRED:
-                return t("applications:clientSecrets.expiry.expiredOn", { date: formattedDate });
-            default:
-                return t("applications:clientSecrets.expiry.expiresOn", { date: formattedDate });
-        }
-    };
+    if (state === ClientSecretExpiryState.NEVER) {
+        statusMessage = t("applications:clientSecrets.expiry.neverExpires");
+    } else if (state === ClientSecretExpiryState.EXPIRED) {
+        statusMessage = humanizedExpiry
+            ? t("applications:clientSecrets.expiry.expiredAgo", { duration: humanizedExpiry })
+            : t("applications:clientSecrets.expiry.expired");
+    } else {
+        statusMessage = t("applications:clientSecrets.expiry.expiresIn", { duration: humanizedExpiry });
+    }
 
-    /* Colours match the connection status dot (LabelWithPopup) used across the console. */
-    const resolveColor = (): SemanticCOLORS => {
-        switch (state) {
-            case ClientSecretExpiryState.EXPIRED:
-                return "grey";
-            case ClientSecretExpiryState.EXPIRING_CRITICAL:
-                return "red";
-            case ClientSecretExpiryState.EXPIRING_WARNING:
-                return "yellow";
-            default:
-                return "green";
-        }
-    };
+    let tooltipMessage: string | null = null;
+
+    if (formattedDate) {
+        tooltipMessage = state === ClientSecretExpiryState.EXPIRED
+            ? t("applications:clientSecrets.expiry.expiredOn", { date: formattedDate })
+            : t("applications:clientSecrets.expiry.expiresOn", { date: formattedDate });
+    }
+
+    const statusElement: ReactElement = (
+        <span
+            className={ classNames("client-secret-status-text", STATE_CLASS_NAMES[ state ]) }
+            data-componentid={ `${ componentId }-text` }
+        >
+            { statusMessage }
+        </span>
+    );
 
     return (
         <div className="client-secret-status" data-componentid={ componentId }>
-            <Label circular empty size="mini" color={ resolveColor() } className="client-secret-status-dot" />
-            <span className="client-secret-status-text">
-                { `${ resolveLabel() } : ${ resolveExpiryText() }` }
-            </span>
+            { tooltipMessage
+                ? (
+                    <Popup
+                        trigger={ statusElement }
+                        content={ tooltipMessage }
+                        position="right center"
+                        size="mini"
+                        inverted
+                    />
+                )
+                : statusElement }
         </div>
     );
 };

--- a/features/admin.applications.v1/components/client-secrets/client-secret-utils.ts
+++ b/features/admin.applications.v1/components/client-secrets/client-secret-utils.ts
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import dayjs from "dayjs";
 import { ClientSecretInterface, ClientSecretStatus } from "../../models/application-inbound";
 
 /**
@@ -55,12 +56,7 @@ export const resolveClientSecretExpiry = (
     referenceTime: number = Date.now()
 ): { state: ClientSecretExpiryState; formattedDate: string | null } => {
 
-    const formatDate = (epochSeconds: number): string => new Date(epochSeconds * 1000).toLocaleDateString("en-US", {
-        day: "numeric",
-        month: "short",
-        weekday: "short",
-        year: "numeric"
-    });
+    const formatDate = (epochSeconds: number): string => dayjs.unix(epochSeconds).format("ddd, MMM D, YYYY");
 
     if (secret?.status === ClientSecretStatus.EXPIRED) {
         return {

--- a/features/admin.applications.v1/components/client-secrets/client-secret-utils.ts
+++ b/features/admin.applications.v1/components/client-secrets/client-secret-utils.ts
@@ -16,94 +16,93 @@
  * under the License.
  */
 
-import dayjs from "dayjs";
+import dayjs, { Dayjs } from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
 import { ClientSecretInterface, ClientSecretStatus } from "../../models/application-inbound";
 
+dayjs.extend(relativeTime);
+
 /**
- * Expiry thresholds (in days) used to classify how soon a client secret expires. Hardcoded in the
- * console (not deployment configurable).
+ * Number of days before expiry at which a client secret is considered about to expire. Hardcoded in
+ * the console (not deployment configurable).
  */
-const EXPIRY_WARNING_DAYS: number = 20;
-const EXPIRY_CRITICAL_DAYS: number = 10;
-
-const MILLISECONDS_PER_DAY: number = 24 * 60 * 60 * 1000;
+const EXPIRY_THRESHOLD_DAYS: number = 14;
 
 /**
- * Expiry state of a client secret, mapped to the status dot colour.
+ * Expiry state of a client secret.
  */
 export enum ClientSecretExpiryState {
-    /** Green — not expiring anytime soon. */
+    // Not expiring anytime soon.
     ACTIVE = "active",
-    /** Green — never expires. */
+    // Never expires.
     NEVER = "never",
-    /** Yellow — expiring within the warning window. */
-    EXPIRING_WARNING = "expiringWarning",
-    /** Red — expiring within the critical window. */
-    EXPIRING_CRITICAL = "expiringCritical",
-    /** Grey — already expired. */
+    // Within the expiry threshold window; also drives the expiry banner.
+    EXPIRING = "expiring",
+    // Already expired.
     EXPIRED = "expired"
 }
 
 /**
- * Resolves the expiry state and a human-readable expiry date of a client secret.
+ * Resolves the expiry state, humanized expiry duration, and exact expiry date of a client secret.
  *
  * @param secret - Client secret metadata.
  * @param referenceTime - Epoch milliseconds to evaluate the expiry against.
- * @returns Resolved expiry details.
+ * @returns Resolved expiry details. `humanizedExpiry` is the duration to/from expiry without a suffix
+ * (e.g. "20 days", "a month"); both it and `formattedDate` are null when there is no expiry timestamp.
  */
 export const resolveClientSecretExpiry = (
     secret: ClientSecretInterface,
     referenceTime: number = Date.now()
-): { state: ClientSecretExpiryState; formattedDate: string | null } => {
+): { state: ClientSecretExpiryState; humanizedExpiry: string | null; formattedDate: string | null } => {
 
-    const formatDate = (epochSeconds: number): string => dayjs.unix(epochSeconds).format("ddd, MMM D, YYYY");
+    const expiresAt: number | undefined = secret?.expiresAt;
 
-    if (secret?.status === ClientSecretStatus.EXPIRED) {
-        return {
-            formattedDate: secret?.expiresAt ? formatDate(secret.expiresAt) : null,
-            state: ClientSecretExpiryState.EXPIRED
-        };
-    }
-
-    if (!secret?.expiresAt) {
+    if (!expiresAt) {
+        /* No expiry timestamp: trust an API-stamped EXPIRED status; otherwise the secret never expires. */
         return {
             formattedDate: null,
-            state: ClientSecretExpiryState.NEVER
+            humanizedExpiry: null,
+            state: secret?.status === ClientSecretStatus.EXPIRED
+                ? ClientSecretExpiryState.EXPIRED
+                : ClientSecretExpiryState.NEVER
         };
     }
 
-    const daysRemaining: number = Math.ceil((secret.expiresAt * 1000 - referenceTime) / MILLISECONDS_PER_DAY);
-    const formattedDate: string = formatDate(secret.expiresAt);
+    const expiryDate: Dayjs = dayjs.unix(expiresAt);
+    const refDate: Dayjs = dayjs(referenceTime);
 
-    /* The secret is active here (EXPIRED is trusted from the API above); classify how soon it expires. */
-    let state: ClientSecretExpiryState;
+    const formattedDate: string = expiryDate.format("ddd, MMM D, YYYY");
+    const humanizedExpiry: string = expiryDate.from(refDate, true);
 
-    if (daysRemaining <= EXPIRY_CRITICAL_DAYS) {
-        state = ClientSecretExpiryState.EXPIRING_CRITICAL;
-    } else if (daysRemaining <= EXPIRY_WARNING_DAYS) {
-        state = ClientSecretExpiryState.EXPIRING_WARNING;
-    } else {
-        state = ClientSecretExpiryState.ACTIVE;
+    /*
+     * A secret is expired when the API says so, or when its expiry timestamp is already in the past —
+     * the latest secret is built from the OIDC configuration without an API status.
+     */
+    if (secret?.status === ClientSecretStatus.EXPIRED || expiresAt * 1000 <= referenceTime) {
+        return { formattedDate, humanizedExpiry, state: ClientSecretExpiryState.EXPIRED };
     }
 
-    return { formattedDate, state };
+    const daysRemaining: number = expiryDate.diff(refDate, "day");
+    const state: ClientSecretExpiryState = daysRemaining <= EXPIRY_THRESHOLD_DAYS
+        ? ClientSecretExpiryState.EXPIRING
+        : ClientSecretExpiryState.ACTIVE;
+
+    return { formattedDate, humanizedExpiry, state };
 };
 
 /**
- * Whether at least one active client secret is within the critical expiry window.
+ * Whether at least one client secret is about to expire.
  *
  * @param secrets - List of client secrets.
  * @param referenceTime - Epoch milliseconds to evaluate the expiry against.
- * @returns True when any active secret is critically close to expiry.
+ * @returns True when any secret is within the expiry threshold window.
  */
-export const hasCriticallyExpiringSecret = (
+export const hasSecretsAboutToExpire = (
     secrets: ClientSecretInterface[],
     referenceTime: number = Date.now()
 ): boolean => {
 
-    /* Consider active secrets only; stop at the first one in the critical window. */
-    return (secrets ?? [])
-        .filter((secret: ClientSecretInterface) => secret?.status === ClientSecretStatus.ACTIVE)
-        .some((secret: ClientSecretInterface) =>
-            resolveClientSecretExpiry(secret, referenceTime).state === ClientSecretExpiryState.EXPIRING_CRITICAL);
+    return (secrets ?? []).some((secret: ClientSecretInterface) =>
+        resolveClientSecretExpiry(secret, referenceTime).state === ClientSecretExpiryState.EXPIRING
+    );
 };

--- a/features/admin.applications.v1/components/client-secrets/client-secret-utils.ts
+++ b/features/admin.applications.v1/components/client-secrets/client-secret-utils.ts
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ClientSecretInterface, ClientSecretStatus } from "../../models/application-inbound";
+
+/**
+ * Expiry thresholds (in days) used to classify how soon a client secret expires. Hardcoded in the
+ * console (not deployment configurable).
+ */
+const EXPIRY_WARNING_DAYS: number = 20;
+const EXPIRY_CRITICAL_DAYS: number = 10;
+
+const MILLISECONDS_PER_DAY: number = 24 * 60 * 60 * 1000;
+
+/**
+ * Expiry state of a client secret, mapped to the status dot colour.
+ */
+export enum ClientSecretExpiryState {
+    /** Green — not expiring anytime soon. */
+    ACTIVE = "active",
+    /** Green — never expires. */
+    NEVER = "never",
+    /** Yellow — expiring within the warning window. */
+    EXPIRING_WARNING = "expiringWarning",
+    /** Red — expiring within the critical window. */
+    EXPIRING_CRITICAL = "expiringCritical",
+    /** Grey — already expired. */
+    EXPIRED = "expired"
+}
+
+/**
+ * Resolves the expiry state and a human-readable expiry date of a client secret.
+ *
+ * @param secret - Client secret metadata.
+ * @param referenceTime - Epoch milliseconds to evaluate the expiry against.
+ * @returns Resolved expiry details.
+ */
+export const resolveClientSecretExpiry = (
+    secret: ClientSecretInterface,
+    referenceTime: number = Date.now()
+): { state: ClientSecretExpiryState; formattedDate: string | null } => {
+
+    const formatDate = (epochSeconds: number): string => new Date(epochSeconds * 1000).toLocaleDateString("en-US", {
+        day: "numeric",
+        month: "short",
+        weekday: "short",
+        year: "numeric"
+    });
+
+    if (secret?.status === ClientSecretStatus.EXPIRED) {
+        return {
+            formattedDate: secret?.expiresAt ? formatDate(secret.expiresAt) : null,
+            state: ClientSecretExpiryState.EXPIRED
+        };
+    }
+
+    if (!secret?.expiresAt) {
+        return {
+            formattedDate: null,
+            state: ClientSecretExpiryState.NEVER
+        };
+    }
+
+    const daysRemaining: number = Math.ceil((secret.expiresAt * 1000 - referenceTime) / MILLISECONDS_PER_DAY);
+    const formattedDate: string = formatDate(secret.expiresAt);
+
+    /* The secret is active here (EXPIRED is trusted from the API above); classify how soon it expires. */
+    let state: ClientSecretExpiryState;
+
+    if (daysRemaining <= EXPIRY_CRITICAL_DAYS) {
+        state = ClientSecretExpiryState.EXPIRING_CRITICAL;
+    } else if (daysRemaining <= EXPIRY_WARNING_DAYS) {
+        state = ClientSecretExpiryState.EXPIRING_WARNING;
+    } else {
+        state = ClientSecretExpiryState.ACTIVE;
+    }
+
+    return { formattedDate, state };
+};
+
+/**
+ * Whether at least one active client secret is within the critical expiry window.
+ *
+ * @param secrets - List of client secrets.
+ * @param referenceTime - Epoch milliseconds to evaluate the expiry against.
+ * @returns True when any active secret is critically close to expiry.
+ */
+export const hasCriticallyExpiringSecret = (
+    secrets: ClientSecretInterface[],
+    referenceTime: number = Date.now()
+): boolean => {
+
+    /* Consider active secrets only; stop at the first one in the critical window. */
+    return (secrets ?? [])
+        .filter((secret: ClientSecretInterface) => secret?.status === ClientSecretStatus.ACTIVE)
+        .some((secret: ClientSecretInterface) =>
+            resolveClientSecretExpiry(secret, referenceTime).state === ClientSecretExpiryState.EXPIRING_CRITICAL);
+};

--- a/features/admin.applications.v1/components/client-secrets/client-secret-value-field.scss
+++ b/features/admin.applications.v1/components/client-secrets/client-secret-value-field.scss
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* Fixed basis so the secret field renders at the same width regardless of the action beside it. */
+.client-secret-value-field {
+    flex: 0 1 570px;
+    min-width: 0;
+    max-width: 570px;
+}

--- a/features/admin.applications.v1/components/client-secrets/client-secret-value-field.scss
+++ b/features/admin.applications.v1/components/client-secrets/client-secret-value-field.scss
@@ -21,4 +21,10 @@
     flex: 0 1 570px;
     min-width: 0;
     max-width: 570px;
+
+    /* No action beside it (read-only) — span the full width to match the Client ID field above. */
+    &:only-child {
+        flex: 1 1 auto;
+        max-width: none;
+    }
 }

--- a/features/admin.applications.v1/components/client-secrets/client-secret-value-field.tsx
+++ b/features/admin.applications.v1/components/client-secrets/client-secret-value-field.tsx
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { IdentifiableComponentInterface } from "@wso2is/core/models";
+import { CopyInputField } from "@wso2is/react-components";
+import React, { FunctionComponent, ReactElement } from "react";
+import { useTranslation } from "react-i18next";
+import { Input } from "semantic-ui-react";
+import "./client-secret-value-field.scss";
+
+const MASKED_PLACEHOLDER: string = "••••••••••••••••••••••••••••";
+
+/**
+ * Props for the client secret value field.
+ */
+interface ClientSecretValueFieldPropsInterface extends IdentifiableComponentInterface {
+    /**
+     * The client secret value to display (masked with show/copy).
+     */
+    value: string;
+    /**
+     * Whether the secret value is unavailable (e.g. when client secret hashing is enabled).
+     * When true, a masked read-only field is shown without the show/copy actions.
+     */
+    hideSecretValue?: boolean;
+}
+
+/**
+ * Single source of truth for how a client secret value is displayed. Fixing the field's width here
+ * guarantees every secret (current and previous) renders at the same size.
+ *
+ * @param props - Props injected to the component.
+ * @returns Client secret value field.
+ */
+const ClientSecretValueField: FunctionComponent<ClientSecretValueFieldPropsInterface> = (
+    props: ClientSecretValueFieldPropsInterface
+): ReactElement => {
+
+    const {
+        value,
+        hideSecretValue,
+        [ "data-componentid" ]: componentId = "client-secret-value-field"
+    } = props;
+
+    const { t } = useTranslation();
+
+    return (
+        <div className="client-secret-value-field" data-componentid={ componentId }>
+            { hideSecretValue
+                ? (
+                    <Input
+                        fluid
+                        readOnly
+                        type="password"
+                        value={ MASKED_PLACEHOLDER }
+                        data-componentid={ `${ componentId }-masked` }
+                    />
+                )
+                : (
+                    <CopyInputField
+                        secret
+                        value={ value }
+                        hideSecretLabel={ t("applications:forms.inboundOIDC.fields.clientSecret.hideSecret") }
+                        showSecretLabel={ t("applications:forms.inboundOIDC.fields.clientSecret.showSecret") }
+                        data-componentid={ `${ componentId }-value` }
+                    />
+                )
+            }
+        </div>
+    );
+};
+
+export default ClientSecretValueField;

--- a/features/admin.applications.v1/components/client-secrets/client-secrets-section.scss
+++ b/features/admin.applications.v1/components/client-secrets/client-secrets-section.scss
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.client-secrets-section {
+    .client-secrets-section-toggle {
+        padding-left: 0;
+        margin-top: 0.25rem;
+    }
+
+    /* Wraps the disabled Generate button so hover still reaches the tooltip (disabled buttons
+       don't emit pointer events). */
+    .client-secrets-section-generate-trigger {
+        display: inline-flex;
+    }
+}

--- a/features/admin.applications.v1/components/client-secrets/client-secrets-section.scss
+++ b/features/admin.applications.v1/components/client-secrets/client-secrets-section.scss
@@ -26,5 +26,12 @@
        don't emit pointer events). */
     .client-secrets-section-generate-trigger {
         display: inline-flex;
+
+        /* The default outlined-disabled state is very faint; use a more prominent grey so the
+           limit-reached state reads clearly. */
+        .MuiButton-outlinedPrimary.Mui-disabled {
+            color: var(--oxygen-palette-text-disabled);
+            border-color: var(--oxygen-palette-text-disabled);
+        }
     }
 }

--- a/features/admin.applications.v1/components/client-secrets/client-secrets-section.tsx
+++ b/features/admin.applications.v1/components/client-secrets/client-secrets-section.tsx
@@ -22,7 +22,7 @@ import { AlertLevels, HttpErrorResponseDataInterface, IdentifiableComponentInter
 import { addAlert } from "@wso2is/core/store";
 import { LinkButton, Popup } from "@wso2is/react-components";
 import { AxiosError } from "axios";
-import React, { FunctionComponent, ReactElement, useEffect, useRef, useState } from "react";
+import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Dispatch } from "redux";
@@ -59,12 +59,8 @@ interface ClientSecretsSectionPropsInterface extends IdentifiableComponentInterf
      */
     multipleClientSecretsConfigured?: boolean;
     /**
-     * Whether the user has the client secret create scope. Gates the generate and delete actions
-     * (the delete endpoint requires the same create scope as the create endpoint).
-     */
-    hasCreatePermission?: boolean;
-    /**
-     * Whether the section is rendered in read-only mode.
+     * Whether the section is rendered in read-only mode. The parent folds the client secret create
+     * scope into this, so it also gates the generate and delete actions.
      */
     readOnly?: boolean;
     /**
@@ -93,7 +89,6 @@ const ClientSecretsSection: FunctionComponent<ClientSecretsSectionPropsInterface
         clientSecret,
         clientSecretExpiresAt,
         multipleClientSecretsConfigured,
-        hasCreatePermission,
         readOnly,
         hideSecretValue,
         onUpdate,
@@ -108,13 +103,12 @@ const ClientSecretsSection: FunctionComponent<ClientSecretsSectionPropsInterface
     const isClientSecretHashEnabled: boolean = useSelector(
         (state: AppState) => state.config.ui.isClientSecretHashEnabled);
 
-    const [ showPrevious, setShowPrevious ] = useState<boolean>(false);
+    const [ showPreviousSecrets, setShowPreviousSecrets ] = useState<boolean>(false);
     const [ showGenerateModal, setShowGenerateModal ] = useState<boolean>(false);
     const [ generatedSecret, setGeneratedSecret ] = useState<ClientSecretInterface>(null);
     const [ secretToDelete, setSecretToDelete ] = useState<ClientSecretInterface>(null);
 
-    /* Generate and delete both require the client secret create scope. */
-    const canManageSecrets: boolean = !readOnly && hasCreatePermission;
+    const canManageSecrets: boolean = !readOnly;
 
     /*
      * The list is fetched up front only for users who can generate, since they are the ones who need
@@ -127,23 +121,13 @@ const ClientSecretsSection: FunctionComponent<ClientSecretsSectionPropsInterface
         isLoading: isClientSecretListLoading,
         error: clientSecretListError,
         mutate: mutateClientSecretList
-    } = useGetOAuthClientSecrets(appId, canManageSecrets || showPrevious);
-
-    /* Notify once per failed fetch; SWR retries update the error reference, so guard against re-toasting. */
-    const isFetchErrorNotified: React.MutableRefObject<boolean> = useRef(false);
+    } = useGetOAuthClientSecrets(appId, canManageSecrets || showPreviousSecrets);
 
     useEffect(() => {
         if (!clientSecretListError) {
-            isFetchErrorNotified.current = false;
-
             return;
         }
 
-        if (isFetchErrorNotified.current) {
-            return;
-        }
-
-        isFetchErrorNotified.current = true;
         dispatch(addAlert({
             description: t("applications:clientSecrets.notifications.getSecrets.genericError.description"),
             level: AlertLevels.ERROR,
@@ -258,15 +242,15 @@ const ClientSecretsSection: FunctionComponent<ClientSecretsSectionPropsInterface
                     <LinkButton
                         type="button"
                         className="client-secrets-section-toggle"
-                        onClick={ (): void => setShowPrevious((previous: boolean) => !previous) }
+                        onClick={ (): void => setShowPreviousSecrets((previous: boolean) => !previous) }
                         data-componentid={ `${ componentId }-toggle` }
                     >
-                        <Icon name={ showPrevious ? "chevron up" : "chevron down" } />
-                        { showPrevious
+                        <Icon name={ showPreviousSecrets ? "chevron up" : "chevron down" } />
+                        { showPreviousSecrets
                             ? t("applications:clientSecrets.hidePreviousSecrets")
                             : t("applications:clientSecrets.viewPreviousSecrets") }
                     </LinkButton>
-                    { showPrevious && (
+                    { showPreviousSecrets && (
                         <PreviousClientSecrets
                             secrets={ previousSecrets }
                             isLoading={ isClientSecretListLoading }

--- a/features/admin.applications.v1/components/client-secrets/client-secrets-section.tsx
+++ b/features/admin.applications.v1/components/client-secrets/client-secrets-section.tsx
@@ -17,11 +17,10 @@
  */
 
 import Button from "@oxygen-ui/react/Button";
-import { FeatureAccessConfigInterface, useRequiredScopes } from "@wso2is/access-control";
 import { AppState } from "@wso2is/admin.core.v1/store";
 import { AlertLevels, HttpErrorResponseDataInterface, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { LinkButton, Popup } from "@wso2is/react-components";
+import { LinkButton, Message, Popup } from "@wso2is/react-components";
 import { AxiosError } from "axios";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -36,6 +35,7 @@ import GeneratedClientSecretModal from "./generated-client-secret-modal";
 import PreviousClientSecrets from "./previous-client-secrets";
 import { deleteClientSecretById } from "../../api/application";
 import useGetOAuthClientSecrets from "../../api/use-get-oauth-client-secrets";
+import useClientSecretManagement from "../../hooks/use-client-secret-management";
 import { ClientSecretInterface, ClientSecretStatus } from "../../models/application-inbound";
 
 /**
@@ -46,6 +46,10 @@ interface ClientSecretsSectionPropsInterface extends IdentifiableComponentInterf
      * ID of the application.
      */
     appId: string;
+    /**
+     * Client ID of the application.
+     */
+    clientId?: string;
     /**
      * Value of the current (latest) client secret, from the OIDC configuration.
      */
@@ -86,6 +90,7 @@ const ClientSecretsSection: FunctionComponent<ClientSecretsSectionPropsInterface
 
     const {
         appId,
+        clientId,
         clientSecret,
         clientSecretExpiresAt,
         multipleClientSecretsConfigured,
@@ -98,12 +103,8 @@ const ClientSecretsSection: FunctionComponent<ClientSecretsSectionPropsInterface
     const { t } = useTranslation();
     const dispatch: Dispatch = useDispatch();
 
-    const maxCount: number = useSelector((state: AppState) =>
-        state?.config?.ui?.features?.applications?.properties?.multipleClientSecretsMaxCount as number);
     const isClientSecretHashEnabled: boolean = useSelector(
         (state: AppState) => state.config.ui.isClientSecretHashEnabled);
-    const applicationFeatureConfig: FeatureAccessConfigInterface = useSelector((state: AppState) =>
-        state?.config?.ui?.features?.applications);
 
     const [ showPreviousSecrets, setShowPreviousSecrets ] = useState<boolean>(false);
     const [ showGenerateModal, setShowGenerateModal ] = useState<boolean>(false);
@@ -111,29 +112,28 @@ const ClientSecretsSection: FunctionComponent<ClientSecretsSectionPropsInterface
     const [ secretToDelete, setSecretToDelete ] = useState<ClientSecretInterface | null>(null);
 
     /*
-     * Generating and deleting secrets are both disabled while the app is read-only (view mode). When
-     * editable, each is gated on its own dedicated client secret scope, which the /secrets endpoints
-     * always enforce (the skip-enforce flag applies only to the legacy single-secret path).
+     * The /secrets endpoints always enforce their dedicated scopes (skip-enforce covers only the
+     * application OIDC protocol GET); generating/deleting also require the app to be editable.
      */
-    const hasGeneratePermission: boolean = useRequiredScopes(
-        applicationFeatureConfig?.subFeatures?.applicationClientSecretManagement?.scopes?.create ?? []);
-    const hasDeletePermission: boolean = useRequiredScopes(
-        applicationFeatureConfig?.subFeatures?.applicationClientSecretManagement?.scopes?.delete ?? []);
-    const canGenerate: boolean = !readOnly && hasGeneratePermission;
-    const canDelete: boolean = !readOnly && hasDeletePermission;
+    const {
+        hasClientSecretReadPermission,
+        hasClientSecretCreatePermission,
+        hasClientSecretDeletePermission,
+        maxSecretCount: maxCount
+    } = useClientSecretManagement();
+    const canGenerate: boolean = !readOnly && hasClientSecretCreatePermission;
+    const canDelete: boolean = !readOnly && hasClientSecretDeletePermission;
 
     /*
-     * The list is fetched up front only for users who can generate, since they are the ones who need
-     * the total count to know whether the limit is reached (which disables the button). Other viewers
-     * fetch lazily when they expand the previous secrets dropdown. Either way the dropdown is a pure
-     * show/hide toggle over this same data.
+     * Fetched eagerly only for generate-capable users, who need the count for the limit check;
+     * others fetch lazily when expanding the previous secrets dropdown.
      */
     const {
         data: clientSecretList,
         isLoading: isClientSecretListLoading,
         error: clientSecretListError,
         mutate: mutateClientSecretList
-    } = useGetOAuthClientSecrets(appId, canGenerate || showPreviousSecrets);
+    } = useGetOAuthClientSecrets(appId, hasClientSecretReadPermission && (canGenerate || showPreviousSecrets));
 
     useEffect(() => {
         if (!clientSecretListError) {
@@ -158,27 +158,20 @@ const ClientSecretsSection: FunctionComponent<ClientSecretsSectionPropsInterface
         .filter((secret: ClientSecretInterface) => !secret?.latest);
 
     /*
-     * The previous secrets dropdown is shown when the app has previous secrets. Before the list is
-     * fetched we rely on the OIDC config flag; once fetched, the list is the source of truth, so
-     * deleting the last previous secret removes the dropdown.
+     * Before the list is fetched, the OIDC config flag decides whether previous secrets exist;
+     * once fetched, the list is the source of truth.
      */
     const hasPreviousSecrets: boolean = clientSecretList
         ? previousSecrets.length > 0
         : Boolean(multipleClientSecretsConfigured);
 
     /*
-     * Proactively block generation once the app is at the secret limit. This is knowable only after
-     * the list resolves; while it is unknown (still loading, or the fetch failed) the button stays
-     * enabled and the create endpoint's 409 is the authoritative backstop, surfaced as a notification.
+     * Knowable only after the list resolves; until then the button stays enabled and the create
+     * endpoint's 409 is the authoritative backstop.
      */
     const isMaxCountReached: boolean = Boolean(clientSecretList)
         && maxCount !== undefined
         && (clientSecretList?.list?.length ?? 0) >= maxCount;
-
-    const resolveErrorDescription = (
-        error: AxiosError<HttpErrorResponseDataInterface>,
-        fallback: string
-    ): string => error?.response?.data?.description ?? fallback;
 
     const handleGenerated = (secret: ClientSecretInterface): void => {
         dispatch(addAlert({
@@ -187,11 +180,18 @@ const ClientSecretsSection: FunctionComponent<ClientSecretsSectionPropsInterface
             message: t("applications:clientSecrets.notifications.generateSecret.success.message")
         }));
         setShowGenerateModal(false);
-        /* Surface the plaintext value only when hashing hides it from the secret cards. */
+        mutateClientSecretList();
+
+        /*
+         * With hashing enabled, the parent refresh is deferred until the reveal modal is dismissed —
+         * refreshing would unmount the modal before the user sees the one-time value.
+         */
         if (isClientSecretHashEnabled) {
             setGeneratedSecret(secret);
+
+            return;
         }
-        mutateClientSecretList();
+
         onUpdate(appId);
     };
 
@@ -212,10 +212,8 @@ const ClientSecretsSection: FunctionComponent<ClientSecretsSectionPropsInterface
             })
             .catch((error: AxiosError<HttpErrorResponseDataInterface>) => {
                 dispatch(addAlert({
-                    description: resolveErrorDescription(
-                        error,
-                        t("applications:clientSecrets.notifications.deleteSecret.genericError.description")
-                    ),
+                    description: error?.response?.data?.description
+                        ?? t("applications:clientSecrets.notifications.deleteSecret.genericError.description"),
                     level: AlertLevels.ERROR,
                     message: t("applications:clientSecrets.notifications.deleteSecret.genericError.message")
                 }));
@@ -223,27 +221,24 @@ const ClientSecretsSection: FunctionComponent<ClientSecretsSectionPropsInterface
             });
     };
 
-    /*
-     * Pluralize the toggle by how many previous secrets the app can hold (the max total minus the
-     * current secret), which is known from configuration up front — unlike the actual count, which is
-     * unavailable until the list is fetched (e.g. before a viewer without generate access expands it).
-     */
-    const resolvePreviousSecretsToggleLabel = (): string => {
-        const maxPreviousSecrets: number = maxCount - 1;
-
-        if (showPreviousSecrets) {
-            return maxPreviousSecrets === 1
-                ? t("applications:clientSecrets.hidePreviousSecret")
-                : t("applications:clientSecrets.hidePreviousSecrets");
-        }
-
-        return maxPreviousSecrets === 1
-            ? t("applications:clientSecrets.viewPreviousSecret")
-            : t("applications:clientSecrets.viewPreviousSecrets");
-    };
+    const hasSinglePreviousSecret: boolean = maxCount - 1 === 1;
+    const previousSecretsToggleLabel: string = showPreviousSecrets
+        ? t(hasSinglePreviousSecret
+            ? "applications:clientSecrets.hidePreviousSecret"
+            : "applications:clientSecrets.hidePreviousSecrets")
+        : t(hasSinglePreviousSecret
+            ? "applications:clientSecrets.viewPreviousSecret"
+            : "applications:clientSecrets.viewPreviousSecrets");
 
     return (
         <div className="client-secrets-section" data-componentid={ componentId }>
+            { hideSecretValue && (
+                <Message
+                    type="info"
+                    content={ t("applications:clientSecrets.hashedDisclaimer") }
+                    data-componentid={ `${ componentId }-hashed-disclaimer` }
+                />
+            ) }
             <ClientSecretRow
                 secret={ currentSecret }
                 hideSecretValue={ hideSecretValue }
@@ -271,8 +266,7 @@ const ClientSecretsSection: FunctionComponent<ClientSecretsSectionPropsInterface
                 ) }
                 data-componentid={ `${ componentId }-current` }
             />
-            { /* The previous secrets dropdown appears only while the app has previous secrets. */ }
-            { hasPreviousSecrets && (
+            { hasClientSecretReadPermission && hasPreviousSecrets && (
                 <>
                     <LinkButton
                         type="button"
@@ -281,7 +275,7 @@ const ClientSecretsSection: FunctionComponent<ClientSecretsSectionPropsInterface
                         data-componentid={ `${ componentId }-toggle` }
                     >
                         <Icon name={ showPreviousSecrets ? "chevron up" : "chevron down" } />
-                        { resolvePreviousSecretsToggleLabel() }
+                        { previousSecretsToggleLabel }
                     </LinkButton>
                     { showPreviousSecrets && (
                         <PreviousClientSecrets
@@ -301,7 +295,7 @@ const ClientSecretsSection: FunctionComponent<ClientSecretsSectionPropsInterface
                     appId={ appId }
                     maxCount={ maxCount }
                     onGenerated={ handleGenerated }
-                    onCancel={ (): void => setShowGenerateModal(false) }
+                    onClose={ (): void => setShowGenerateModal(false) }
                     data-componentid={ `${ componentId }-generate-modal` }
                 />
             ) }
@@ -318,7 +312,11 @@ const ClientSecretsSection: FunctionComponent<ClientSecretsSectionPropsInterface
                 <GeneratedClientSecretModal
                     open={ Boolean(generatedSecret) }
                     secret={ generatedSecret }
-                    onClose={ (): void => setGeneratedSecret(null) }
+                    clientId={ clientId }
+                    onClose={ (): void => {
+                        setGeneratedSecret(null);
+                        onUpdate(appId);
+                    } }
                     data-componentid={ `${ componentId }-generated-modal` }
                 />
             ) }

--- a/features/admin.applications.v1/components/client-secrets/client-secrets-section.tsx
+++ b/features/admin.applications.v1/components/client-secrets/client-secrets-section.tsx
@@ -223,6 +223,25 @@ const ClientSecretsSection: FunctionComponent<ClientSecretsSectionPropsInterface
             });
     };
 
+    /*
+     * Pluralize the toggle by how many previous secrets the app can hold (the max total minus the
+     * current secret), which is known from configuration up front — unlike the actual count, which is
+     * unavailable until the list is fetched (e.g. before a viewer without generate access expands it).
+     */
+    const resolvePreviousSecretsToggleLabel = (): string => {
+        const maxPreviousSecrets: number = maxCount - 1;
+
+        if (showPreviousSecrets) {
+            return maxPreviousSecrets === 1
+                ? t("applications:clientSecrets.hidePreviousSecret")
+                : t("applications:clientSecrets.hidePreviousSecrets");
+        }
+
+        return maxPreviousSecrets === 1
+            ? t("applications:clientSecrets.viewPreviousSecret")
+            : t("applications:clientSecrets.viewPreviousSecrets");
+    };
+
     return (
         <div className="client-secrets-section" data-componentid={ componentId }>
             <ClientSecretRow
@@ -262,9 +281,7 @@ const ClientSecretsSection: FunctionComponent<ClientSecretsSectionPropsInterface
                         data-componentid={ `${ componentId }-toggle` }
                     >
                         <Icon name={ showPreviousSecrets ? "chevron up" : "chevron down" } />
-                        { showPreviousSecrets
-                            ? t("applications:clientSecrets.hidePreviousSecrets")
-                            : t("applications:clientSecrets.viewPreviousSecrets") }
+                        { resolvePreviousSecretsToggleLabel() }
                     </LinkButton>
                     { showPreviousSecrets && (
                         <PreviousClientSecrets

--- a/features/admin.applications.v1/components/client-secrets/client-secrets-section.tsx
+++ b/features/admin.applications.v1/components/client-secrets/client-secrets-section.tsx
@@ -17,6 +17,7 @@
  */
 
 import Button from "@oxygen-ui/react/Button";
+import { FeatureAccessConfigInterface, useRequiredScopes } from "@wso2is/access-control";
 import { AppState } from "@wso2is/admin.core.v1/store";
 import { AlertLevels, HttpErrorResponseDataInterface, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
@@ -59,11 +60,6 @@ interface ClientSecretsSectionPropsInterface extends IdentifiableComponentInterf
      */
     multipleClientSecretsConfigured?: boolean;
     /**
-     * Whether the section is rendered in read-only mode. The parent folds the client secret create
-     * scope into this, so it also gates the generate and delete actions.
-     */
-    readOnly?: boolean;
-    /**
      * Whether secret values are unavailable (client secret hashing enabled).
      */
     hideSecretValue?: boolean;
@@ -71,6 +67,10 @@ interface ClientSecretsSectionPropsInterface extends IdentifiableComponentInterf
      * Callback to refresh the inbound OIDC configuration (e.g. after the current secret changes).
      */
     onUpdate: (id: string) => void;
+    /**
+     * Whether the application is in a read-only (non-editable) state.
+     */
+    readOnly?: boolean;
 }
 
 /**
@@ -89,9 +89,9 @@ const ClientSecretsSection: FunctionComponent<ClientSecretsSectionPropsInterface
         clientSecret,
         clientSecretExpiresAt,
         multipleClientSecretsConfigured,
-        readOnly,
         hideSecretValue,
         onUpdate,
+        readOnly,
         [ "data-componentid" ]: componentId = "client-secrets-section"
     } = props;
 
@@ -102,26 +102,38 @@ const ClientSecretsSection: FunctionComponent<ClientSecretsSectionPropsInterface
         state?.config?.ui?.features?.applications?.properties?.multipleClientSecretsMaxCount as number);
     const isClientSecretHashEnabled: boolean = useSelector(
         (state: AppState) => state.config.ui.isClientSecretHashEnabled);
+    const applicationFeatureConfig: FeatureAccessConfigInterface = useSelector((state: AppState) =>
+        state?.config?.ui?.features?.applications);
 
     const [ showPreviousSecrets, setShowPreviousSecrets ] = useState<boolean>(false);
     const [ showGenerateModal, setShowGenerateModal ] = useState<boolean>(false);
-    const [ generatedSecret, setGeneratedSecret ] = useState<ClientSecretInterface>(null);
-    const [ secretToDelete, setSecretToDelete ] = useState<ClientSecretInterface>(null);
+    const [ generatedSecret, setGeneratedSecret ] = useState<ClientSecretInterface | null>(null);
+    const [ secretToDelete, setSecretToDelete ] = useState<ClientSecretInterface | null>(null);
 
-    const canManageSecrets: boolean = !readOnly;
+    /*
+     * Generating and deleting secrets are both disabled while the app is read-only (view mode). When
+     * editable, each is gated on its own dedicated client secret scope, which the /secrets endpoints
+     * always enforce (the skip-enforce flag applies only to the legacy single-secret path).
+     */
+    const hasGeneratePermission: boolean = useRequiredScopes(
+        applicationFeatureConfig?.subFeatures?.applicationClientSecretManagement?.scopes?.create ?? []);
+    const hasDeletePermission: boolean = useRequiredScopes(
+        applicationFeatureConfig?.subFeatures?.applicationClientSecretManagement?.scopes?.delete ?? []);
+    const canGenerate: boolean = !readOnly && hasGeneratePermission;
+    const canDelete: boolean = !readOnly && hasDeletePermission;
 
     /*
      * The list is fetched up front only for users who can generate, since they are the ones who need
-     * the total count to know whether the limit is reached (which disables the button). Read-only
-     * viewers have no generate button, so the list is fetched lazily when they expand the previous
-     * secrets dropdown. Either way the dropdown is a pure show/hide toggle over this same data.
+     * the total count to know whether the limit is reached (which disables the button). Other viewers
+     * fetch lazily when they expand the previous secrets dropdown. Either way the dropdown is a pure
+     * show/hide toggle over this same data.
      */
     const {
         data: clientSecretList,
         isLoading: isClientSecretListLoading,
         error: clientSecretListError,
         mutate: mutateClientSecretList
-    } = useGetOAuthClientSecrets(appId, canManageSecrets || showPreviousSecrets);
+    } = useGetOAuthClientSecrets(appId, canGenerate || showPreviousSecrets);
 
     useEffect(() => {
         if (!clientSecretListError) {
@@ -184,7 +196,11 @@ const ClientSecretsSection: FunctionComponent<ClientSecretsSectionPropsInterface
     };
 
     const handleDelete = (secret: ClientSecretInterface): void => {
-        deleteClientSecretById(appId, secret?.secretId)
+        if (!secret?.secretId) {
+            return;
+        }
+
+        deleteClientSecretById(appId, secret.secretId)
             .then(() => {
                 dispatch(addAlert({
                     description: t("applications:clientSecrets.notifications.deleteSecret.success.description"),
@@ -212,7 +228,7 @@ const ClientSecretsSection: FunctionComponent<ClientSecretsSectionPropsInterface
             <ClientSecretRow
                 secret={ currentSecret }
                 hideSecretValue={ hideSecretValue }
-                action={ canManageSecrets && (
+                action={ canGenerate && (
                     <Popup
                         wide
                         position="top center"
@@ -254,7 +270,7 @@ const ClientSecretsSection: FunctionComponent<ClientSecretsSectionPropsInterface
                         <PreviousClientSecrets
                             secrets={ previousSecrets }
                             isLoading={ isClientSecretListLoading }
-                            readOnly={ !canManageSecrets }
+                            readOnly={ !canDelete }
                             hideSecretValue={ hideSecretValue }
                             onDelete={ (secret: ClientSecretInterface): void => setSecretToDelete(secret) }
                             data-componentid={ `${ componentId }-previous` }

--- a/features/admin.applications.v1/components/client-secrets/client-secrets-section.tsx
+++ b/features/admin.applications.v1/components/client-secrets/client-secrets-section.tsx
@@ -1,0 +1,312 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Button from "@oxygen-ui/react/Button";
+import { AppState } from "@wso2is/admin.core.v1/store";
+import { AlertLevels, HttpErrorResponseDataInterface, IdentifiableComponentInterface } from "@wso2is/core/models";
+import { addAlert } from "@wso2is/core/store";
+import { LinkButton, Popup } from "@wso2is/react-components";
+import { AxiosError } from "axios";
+import React, { FunctionComponent, ReactElement, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useDispatch, useSelector } from "react-redux";
+import { Dispatch } from "redux";
+import { Icon } from "semantic-ui-react";
+import ClientSecretRow from "./client-secret-row";
+import "./client-secrets-section.scss";
+import DeleteClientSecretModal from "./delete-client-secret-modal";
+import GenerateClientSecretModal from "./generate-client-secret-modal";
+import GeneratedClientSecretModal from "./generated-client-secret-modal";
+import PreviousClientSecrets from "./previous-client-secrets";
+import { deleteClientSecretById } from "../../api/application";
+import useGetOAuthClientSecrets from "../../api/use-get-oauth-client-secrets";
+import { ClientSecretInterface, ClientSecretStatus } from "../../models/application-inbound";
+
+/**
+ * Props for the client secrets section.
+ */
+interface ClientSecretsSectionPropsInterface extends IdentifiableComponentInterface {
+    /**
+     * ID of the application.
+     */
+    appId: string;
+    /**
+     * Value of the current (latest) client secret, from the OIDC configuration.
+     */
+    clientSecret: string;
+    /**
+     * Expiry of the current client secret as Unix epoch seconds (0 when it does not expire).
+     */
+    clientSecretExpiresAt?: number;
+    /**
+     * Whether the application has more than one client secret configured. The previous secrets
+     * dropdown is only shown when this is true.
+     */
+    multipleClientSecretsConfigured?: boolean;
+    /**
+     * Whether the user has the client secret create scope. Gates the generate and delete actions
+     * (the delete endpoint requires the same create scope as the create endpoint).
+     */
+    hasCreatePermission?: boolean;
+    /**
+     * Whether the section is rendered in read-only mode.
+     */
+    readOnly?: boolean;
+    /**
+     * Whether secret values are unavailable (client secret hashing enabled).
+     */
+    hideSecretValue?: boolean;
+    /**
+     * Callback to refresh the inbound OIDC configuration (e.g. after the current secret changes).
+     */
+    onUpdate: (id: string) => void;
+}
+
+/**
+ * Client secrets section shown on the OIDC protocol tab — the current secret with a generate action,
+ * and a lazily-loaded, expandable list of previous secrets.
+ *
+ * @param props - Props injected to the component.
+ * @returns Client secrets section.
+ */
+const ClientSecretsSection: FunctionComponent<ClientSecretsSectionPropsInterface> = (
+    props: ClientSecretsSectionPropsInterface
+): ReactElement => {
+
+    const {
+        appId,
+        clientSecret,
+        clientSecretExpiresAt,
+        multipleClientSecretsConfigured,
+        hasCreatePermission,
+        readOnly,
+        hideSecretValue,
+        onUpdate,
+        [ "data-componentid" ]: componentId = "client-secrets-section"
+    } = props;
+
+    const { t } = useTranslation();
+    const dispatch: Dispatch = useDispatch();
+
+    const maxCount: number = useSelector((state: AppState) =>
+        state?.config?.ui?.features?.applications?.properties?.multipleClientSecretsMaxCount as number);
+    const isClientSecretHashEnabled: boolean = useSelector(
+        (state: AppState) => state.config.ui.isClientSecretHashEnabled);
+
+    const [ showPrevious, setShowPrevious ] = useState<boolean>(false);
+    const [ showGenerateModal, setShowGenerateModal ] = useState<boolean>(false);
+    const [ generatedSecret, setGeneratedSecret ] = useState<ClientSecretInterface>(null);
+    const [ secretToDelete, setSecretToDelete ] = useState<ClientSecretInterface>(null);
+
+    /* Generate and delete both require the client secret create scope. */
+    const canManageSecrets: boolean = !readOnly && hasCreatePermission;
+
+    /*
+     * The list is fetched up front only for users who can generate, since they are the ones who need
+     * the total count to know whether the limit is reached (which disables the button). Read-only
+     * viewers have no generate button, so the list is fetched lazily when they expand the previous
+     * secrets dropdown. Either way the dropdown is a pure show/hide toggle over this same data.
+     */
+    const {
+        data: clientSecretList,
+        isLoading: isClientSecretListLoading,
+        error: clientSecretListError,
+        mutate: mutateClientSecretList
+    } = useGetOAuthClientSecrets(appId, canManageSecrets || showPrevious);
+
+    /* Notify once per failed fetch; SWR retries update the error reference, so guard against re-toasting. */
+    const isFetchErrorNotified: React.MutableRefObject<boolean> = useRef(false);
+
+    useEffect(() => {
+        if (!clientSecretListError) {
+            isFetchErrorNotified.current = false;
+
+            return;
+        }
+
+        if (isFetchErrorNotified.current) {
+            return;
+        }
+
+        isFetchErrorNotified.current = true;
+        dispatch(addAlert({
+            description: t("applications:clientSecrets.notifications.getSecrets.genericError.description"),
+            level: AlertLevels.ERROR,
+            message: t("applications:clientSecrets.notifications.getSecrets.genericError.message")
+        }));
+    }, [ clientSecretListError ]);
+
+    const currentSecret: ClientSecretInterface = {
+        expiresAt: clientSecretExpiresAt,
+        latest: true,
+        secretValue: clientSecret,
+        status: ClientSecretStatus.ACTIVE
+    };
+
+    const previousSecrets: ClientSecretInterface[] = (clientSecretList?.list ?? [])
+        .filter((secret: ClientSecretInterface) => !secret?.latest);
+
+    /*
+     * The previous secrets dropdown is shown when the app has previous secrets. Before the list is
+     * fetched we rely on the OIDC config flag; once fetched, the list is the source of truth, so
+     * deleting the last previous secret removes the dropdown.
+     */
+    const hasPreviousSecrets: boolean = clientSecretList
+        ? previousSecrets.length > 0
+        : Boolean(multipleClientSecretsConfigured);
+
+    /*
+     * Proactively block generation once the app is at the secret limit. This is knowable only after
+     * the list resolves; while it is unknown (still loading, or the fetch failed) the button stays
+     * enabled and the create endpoint's 409 is the authoritative backstop, surfaced as a notification.
+     */
+    const isMaxCountReached: boolean = Boolean(clientSecretList)
+        && maxCount !== undefined
+        && (clientSecretList?.list?.length ?? 0) >= maxCount;
+
+    const resolveErrorDescription = (
+        error: AxiosError<HttpErrorResponseDataInterface>,
+        fallback: string
+    ): string => error?.response?.data?.description ?? fallback;
+
+    const handleGenerated = (secret: ClientSecretInterface): void => {
+        dispatch(addAlert({
+            description: t("applications:clientSecrets.notifications.generateSecret.success.description"),
+            level: AlertLevels.SUCCESS,
+            message: t("applications:clientSecrets.notifications.generateSecret.success.message")
+        }));
+        setShowGenerateModal(false);
+        /* Surface the plaintext value only when hashing hides it from the secret cards. */
+        if (isClientSecretHashEnabled) {
+            setGeneratedSecret(secret);
+        }
+        mutateClientSecretList();
+        onUpdate(appId);
+    };
+
+    const handleDelete = (secret: ClientSecretInterface): void => {
+        deleteClientSecretById(appId, secret?.secretId)
+            .then(() => {
+                dispatch(addAlert({
+                    description: t("applications:clientSecrets.notifications.deleteSecret.success.description"),
+                    level: AlertLevels.SUCCESS,
+                    message: t("applications:clientSecrets.notifications.deleteSecret.success.message")
+                }));
+                setSecretToDelete(null);
+                mutateClientSecretList();
+            })
+            .catch((error: AxiosError<HttpErrorResponseDataInterface>) => {
+                dispatch(addAlert({
+                    description: resolveErrorDescription(
+                        error,
+                        t("applications:clientSecrets.notifications.deleteSecret.genericError.description")
+                    ),
+                    level: AlertLevels.ERROR,
+                    message: t("applications:clientSecrets.notifications.deleteSecret.genericError.message")
+                }));
+                setSecretToDelete(null);
+            });
+    };
+
+    return (
+        <div className="client-secrets-section" data-componentid={ componentId }>
+            <ClientSecretRow
+                secret={ currentSecret }
+                hideSecretValue={ hideSecretValue }
+                action={ canManageSecrets && (
+                    <Popup
+                        wide
+                        position="top center"
+                        disabled={ !isMaxCountReached }
+                        content={ t("applications:clientSecrets.maxCountReachedHint", { count: maxCount }) }
+                        trigger={ (
+                            <span className="client-secrets-section-generate-trigger">
+                                <Button
+                                    variant="outlined"
+                                    color="primary"
+                                    disabled={ isMaxCountReached }
+                                    onClick={ (): void => setShowGenerateModal(true) }
+                                    data-componentid={ `${ componentId }-generate-button` }
+                                >
+                                    { t("applications:clientSecrets.generateButton") }
+                                </Button>
+                            </span>
+                        ) }
+                        data-componentid={ `${ componentId }-max-count-tooltip` }
+                    />
+                ) }
+                data-componentid={ `${ componentId }-current` }
+            />
+            { /* The previous secrets dropdown appears only while the app has previous secrets. */ }
+            { hasPreviousSecrets && (
+                <>
+                    <LinkButton
+                        type="button"
+                        className="client-secrets-section-toggle"
+                        onClick={ (): void => setShowPrevious((previous: boolean) => !previous) }
+                        data-componentid={ `${ componentId }-toggle` }
+                    >
+                        <Icon name={ showPrevious ? "chevron up" : "chevron down" } />
+                        { showPrevious
+                            ? t("applications:clientSecrets.hidePreviousSecrets")
+                            : t("applications:clientSecrets.viewPreviousSecrets") }
+                    </LinkButton>
+                    { showPrevious && (
+                        <PreviousClientSecrets
+                            secrets={ previousSecrets }
+                            isLoading={ isClientSecretListLoading }
+                            readOnly={ !canManageSecrets }
+                            hideSecretValue={ hideSecretValue }
+                            onDelete={ (secret: ClientSecretInterface): void => setSecretToDelete(secret) }
+                            data-componentid={ `${ componentId }-previous` }
+                        />
+                    ) }
+                </>
+            ) }
+            { showGenerateModal && (
+                <GenerateClientSecretModal
+                    open={ showGenerateModal }
+                    appId={ appId }
+                    maxCount={ maxCount }
+                    onGenerated={ handleGenerated }
+                    onCancel={ (): void => setShowGenerateModal(false) }
+                    data-componentid={ `${ componentId }-generate-modal` }
+                />
+            ) }
+            { secretToDelete && (
+                <DeleteClientSecretModal
+                    open={ Boolean(secretToDelete) }
+                    secret={ secretToDelete }
+                    onConfirm={ handleDelete }
+                    onCancel={ (): void => setSecretToDelete(null) }
+                    data-componentid={ `${ componentId }-delete-modal` }
+                />
+            ) }
+            { generatedSecret && (
+                <GeneratedClientSecretModal
+                    open={ Boolean(generatedSecret) }
+                    secret={ generatedSecret }
+                    onClose={ (): void => setGeneratedSecret(null) }
+                    data-componentid={ `${ componentId }-generated-modal` }
+                />
+            ) }
+        </div>
+    );
+};
+
+export default ClientSecretsSection;

--- a/features/admin.applications.v1/components/client-secrets/delete-client-secret-modal.tsx
+++ b/features/admin.applications.v1/components/client-secrets/delete-client-secret-modal.tsx
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { IdentifiableComponentInterface } from "@wso2is/core/models";
+import { ConfirmationModal } from "@wso2is/react-components";
+import React, { FunctionComponent, ReactElement } from "react";
+import { useTranslation } from "react-i18next";
+import { ClientSecretInterface } from "../../models/application-inbound";
+
+/**
+ * Props for the delete client secret modal component.
+ */
+interface DeleteClientSecretModalPropsInterface extends IdentifiableComponentInterface {
+    /**
+     * Client secret to be deleted.
+     */
+    secret: ClientSecretInterface;
+    /**
+     * Whether the modal is open.
+     */
+    open: boolean;
+    /**
+     * Callback fired when the deletion is confirmed.
+     */
+    onConfirm: (secret: ClientSecretInterface) => void;
+    /**
+     * Callback fired when the modal is dismissed.
+     */
+    onCancel: () => void;
+}
+
+/**
+ * Confirmation modal shown before deleting a client secret.
+ *
+ * @param props - Props injected to the component.
+ * @returns Delete client secret modal.
+ */
+const DeleteClientSecretModal: FunctionComponent<DeleteClientSecretModalPropsInterface> = (
+    props: DeleteClientSecretModalPropsInterface
+): ReactElement => {
+
+    const {
+        secret,
+        open,
+        onConfirm,
+        onCancel,
+        [ "data-componentid" ]: componentId = "delete-client-secret-modal"
+    } = props;
+
+    const { t } = useTranslation();
+
+    return (
+        <ConfirmationModal
+            type="negative"
+            open={ open }
+            assertionHint={ t("applications:clientSecrets.confirmations.deleteSecret.assertionHint") }
+            assertionType="checkbox"
+            primaryAction={ t("common:confirm") }
+            secondaryAction={ t("common:cancel") }
+            onClose={ onCancel }
+            onSecondaryActionClick={ onCancel }
+            onPrimaryActionClick={ (): void => onConfirm(secret) }
+            closeOnDimmerClick={ false }
+            data-componentid={ componentId }
+        >
+            <ConfirmationModal.Header data-componentid={ `${ componentId }-header` }>
+                { t("applications:clientSecrets.confirmations.deleteSecret.header") }
+            </ConfirmationModal.Header>
+            <ConfirmationModal.Message
+                attached
+                negative
+                data-componentid={ `${ componentId }-message` }
+            >
+                { t("applications:clientSecrets.confirmations.deleteSecret.message") }
+            </ConfirmationModal.Message>
+            <ConfirmationModal.Content data-componentid={ `${ componentId }-content` }>
+                { t("applications:clientSecrets.confirmations.deleteSecret.content") }
+            </ConfirmationModal.Content>
+        </ConfirmationModal>
+    );
+};
+
+export default DeleteClientSecretModal;

--- a/features/admin.applications.v1/components/client-secrets/generate-client-secret-modal.tsx
+++ b/features/admin.applications.v1/components/client-secrets/generate-client-secret-modal.tsx
@@ -1,0 +1,298 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AlertLevels, HttpErrorResponseDataInterface, IdentifiableComponentInterface } from "@wso2is/core/models";
+import { Field, Form } from "@wso2is/forms";
+import { Heading, LinkButton, Message, PrimaryButton, useWizardAlert } from "@wso2is/react-components";
+import { AxiosError, AxiosResponse } from "axios";
+import React, { FunctionComponent, ReactElement, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Grid, Modal } from "semantic-ui-react";
+import { createClientSecret } from "../../api/application";
+import { ClientSecretExpirationOption, ClientSecretInterface } from "../../models/application-inbound";
+
+const FORM_ID: string = "generate-client-secret-form";
+const SECONDS_PER_DAY: number = 24 * 60 * 60;
+const CUSTOM_EXPIRY_MIN_DAYS: number = 1;
+const CUSTOM_EXPIRY_MAX_DAYS: number = 3650;
+
+/**
+ * Shape of the generate client secret form values.
+ */
+interface GenerateClientSecretFormValues {
+    expiration: ClientSecretExpirationOption;
+    customExpiryDays?: string;
+}
+
+/**
+ * Props for the generate client secret modal component.
+ */
+interface GenerateClientSecretModalPropsInterface extends IdentifiableComponentInterface {
+    /**
+     * Whether the modal is open.
+     */
+    open: boolean;
+    /**
+     * ID of the application.
+     */
+    appId: string;
+    /**
+     * Maximum number of client secrets allowed, shown in the limit-reached message.
+     */
+    maxCount: number;
+    /**
+     * Callback fired with the created secret once generation succeeds.
+     */
+    onGenerated: (secret: ClientSecretInterface) => void;
+    /**
+     * Callback fired when the modal is dismissed.
+     */
+    onCancel: () => void;
+}
+
+/**
+ * Modal to generate a new OAuth2/OIDC client secret.
+ *
+ * @param props - Props injected to the component.
+ * @returns Generate client secret modal.
+ */
+const GenerateClientSecretModal: FunctionComponent<GenerateClientSecretModalPropsInterface> = (
+    props: GenerateClientSecretModalPropsInterface
+): ReactElement => {
+
+    const {
+        open,
+        appId,
+        maxCount,
+        onGenerated,
+        onCancel,
+        [ "data-componentid" ]: componentId = "generate-client-secret-modal"
+    } = props;
+
+    const { t } = useTranslation();
+
+    const [ alert, setAlert, alertComponent ] = useWizardAlert();
+
+    const formRef: React.MutableRefObject<any> = useRef(null);
+
+    const [ selectedExpiration, setSelectedExpiration ] = useState<ClientSecretExpirationOption>(
+        ClientSecretExpirationOption.THIRTY_DAYS
+    );
+    const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
+
+    const expirationOptions: { key: string; text: string; value: string }[] = [
+        {
+            key: ClientSecretExpirationOption.THIRTY_DAYS,
+            text: t("applications:clientSecrets.wizard.expiration.options.days", { count: 30 }),
+            value: ClientSecretExpirationOption.THIRTY_DAYS
+        },
+        {
+            key: ClientSecretExpirationOption.SIXTY_DAYS,
+            text: t("applications:clientSecrets.wizard.expiration.options.days", { count: 60 }),
+            value: ClientSecretExpirationOption.SIXTY_DAYS
+        },
+        {
+            key: ClientSecretExpirationOption.NINETY_DAYS,
+            text: t("applications:clientSecrets.wizard.expiration.options.days", { count: 90 }),
+            value: ClientSecretExpirationOption.NINETY_DAYS
+        },
+        {
+            key: ClientSecretExpirationOption.ONE_EIGHTY_DAYS,
+            text: t("applications:clientSecrets.wizard.expiration.options.days", { count: 180 }),
+            value: ClientSecretExpirationOption.ONE_EIGHTY_DAYS
+        },
+        {
+            key: ClientSecretExpirationOption.CUSTOM,
+            text: t("applications:clientSecrets.wizard.expiration.options.custom"),
+            value: ClientSecretExpirationOption.CUSTOM
+        },
+        {
+            key: ClientSecretExpirationOption.NO_EXPIRATION,
+            text: t("applications:clientSecrets.wizard.expiration.options.neverExpire"),
+            value: ClientSecretExpirationOption.NO_EXPIRATION
+        }
+    ];
+
+    const resolveExpiresAt = (values: GenerateClientSecretFormValues): number | undefined => {
+        const nowInSeconds: number = Math.floor(Date.now() / 1000);
+
+        switch (values.expiration) {
+            case ClientSecretExpirationOption.NO_EXPIRATION:
+                return undefined;
+            case ClientSecretExpirationOption.CUSTOM:
+                return nowInSeconds + Number(values.customExpiryDays) * SECONDS_PER_DAY;
+            default:
+                return nowInSeconds + Number(values.expiration) * SECONDS_PER_DAY;
+        }
+    };
+
+    const handleSubmit = (values: GenerateClientSecretFormValues): void => {
+        setIsSubmitting(true);
+
+        createClientSecret(appId, { expiresAt: resolveExpiresAt(values) })
+            .then((response: AxiosResponse<ClientSecretInterface>) => {
+                onGenerated(response.data);
+            })
+            .catch((error: AxiosError<HttpErrorResponseDataInterface>) => {
+                if (error?.response?.status === 409) {
+                    setAlert({
+                        description: t("applications:clientSecrets.maxCountReachedHint", { count: maxCount }),
+                        level: AlertLevels.ERROR,
+                        message: null
+                    });
+
+                    return;
+                }
+
+                if (error?.response?.data?.description) {
+                    setAlert({
+                        description: error.response.data.description,
+                        level: AlertLevels.ERROR,
+                        message: t("applications:clientSecrets.notifications.generateSecret.error.message")
+                    });
+
+                    return;
+                }
+
+                setAlert({
+                    description: t("applications:clientSecrets.notifications.generateSecret.genericError.description"),
+                    level: AlertLevels.ERROR,
+                    message: t("applications:clientSecrets.notifications.generateSecret.genericError.message")
+                });
+            })
+            .finally(() => setIsSubmitting(false));
+    };
+
+    /**
+     * Form-level validation. Enforces the custom expiry field when the Custom option is selected,
+     * since the field-level `required` check only fires once the field has been modified.
+     *
+     * @param values - Current form values.
+     * @returns Validation errors keyed by field name.
+     */
+    const validateForm = (values: GenerateClientSecretFormValues): Record<string, string> => {
+        const errors: Record<string, string> = {};
+
+        if (values.expiration === ClientSecretExpirationOption.CUSTOM) {
+            const days: number = Number(values.customExpiryDays);
+
+            if (!values.customExpiryDays) {
+                errors.customExpiryDays =
+                    t("applications:clientSecrets.wizard.customExpiry.validations.required");
+            } else if (isNaN(days) || days < CUSTOM_EXPIRY_MIN_DAYS || days > CUSTOM_EXPIRY_MAX_DAYS) {
+                errors.customExpiryDays =
+                    t("applications:clientSecrets.wizard.customExpiry.validations.invalid");
+            }
+        }
+
+        return errors;
+    };
+
+    return (
+        <Modal
+            className="wizard application-create-wizard"
+            dimmer="blurring"
+            size="small"
+            open={ open }
+            onClose={ onCancel }
+            onKeyPress={ (event: React.KeyboardEvent) => {
+                if (event.key === "Enter" && open) {
+                    formRef?.current?.triggerSubmit();
+                }
+            } }
+            data-componentid={ componentId }
+        >
+            <Modal.Header className="wizard-header">
+                { t("applications:clientSecrets.wizard.heading") }
+                <Heading as="h6">
+                    { t("applications:clientSecrets.wizard.subHeading") }
+                </Heading>
+            </Modal.Header>
+            <Modal.Content className="content-container">
+                { alert && alertComponent }
+                <Form
+                    id={ FORM_ID }
+                    ref={ formRef }
+                    uncontrolledForm={ false }
+                    onSubmit={ handleSubmit }
+                    validate={ validateForm }
+                    initialValues={ { expiration: ClientSecretExpirationOption.THIRTY_DAYS } }
+                >
+                    <Field.Dropdown
+                        required
+                        name="expiration"
+                        label={ t("applications:clientSecrets.wizard.expiration.label") }
+                        ariaLabel={ t("applications:clientSecrets.wizard.expiration.label") }
+                        options={ expirationOptions }
+                        value={ selectedExpiration }
+                        listen={ (value: ClientSecretExpirationOption) => setSelectedExpiration(value) }
+                        data-componentid={ `${ componentId }-expiration` }
+                    />
+                    { selectedExpiration === ClientSecretExpirationOption.CUSTOM && (
+                        <Field.Input
+                            required
+                            name="customExpiryDays"
+                            inputType="number"
+                            label={ t("applications:clientSecrets.wizard.customExpiry.label") }
+                            ariaLabel={ t("applications:clientSecrets.wizard.customExpiry.label") }
+                            placeholder={ t("applications:clientSecrets.wizard.customExpiry.placeholder") }
+                            min={ CUSTOM_EXPIRY_MIN_DAYS }
+                            max={ CUSTOM_EXPIRY_MAX_DAYS }
+                            minLength={ 1 }
+                            maxLength={ 4 }
+                            data-componentid={ `${ componentId }-custom-expiry` }
+                        />
+                    ) }
+                    <Message
+                        type="warning"
+                        content={ t("applications:clientSecrets.wizard.expiryWarning") }
+                        data-componentid={ `${ componentId }-expiry-warning` }
+                    />
+                </Form>
+            </Modal.Content>
+            <Modal.Actions>
+                <Grid>
+                    <Grid.Row column={ 1 }>
+                        <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 8 }>
+                            <LinkButton
+                                floated="left"
+                                onClick={ onCancel }
+                                data-componentid={ `${ componentId }-cancel-button` }
+                            >
+                                { t("common:cancel") }
+                            </LinkButton>
+                        </Grid.Column>
+                        <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 8 }>
+                            <PrimaryButton
+                                floated="right"
+                                disabled={ isSubmitting }
+                                loading={ isSubmitting }
+                                onClick={ () => formRef?.current?.triggerSubmit() }
+                                data-componentid={ `${ componentId }-generate-button` }
+                            >
+                                { t("applications:clientSecrets.wizard.generateButton") }
+                            </PrimaryButton>
+                        </Grid.Column>
+                    </Grid.Row>
+                </Grid>
+            </Modal.Actions>
+        </Modal>
+    );
+};
+
+export default GenerateClientSecretModal;

--- a/features/admin.applications.v1/components/client-secrets/generate-client-secret-modal.tsx
+++ b/features/admin.applications.v1/components/client-secrets/generate-client-secret-modal.tsx
@@ -17,19 +17,22 @@
  */
 
 import { AlertLevels, HttpErrorResponseDataInterface, IdentifiableComponentInterface } from "@wso2is/core/models";
-import { Field, Form } from "@wso2is/forms";
-import { Heading, LinkButton, Message, PrimaryButton, useWizardAlert } from "@wso2is/react-components";
+import { addAlert } from "@wso2is/core/store";
+import { Field, Form, FormPropsInterface } from "@wso2is/forms";
+import { Heading, LinkButton, Message, PrimaryButton } from "@wso2is/react-components";
 import { AxiosError, AxiosResponse } from "axios";
+import dayjs from "dayjs";
 import React, { FunctionComponent, ReactElement, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useDispatch } from "react-redux";
+import { Dispatch } from "redux";
 import { Grid, Modal } from "semantic-ui-react";
 import { createClientSecret } from "../../api/application";
 import { ClientSecretExpirationOption, ClientSecretInterface } from "../../models/application-inbound";
 
 const FORM_ID: string = "generate-client-secret-form";
-const SECONDS_PER_DAY: number = 24 * 60 * 60;
 const CUSTOM_EXPIRY_MIN_DAYS: number = 1;
-const CUSTOM_EXPIRY_MAX_DAYS: number = 3650;
+const CUSTOM_EXPIRY_MAX_DAYS: number = 9999;
 
 /**
  * Shape of the generate client secret form values.
@@ -60,10 +63,27 @@ interface GenerateClientSecretModalPropsInterface extends IdentifiableComponentI
      */
     onGenerated: (secret: ClientSecretInterface) => void;
     /**
-     * Callback fired when the modal is dismissed.
+     * Callback fired when the modal is closed.
      */
-    onCancel: () => void;
+    onClose: () => void;
 }
+
+/**
+ * Resolves the absolute expiry of the selected expiration option in epoch seconds.
+ *
+ * @param values - Submitted form values.
+ * @returns Expiry as epoch seconds, or undefined for a non-expiring secret.
+ */
+const resolveExpiresAt = (values: GenerateClientSecretFormValues): number | undefined => {
+    switch (values.expiration) {
+        case ClientSecretExpirationOption.NO_EXPIRATION:
+            return undefined;
+        case ClientSecretExpirationOption.CUSTOM:
+            return dayjs().add(Number(values.customExpiryDays), "day").unix();
+        default:
+            return dayjs().add(Number(values.expiration), "day").unix();
+    }
+};
 
 /**
  * Modal to generate a new OAuth2/OIDC client secret.
@@ -80,15 +100,14 @@ const GenerateClientSecretModal: FunctionComponent<GenerateClientSecretModalProp
         appId,
         maxCount,
         onGenerated,
-        onCancel,
+        onClose,
         [ "data-componentid" ]: componentId = "generate-client-secret-modal"
     } = props;
 
     const { t } = useTranslation();
+    const dispatch: Dispatch = useDispatch();
 
-    const [ alert, setAlert, alertComponent ] = useWizardAlert();
-
-    const formRef: React.MutableRefObject<any> = useRef(null);
+    const formRef: React.MutableRefObject<FormPropsInterface> = useRef<FormPropsInterface>(null);
 
     const [ selectedExpiration, setSelectedExpiration ] = useState<ClientSecretExpirationOption>(
         ClientSecretExpirationOption.THIRTY_DAYS
@@ -128,19 +147,6 @@ const GenerateClientSecretModal: FunctionComponent<GenerateClientSecretModalProp
         }
     ];
 
-    const resolveExpiresAt = (values: GenerateClientSecretFormValues): number | undefined => {
-        const nowInSeconds: number = Math.floor(Date.now() / 1000);
-
-        switch (values.expiration) {
-            case ClientSecretExpirationOption.NO_EXPIRATION:
-                return undefined;
-            case ClientSecretExpirationOption.CUSTOM:
-                return nowInSeconds + Number(values.customExpiryDays) * SECONDS_PER_DAY;
-            default:
-                return nowInSeconds + Number(values.expiration) * SECONDS_PER_DAY;
-        }
-    };
-
     const handleSubmit = (values: GenerateClientSecretFormValues): void => {
         setIsSubmitting(true);
 
@@ -149,31 +155,34 @@ const GenerateClientSecretModal: FunctionComponent<GenerateClientSecretModalProp
                 onGenerated(response.data);
             })
             .catch((error: AxiosError<HttpErrorResponseDataInterface>) => {
+                onClose();
+
                 if (error?.response?.status === 409) {
-                    setAlert({
+                    dispatch(addAlert({
                         description: t("applications:clientSecrets.maxCountReachedHint", { count: maxCount }),
                         level: AlertLevels.ERROR,
-                        message: null
-                    });
+                        message: t("applications:clientSecrets.notifications.generateSecret.error.message")
+                    }));
 
                     return;
                 }
 
                 if (error?.response?.data?.description) {
-                    setAlert({
+                    dispatch(addAlert({
                         description: error.response.data.description,
                         level: AlertLevels.ERROR,
                         message: t("applications:clientSecrets.notifications.generateSecret.error.message")
-                    });
+                    }));
 
                     return;
                 }
 
-                setAlert({
-                    description: t("applications:clientSecrets.notifications.generateSecret.genericError.description"),
+                dispatch(addAlert({
+                    description:
+                        t("applications:clientSecrets.notifications.generateSecret.genericError.description"),
                     level: AlertLevels.ERROR,
                     message: t("applications:clientSecrets.notifications.generateSecret.genericError.message")
-                });
+                }));
             })
             .finally(() => setIsSubmitting(false));
     };
@@ -194,7 +203,7 @@ const GenerateClientSecretModal: FunctionComponent<GenerateClientSecretModalProp
             if (!values.customExpiryDays) {
                 errors.customExpiryDays =
                     t("applications:clientSecrets.wizard.customExpiry.validations.required");
-            } else if (isNaN(days) || days < CUSTOM_EXPIRY_MIN_DAYS || days > CUSTOM_EXPIRY_MAX_DAYS) {
+            } else if (!Number.isInteger(days) || days < CUSTOM_EXPIRY_MIN_DAYS || days > CUSTOM_EXPIRY_MAX_DAYS) {
                 errors.customExpiryDays =
                     t("applications:clientSecrets.wizard.customExpiry.validations.invalid");
             }
@@ -209,7 +218,7 @@ const GenerateClientSecretModal: FunctionComponent<GenerateClientSecretModalProp
             dimmer="blurring"
             size="small"
             open={ open }
-            onClose={ onCancel }
+            onClose={ onClose }
             onKeyPress={ (event: React.KeyboardEvent) => {
                 if (event.key === "Enter" && open) {
                     formRef?.current?.triggerSubmit();
@@ -224,7 +233,6 @@ const GenerateClientSecretModal: FunctionComponent<GenerateClientSecretModalProp
                 </Heading>
             </Modal.Header>
             <Modal.Content className="content-container">
-                { alert && alertComponent }
                 <Form
                     id={ FORM_ID }
                     ref={ formRef }
@@ -240,7 +248,7 @@ const GenerateClientSecretModal: FunctionComponent<GenerateClientSecretModalProp
                         ariaLabel={ t("applications:clientSecrets.wizard.expiration.label") }
                         options={ expirationOptions }
                         value={ selectedExpiration }
-                        listen={ (value: ClientSecretExpirationOption) => setSelectedExpiration(value) }
+                        listen={ setSelectedExpiration }
                         data-componentid={ `${ componentId }-expiration` }
                     />
                     { selectedExpiration === ClientSecretExpirationOption.CUSTOM && (
@@ -271,7 +279,7 @@ const GenerateClientSecretModal: FunctionComponent<GenerateClientSecretModalProp
                         <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 8 }>
                             <LinkButton
                                 floated="left"
-                                onClick={ onCancel }
+                                onClick={ onClose }
                                 data-componentid={ `${ componentId }-cancel-button` }
                             >
                                 { t("common:cancel") }

--- a/features/admin.applications.v1/components/client-secrets/generated-client-secret-modal.tsx
+++ b/features/admin.applications.v1/components/client-secrets/generated-client-secret-modal.tsx
@@ -36,6 +36,10 @@ interface GeneratedClientSecretModalPropsInterface extends IdentifiableComponent
      */
     secret: ClientSecretInterface;
     /**
+     * Client ID of the application, displayed alongside the generated secret.
+     */
+    clientId?: string;
+    /**
      * Callback fired when the modal is dismissed.
      */
     onClose: () => void;
@@ -54,6 +58,7 @@ const GeneratedClientSecretModal: FunctionComponent<GeneratedClientSecretModalPr
     const {
         open,
         secret,
+        clientId,
         onClose,
         [ "data-componentid" ]: componentId = "generated-client-secret-modal"
     } = props;
@@ -81,6 +86,18 @@ const GeneratedClientSecretModal: FunctionComponent<GeneratedClientSecretModalPr
             </ConfirmationModal.Message>
             <ConfirmationModal.Content data-componentid={ `${ componentId }-content` }>
                 <Form>
+                    { clientId && (
+                        <Form.Field>
+                            <label>
+                                { t("applications:confirmations.clientSecretHashDisclaimer.forms." +
+                                    "clientIdSecretForm.clientId.label") }
+                            </label>
+                            <CopyInputField
+                                value={ clientId }
+                                data-componentid={ `${ componentId }-client-id` }
+                            />
+                        </Form.Field>
+                    ) }
                     <Form.Field>
                         <label>
                             { t("applications:confirmations.clientSecretHashDisclaimer.forms." +

--- a/features/admin.applications.v1/components/client-secrets/generated-client-secret-modal.tsx
+++ b/features/admin.applications.v1/components/client-secrets/generated-client-secret-modal.tsx
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { IdentifiableComponentInterface } from "@wso2is/core/models";
+import { ConfirmationModal, CopyInputField } from "@wso2is/react-components";
+import React, { FunctionComponent, ReactElement } from "react";
+import { useTranslation } from "react-i18next";
+import { Form } from "semantic-ui-react";
+import { ClientSecretInterface } from "../../models/application-inbound";
+
+/**
+ * Props for the generated client secret modal component.
+ */
+interface GeneratedClientSecretModalPropsInterface extends IdentifiableComponentInterface {
+    /**
+     * Whether the modal is open.
+     */
+    open: boolean;
+    /**
+     * The newly generated client secret to display once.
+     */
+    secret: ClientSecretInterface;
+    /**
+     * Callback fired when the modal is dismissed.
+     */
+    onClose: () => void;
+}
+
+/**
+ * One-time reveal of a newly generated client secret value.
+ *
+ * @param props - Props injected to the component.
+ * @returns Generated client secret modal.
+ */
+const GeneratedClientSecretModal: FunctionComponent<GeneratedClientSecretModalPropsInterface> = (
+    props: GeneratedClientSecretModalPropsInterface
+): ReactElement => {
+
+    const {
+        open,
+        secret,
+        onClose,
+        [ "data-componentid" ]: componentId = "generated-client-secret-modal"
+    } = props;
+
+    const { t } = useTranslation();
+
+    return (
+        <ConfirmationModal
+            type="warning"
+            open={ open }
+            primaryAction={ t("common:confirm") }
+            onPrimaryActionClick={ onClose }
+            onClose={ onClose }
+            data-componentid={ componentId }
+        >
+            <ConfirmationModal.Header data-componentid={ `${ componentId }-header` }>
+                { t("applications:confirmations.clientSecretHashDisclaimer.modal.header") }
+            </ConfirmationModal.Header>
+            <ConfirmationModal.Message
+                attached
+                warning
+                data-componentid={ `${ componentId }-message` }
+            >
+                { t("applications:confirmations.clientSecretHashDisclaimer.modal.message") }
+            </ConfirmationModal.Message>
+            <ConfirmationModal.Content data-componentid={ `${ componentId }-content` }>
+                <Form>
+                    <Form.Field>
+                        <label>
+                            { t("applications:confirmations.clientSecretHashDisclaimer.forms." +
+                                "clientIdSecretForm.clientSecret.label") }
+                        </label>
+                        <CopyInputField
+                            secret
+                            value={ secret?.secretValue }
+                            hideSecretLabel={ t("applications:confirmations.clientSecretHashDisclaimer.forms." +
+                                "clientIdSecretForm.clientSecret.hide") }
+                            showSecretLabel={ t("applications:confirmations.clientSecretHashDisclaimer.forms." +
+                                "clientIdSecretForm.clientSecret.show") }
+                            data-componentid={ `${ componentId }-value` }
+                        />
+                    </Form.Field>
+                </Form>
+            </ConfirmationModal.Content>
+        </ConfirmationModal>
+    );
+};
+
+export default GeneratedClientSecretModal;

--- a/features/admin.applications.v1/components/client-secrets/previous-client-secrets.scss
+++ b/features/admin.applications.v1/components/client-secrets/previous-client-secrets.scss
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.previous-client-secrets {
+    margin-top: 0.75rem;
+
+    /* Constrain the rotation info message to the same width as the secret field, and keep the
+       standard 1rem vertical rhythm used between secret rows. */
+    .previous-client-secrets-info {
+        max-width: 570px;
+        margin-bottom: 1rem;
+    }
+
+    /* Beyond 3 secrets, cap the height (~3 rows) and scroll the rest. */
+    .previous-client-secrets-list-scroll {
+        max-height: 15rem;
+        overflow-y: auto;
+        padding-right: 0.5rem;
+    }
+}

--- a/features/admin.applications.v1/components/client-secrets/previous-client-secrets.tsx
+++ b/features/admin.applications.v1/components/client-secrets/previous-client-secrets.tsx
@@ -19,7 +19,7 @@
 import IconButton from "@oxygen-ui/react/IconButton";
 import { TrashIcon } from "@oxygen-ui/react-icons";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
-import { ContentLoader, Message } from "@wso2is/react-components";
+import { ContentLoader, Message, Popup } from "@wso2is/react-components";
 import classNames from "classnames";
 import React, { FunctionComponent, ReactElement } from "react";
 import { useTranslation } from "react-i18next";
@@ -85,13 +85,16 @@ const PreviousClientSecrets: FunctionComponent<PreviousClientSecretsPropsInterfa
 
     return (
         <div className="previous-client-secrets" data-componentid={ componentId }>
-            <div className="previous-client-secrets-info">
-                <Message
-                    type="info"
-                    content={ t("applications:clientSecrets.rotationInfo") }
-                    data-componentid={ `${ componentId }-info` }
-                />
-            </div>
+            { /* The rotation hint guides generating/deleting secrets, so hide it in read-only mode. */ }
+            { !readOnly && (
+                <div className="previous-client-secrets-info">
+                    <Message
+                        type="info"
+                        content={ t("applications:clientSecrets.rotationInfo") }
+                        data-componentid={ `${ componentId }-info` }
+                    />
+                </div>
+            ) }
             <div
                 className={ classNames("previous-client-secrets-list", {
                     "previous-client-secrets-list-scroll": secrets?.length > MAX_VISIBLE_ROWS
@@ -103,14 +106,21 @@ const PreviousClientSecrets: FunctionComponent<PreviousClientSecretsPropsInterfa
                         secret={ secret }
                         hideSecretValue={ hideSecretValue }
                         action={ !readOnly && (
-                            <IconButton
-                                type="button"
-                                onClick={ (): void => onDelete(secret) }
-                                aria-label={ t("common:delete") }
-                                data-componentid={ `${ componentId }-delete-${ index }` }
-                            >
-                                <TrashIcon size={ 16 } />
-                            </IconButton>
+                            <Popup
+                                trigger={ (
+                                    <IconButton
+                                        type="button"
+                                        onClick={ (): void => onDelete(secret) }
+                                        aria-label={ t("common:delete") }
+                                        data-componentid={ `${ componentId }-delete-${ index }` }
+                                    >
+                                        <TrashIcon />
+                                    </IconButton>
+                                ) }
+                                position="top center"
+                                content={ t("common:delete") }
+                                inverted
+                            />
                         ) }
                         data-componentid={ `${ componentId }-row-${ index }` }
                     />

--- a/features/admin.applications.v1/components/client-secrets/previous-client-secrets.tsx
+++ b/features/admin.applications.v1/components/client-secrets/previous-client-secrets.tsx
@@ -85,13 +85,12 @@ const PreviousClientSecrets: FunctionComponent<PreviousClientSecretsPropsInterfa
 
     return (
         <div className="previous-client-secrets" data-componentid={ componentId }>
-            { /* The rotation hint guides generating/deleting secrets, so hide it in read-only mode. */ }
             { !readOnly && (
                 <div className="previous-client-secrets-info">
                     <Message
-                        type="info"
-                        content={ t("applications:clientSecrets.rotationInfo") }
-                        data-componentid={ `${ componentId }-info` }
+                        type="warning"
+                        content={ t("applications:clientSecrets.rotationWarning") }
+                        data-componentid={ `${ componentId }-warning` }
                     />
                 </div>
             ) }

--- a/features/admin.applications.v1/components/client-secrets/previous-client-secrets.tsx
+++ b/features/admin.applications.v1/components/client-secrets/previous-client-secrets.tsx
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import IconButton from "@oxygen-ui/react/IconButton";
+import { TrashIcon } from "@oxygen-ui/react-icons";
+import { IdentifiableComponentInterface } from "@wso2is/core/models";
+import { ContentLoader, Message } from "@wso2is/react-components";
+import classNames from "classnames";
+import React, { FunctionComponent, ReactElement } from "react";
+import { useTranslation } from "react-i18next";
+import ClientSecretRow from "./client-secret-row";
+import "./previous-client-secrets.scss";
+import { ClientSecretInterface } from "../../models/application-inbound";
+
+/**
+ * Number of previous secrets shown before the list becomes scrollable.
+ */
+const MAX_VISIBLE_ROWS: number = 3;
+
+/**
+ * Props for the previous client secrets list.
+ */
+interface PreviousClientSecretsPropsInterface extends IdentifiableComponentInterface {
+    /**
+     * Previous (non-latest) client secrets.
+     */
+    secrets: ClientSecretInterface[];
+    /**
+     * Whether the list is being fetched.
+     */
+    isLoading: boolean;
+    /**
+     * Whether the list is rendered in read-only mode.
+     */
+    readOnly?: boolean;
+    /**
+     * Whether secret values are unavailable (client secret hashing enabled).
+     */
+    hideSecretValue?: boolean;
+    /**
+     * Callback fired when a secret's delete icon is clicked.
+     */
+    onDelete: (secret: ClientSecretInterface) => void;
+}
+
+/**
+ * Renders the lazily-loaded list of previous client secrets, each with a delete action.
+ *
+ * @param props - Props injected to the component.
+ * @returns Previous client secrets list.
+ */
+const PreviousClientSecrets: FunctionComponent<PreviousClientSecretsPropsInterface> = (
+    props: PreviousClientSecretsPropsInterface
+): ReactElement => {
+
+    const {
+        secrets,
+        isLoading,
+        readOnly,
+        hideSecretValue,
+        onDelete,
+        [ "data-componentid" ]: componentId = "previous-client-secrets"
+    } = props;
+
+    const { t } = useTranslation();
+
+    if (isLoading) {
+        return <ContentLoader data-componentid={ `${ componentId }-loader` } />;
+    }
+
+    return (
+        <div className="previous-client-secrets" data-componentid={ componentId }>
+            <div className="previous-client-secrets-info">
+                <Message
+                    type="info"
+                    content={ t("applications:clientSecrets.rotationInfo") }
+                    data-componentid={ `${ componentId }-info` }
+                />
+            </div>
+            <div
+                className={ classNames("previous-client-secrets-list", {
+                    "previous-client-secrets-list-scroll": secrets?.length > MAX_VISIBLE_ROWS
+                }) }
+            >
+                { secrets?.map((secret: ClientSecretInterface, index: number) => (
+                    <ClientSecretRow
+                        key={ secret?.secretId ?? index }
+                        secret={ secret }
+                        hideSecretValue={ hideSecretValue }
+                        action={ !readOnly && (
+                            <IconButton
+                                type="button"
+                                onClick={ (): void => onDelete(secret) }
+                                aria-label={ t("common:delete") }
+                                data-componentid={ `${ componentId }-delete-${ index }` }
+                            >
+                                <TrashIcon size={ 16 } />
+                            </IconButton>
+                        ) }
+                        data-componentid={ `${ componentId }-row-${ index }` }
+                    />
+                )) }
+            </div>
+        </div>
+    );
+};
+
+export default PreviousClientSecrets;

--- a/features/admin.applications.v1/components/client-secrets/revoke-all-client-secrets-danger-zone.tsx
+++ b/features/admin.applications.v1/components/client-secrets/revoke-all-client-secrets-danger-zone.tsx
@@ -16,19 +16,12 @@
  * under the License.
  */
 
-import { FeatureAccessConfigInterface, useRequiredScopes } from "@wso2is/access-control";
-import { AppState } from "@wso2is/admin.core.v1/store";
-import { isFeatureEnabled } from "@wso2is/core/helpers";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import { ConfirmationModal, DangerZone, DangerZoneGroup } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useSelector } from "react-redux";
 import { Divider } from "semantic-ui-react";
-import {
-    ApplicationFeatureDictionaryKeys,
-    ApplicationManagementConstants
-} from "../../constants/application-management";
+import useClientSecretManagement from "../../hooks/use-client-secret-management";
 
 /**
  * Props for the revoke all client secrets danger zone component.
@@ -62,27 +55,15 @@ const RevokeAllClientSecretsDangerZone: FunctionComponent<RevokeAllClientSecrets
 
     const { t } = useTranslation();
 
-    const applicationFeatureConfig: FeatureAccessConfigInterface = useSelector((state: AppState) =>
-        state?.config?.ui?.features?.applications);
-
-    const isEnforceClientSecretPermissionEnabled: boolean = isFeatureEnabled(
-        applicationFeatureConfig,
-        ApplicationManagementConstants.FEATURE_DICTIONARY.get(
-            ApplicationFeatureDictionaryKeys.ApplicationEditEnforceClientSecretPermission) ?? ""
-    );
-    /* Regenerating a secret maps to the update level of the client secret management resource. */
-    const hasClientSecretRegeneratePermission: boolean = useRequiredScopes(
-        applicationFeatureConfig?.subFeatures?.applicationClientSecretManagement?.scopes?.update ?? []);
+    const { isEnforceClientSecretPermissionEnabled, hasClientSecretCreatePermission } = useClientSecretManagement();
 
     const [ showConfirmationModal, setShowConfirmationModal ] = useState<boolean>(false);
 
     /*
-     * Mirrors the pre-feature regenerate gate: the app must be editable, and when client secret
-     * permission enforcement is on, the dedicated regenerate scope is additionally required. With
-     * enforcement off, the regenerate-secret endpoint falls back to broad application management,
-     * which the readOnly gate already covers.
+     * The regenerate-secret endpoint reuses the create scope when permission enforcement is on;
+     * with enforcement off it only needs application update access, which readOnly covers.
      */
-    if (readOnly || (isEnforceClientSecretPermissionEnabled && !hasClientSecretRegeneratePermission)) {
+    if (readOnly || (isEnforceClientSecretPermissionEnabled && !hasClientSecretCreatePermission)) {
         return null;
     }
 

--- a/features/admin.applications.v1/components/client-secrets/revoke-all-client-secrets-danger-zone.tsx
+++ b/features/admin.applications.v1/components/client-secrets/revoke-all-client-secrets-danger-zone.tsx
@@ -39,7 +39,7 @@ interface RevokeAllClientSecretsDangerZonePropsInterface extends IdentifiableCom
      */
     onRevokeAll: () => void;
     /**
-     * Whether the danger zone is rendered in read-only mode.
+     * Whether the application is in a read-only (non-editable) state.
      */
     readOnly?: boolean;
 }
@@ -52,7 +52,7 @@ interface RevokeAllClientSecretsDangerZonePropsInterface extends IdentifiableCom
  */
 const RevokeAllClientSecretsDangerZone: FunctionComponent<RevokeAllClientSecretsDangerZonePropsInterface> = (
     props: RevokeAllClientSecretsDangerZonePropsInterface
-): ReactElement => {
+): ReactElement | null => {
 
     const {
         onRevokeAll,
@@ -68,18 +68,21 @@ const RevokeAllClientSecretsDangerZone: FunctionComponent<RevokeAllClientSecrets
     const isEnforceClientSecretPermissionEnabled: boolean = isFeatureEnabled(
         applicationFeatureConfig,
         ApplicationManagementConstants.FEATURE_DICTIONARY.get(
-            ApplicationFeatureDictionaryKeys.ApplicationEditEnforceClientSecretPermission)
+            ApplicationFeatureDictionaryKeys.ApplicationEditEnforceClientSecretPermission) ?? ""
     );
-    const hasClientSecretCreatePermission: boolean = useRequiredScopes(
-        applicationFeatureConfig?.subFeatures?.applicationClientSecretManagement?.scopes?.create);
+    /* Regenerating a secret maps to the update level of the client secret management resource. */
+    const hasClientSecretRegeneratePermission: boolean = useRequiredScopes(
+        applicationFeatureConfig?.subFeatures?.applicationClientSecretManagement?.scopes?.update ?? []);
 
     const [ showConfirmationModal, setShowConfirmationModal ] = useState<boolean>(false);
 
     /*
-     * Read-only covers the application update baseline. Regenerating a secret additionally needs the
-     * client secret create scope when client secret permission enforcement is on.
+     * Mirrors the pre-feature regenerate gate: the app must be editable, and when client secret
+     * permission enforcement is on, the dedicated regenerate scope is additionally required. With
+     * enforcement off, the regenerate-secret endpoint falls back to broad application management,
+     * which the readOnly gate already covers.
      */
-    if (readOnly || (isEnforceClientSecretPermissionEnabled && !hasClientSecretCreatePermission)) {
+    if (readOnly || (isEnforceClientSecretPermissionEnabled && !hasClientSecretRegeneratePermission)) {
         return null;
     }
 

--- a/features/admin.applications.v1/components/client-secrets/revoke-all-client-secrets-danger-zone.tsx
+++ b/features/admin.applications.v1/components/client-secrets/revoke-all-client-secrets-danger-zone.tsx
@@ -22,7 +22,7 @@ import { isFeatureEnabled } from "@wso2is/core/helpers";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import { ConfirmationModal, DangerZone, DangerZoneGroup } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useState } from "react";
-import { Trans, useTranslation } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { Divider } from "semantic-ui-react";
 import {
@@ -34,10 +34,6 @@ import {
  * Props for the revoke all client secrets danger zone component.
  */
 interface RevokeAllClientSecretsDangerZonePropsInterface extends IdentifiableComponentInterface {
-    /**
-     * Client ID of the application, used as the assertion to confirm the action.
-     */
-    clientId: string;
     /**
      * Callback fired when the revocation is confirmed.
      */
@@ -59,7 +55,6 @@ const RevokeAllClientSecretsDangerZone: FunctionComponent<RevokeAllClientSecrets
 ): ReactElement => {
 
     const {
-        clientId,
         onRevokeAll,
         readOnly,
         [ "data-componentid" ]: componentId = "revoke-all-client-secrets-danger-zone"
@@ -103,21 +98,10 @@ const RevokeAllClientSecretsDangerZone: FunctionComponent<RevokeAllClientSecrets
                 />
             </DangerZoneGroup>
             <ConfirmationModal
-                type="warning"
+                type="negative"
                 open={ showConfirmationModal }
-                assertion={ clientId }
-                assertionHint={ (
-                    <p>
-                        <Trans
-                            i18nKey="applications:clientSecrets.dangerZone.revokeAll.confirmation.assertionHint"
-                            tOptions={ { id: clientId } }
-                        >
-                            Please type <strong>{ clientId }</strong> to revoke all the client secrets
-                            and regenerate a new one.
-                        </Trans>
-                    </p>
-                ) }
-                assertionType="input"
+                assertionHint={ t("applications:clientSecrets.dangerZone.revokeAll.confirmation.assertionHint") }
+                assertionType="checkbox"
                 primaryAction={ t("common:confirm") }
                 secondaryAction={ t("common:cancel") }
                 onClose={ (): void => setShowConfirmationModal(false) }
@@ -134,7 +118,7 @@ const RevokeAllClientSecretsDangerZone: FunctionComponent<RevokeAllClientSecrets
                 </ConfirmationModal.Header>
                 <ConfirmationModal.Message
                     attached
-                    warning
+                    negative
                     data-componentid={ `${ componentId }-confirmation-modal-message` }
                 >
                     { t("applications:clientSecrets.dangerZone.revokeAll.confirmation.message") }

--- a/features/admin.applications.v1/components/client-secrets/revoke-all-client-secrets-danger-zone.tsx
+++ b/features/admin.applications.v1/components/client-secrets/revoke-all-client-secrets-danger-zone.tsx
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { FeatureAccessConfigInterface, useRequiredScopes } from "@wso2is/access-control";
+import { AppState } from "@wso2is/admin.core.v1/store";
+import { isFeatureEnabled } from "@wso2is/core/helpers";
+import { IdentifiableComponentInterface } from "@wso2is/core/models";
+import { ConfirmationModal, DangerZone, DangerZoneGroup } from "@wso2is/react-components";
+import React, { FunctionComponent, ReactElement, useState } from "react";
+import { Trans, useTranslation } from "react-i18next";
+import { useSelector } from "react-redux";
+import { Divider } from "semantic-ui-react";
+import {
+    ApplicationFeatureDictionaryKeys,
+    ApplicationManagementConstants
+} from "../../constants/application-management";
+
+/**
+ * Props for the revoke all client secrets danger zone component.
+ */
+interface RevokeAllClientSecretsDangerZonePropsInterface extends IdentifiableComponentInterface {
+    /**
+     * Client ID of the application, used as the assertion to confirm the action.
+     */
+    clientId: string;
+    /**
+     * Callback fired when the revocation is confirmed.
+     */
+    onRevokeAll: () => void;
+    /**
+     * Whether the danger zone is rendered in read-only mode.
+     */
+    readOnly?: boolean;
+}
+
+/**
+ * Danger zone that revokes all client secrets and regenerates a fresh one.
+ *
+ * @param props - Props injected to the component.
+ * @returns Revoke all client secrets danger zone.
+ */
+const RevokeAllClientSecretsDangerZone: FunctionComponent<RevokeAllClientSecretsDangerZonePropsInterface> = (
+    props: RevokeAllClientSecretsDangerZonePropsInterface
+): ReactElement => {
+
+    const {
+        clientId,
+        onRevokeAll,
+        readOnly,
+        [ "data-componentid" ]: componentId = "revoke-all-client-secrets-danger-zone"
+    } = props;
+
+    const { t } = useTranslation();
+
+    const applicationFeatureConfig: FeatureAccessConfigInterface = useSelector((state: AppState) =>
+        state?.config?.ui?.features?.applications);
+
+    const isEnforceClientSecretPermissionEnabled: boolean = isFeatureEnabled(
+        applicationFeatureConfig,
+        ApplicationManagementConstants.FEATURE_DICTIONARY.get(
+            ApplicationFeatureDictionaryKeys.ApplicationEditEnforceClientSecretPermission)
+    );
+    const hasClientSecretCreatePermission: boolean = useRequiredScopes(
+        applicationFeatureConfig?.subFeatures?.applicationClientSecretManagement?.scopes?.create);
+
+    const [ showConfirmationModal, setShowConfirmationModal ] = useState<boolean>(false);
+
+    /*
+     * Read-only covers the application update baseline. Regenerating a secret additionally needs the
+     * client secret create scope when client secret permission enforcement is on.
+     */
+    if (readOnly || (isEnforceClientSecretPermissionEnabled && !hasClientSecretCreatePermission)) {
+        return null;
+    }
+
+    return (
+        <>
+            <Divider hidden />
+            <DangerZoneGroup
+                sectionHeader={ t("applications:dangerZoneGroup.header") }
+            >
+                <DangerZone
+                    actionTitle={ t("applications:clientSecrets.dangerZone.revokeAll.actionTitle") }
+                    header={ t("applications:clientSecrets.dangerZone.revokeAll.header") }
+                    subheader={ t("applications:clientSecrets.dangerZone.revokeAll.subheader") }
+                    onActionClick={ (): void => setShowConfirmationModal(true) }
+                    data-componentid={ `${ componentId }-danger-zone` }
+                />
+            </DangerZoneGroup>
+            <ConfirmationModal
+                type="warning"
+                open={ showConfirmationModal }
+                assertion={ clientId }
+                assertionHint={ (
+                    <p>
+                        <Trans
+                            i18nKey="applications:clientSecrets.dangerZone.revokeAll.confirmation.assertionHint"
+                            tOptions={ { id: clientId } }
+                        >
+                            Please type <strong>{ clientId }</strong> to revoke all the client secrets
+                            and regenerate a new one.
+                        </Trans>
+                    </p>
+                ) }
+                assertionType="input"
+                primaryAction={ t("common:confirm") }
+                secondaryAction={ t("common:cancel") }
+                onClose={ (): void => setShowConfirmationModal(false) }
+                onSecondaryActionClick={ (): void => setShowConfirmationModal(false) }
+                onPrimaryActionClick={ (): void => {
+                    onRevokeAll();
+                    setShowConfirmationModal(false);
+                } }
+                closeOnDimmerClick={ false }
+                data-componentid={ `${ componentId }-confirmation-modal` }
+            >
+                <ConfirmationModal.Header data-componentid={ `${ componentId }-confirmation-modal-header` }>
+                    { t("applications:clientSecrets.dangerZone.revokeAll.confirmation.header") }
+                </ConfirmationModal.Header>
+                <ConfirmationModal.Message
+                    attached
+                    warning
+                    data-componentid={ `${ componentId }-confirmation-modal-message` }
+                >
+                    { t("applications:clientSecrets.dangerZone.revokeAll.confirmation.message") }
+                </ConfirmationModal.Message>
+                <ConfirmationModal.Content data-componentid={ `${ componentId }-confirmation-modal-content` }>
+                    { t("applications:clientSecrets.dangerZone.revokeAll.confirmation.content") }
+                </ConfirmationModal.Content>
+            </ConfirmationModal>
+        </>
+    );
+};
+
+export default RevokeAllClientSecretsDangerZone;

--- a/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
+++ b/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
@@ -23,7 +23,7 @@ import Autocomplete, {
 import Box from "@oxygen-ui/react/Box";
 import Chip from "@oxygen-ui/react/Chip";
 import TextField from "@oxygen-ui/react/TextField";
-import { FeatureAccessConfigInterface, useRequiredScopes } from "@wso2is/access-control";
+import { FeatureAccessConfigInterface } from "@wso2is/access-control";
 import {
     ApplicationTabComponentsFilter
 } from "@wso2is/admin.application-templates.v1/components/application-tab-components-filter";
@@ -92,10 +92,7 @@ import { Dispatch } from "redux";
 import { Button, Container, Divider, DropdownProps, Form, Grid, Icon, Label, List, Radio, Table } from "semantic-ui-react";
 import { OIDCScopesManagementConstants } from "../../../admin.oidc-scopes.v1/constants";
 import { getGeneralIcons } from "../../configs/ui";
-import {
-    ApplicationFeatureDictionaryKeys,
-    ApplicationManagementConstants
-} from "../../constants/application-management";
+import { ApplicationManagementConstants } from "../../constants/application-management";
 import CustomApplicationTemplate from
     "../../data/application-templates/templates/custom-application/custom-application.json";
 import M2MApplicationTemplate from "../../data/application-templates/templates/m2m-application/m2m-application.json";
@@ -105,6 +102,7 @@ import OIDCWebApplicationTemplate from
 import SinglePageApplicationTemplate from
     "../../data/application-templates/templates/single-page-application/single-page-application.json";
 import useAllowedIssuers from "../../hooks/use-allowed-issuers";
+import useClientSecretManagement from "../../hooks/use-client-secret-management";
 import { useFapiProfileConstraints } from "@wso2is/admin.fapi-security-policy.v1";
 import {
     ApplicationInterface,
@@ -235,8 +233,6 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
 
     const isClientSecretHashEnabled: boolean = useSelector((state: AppState) =>
         state.config.ui.isClientSecretHashEnabled);
-    const isMultipleClientSecretsEnabled: boolean = useSelector((state: AppState) =>
-        Boolean(state?.config?.ui?.features?.applications?.properties?.isMultipleClientSecretsEnabled));
     const orgType: OrganizationType = useSelector((state: AppState) =>
         state?.organization?.organizationType);
     const currentOrganization: OrganizationResponseInterface = useSelector((state: AppState) =>
@@ -261,20 +257,17 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
         applicationFeatureConfig,
         ApplicationManagementConstants.FEATURE_DICTIONARY.get("APPLICATION_EDIT_ACCESS_CONFIG_FRONT_CHANNEL_LOGOUT")
     );
-    const isEnforceClientSecretPermissionEnabled: boolean = isFeatureEnabled(
-        applicationFeatureConfig,
-        ApplicationManagementConstants.FEATURE_DICTIONARY.get(
-            ApplicationFeatureDictionaryKeys.ApplicationEditEnforceClientSecretPermission) ?? ""
-    );
     const isTokenIssuerSelectionEnabled: boolean = isFeatureEnabled(
         organizationsFeatureConfig,
         OrganizationManagementConstants.FEATURE_DICTIONARY.get("ORGANIZATION_APPLICATION_TOKEN_ISSUER_SELECTION")
     );
 
-    const hasClientSecretReadPermission: boolean = useRequiredScopes(
-        applicationFeatureConfig?.subFeatures?.applicationClientSecretManagement?.scopes?.read ?? []);
-    const hasClientSecretCreatePermission: boolean = useRequiredScopes(
-        applicationFeatureConfig?.subFeatures?.applicationClientSecretManagement?.scopes?.create ?? []);
+    const {
+        isEnforceClientSecretPermissionEnabled,
+        hasClientSecretReadPermission,
+        hasClientSecretCreatePermission,
+        maxSecretCount
+    } = useClientSecretManagement();
 
     const { isFAPIApplication, fapiProfile: initialFapiProfile } = initialValues;
     const [ selectedFapiProfile, setSelectedFapiProfile ] = useState<FapiProfile | null>(
@@ -5647,10 +5640,8 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                             && !isPublicClient
                             && !isSystemApplication
                             && !isDefaultApplication
-                            && (isMultipleClientSecretsEnabled
-                                ? hasClientSecretReadPermission
-                                : (!isEnforceClientSecretPermissionEnabled
-                                    || hasClientSecretReadPermission))
+                            && (!isEnforceClientSecretPermissionEnabled
+                                || hasClientSecretReadPermission)
                             && (
                                 <Grid.Row columns={ 2 } data-componentid={ `${ testId }-oidc-client-secret` }>
                                     <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
@@ -5659,10 +5650,11 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                                 { t("applications:forms.inboundOIDC.fields.clientSecret.label") }
                                             </label>
                                             {
-                                                isMultipleClientSecretsEnabled
+                                                maxSecretCount > 1
                                                     ? (
                                                         <ClientSecretsSection
                                                             appId={ application?.id }
+                                                            clientId={ initialValues?.clientId }
                                                             clientSecret={ initialValues?.clientSecret }
                                                             clientSecretExpiresAt={
                                                                 initialValues?.clientSecretExpiresAt

--- a/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
+++ b/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
@@ -264,7 +264,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
     const isEnforceClientSecretPermissionEnabled: boolean = isFeatureEnabled(
         applicationFeatureConfig,
         ApplicationManagementConstants.FEATURE_DICTIONARY.get(
-            ApplicationFeatureDictionaryKeys.ApplicationEditEnforceClientSecretPermission)
+            ApplicationFeatureDictionaryKeys.ApplicationEditEnforceClientSecretPermission) ?? ""
     );
     const isTokenIssuerSelectionEnabled: boolean = isFeatureEnabled(
         organizationsFeatureConfig,
@@ -272,12 +272,9 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
     );
 
     const hasClientSecretReadPermission: boolean = useRequiredScopes(
-        applicationFeatureConfig?.subFeatures?.applicationClientSecretManagement?.scopes?.read);
+        applicationFeatureConfig?.subFeatures?.applicationClientSecretManagement?.scopes?.read ?? []);
     const hasClientSecretCreatePermission: boolean = useRequiredScopes(
-        applicationFeatureConfig?.subFeatures?.applicationClientSecretManagement?.scopes?.create);
-    /* Only enforced when the feature flag is on; otherwise everyone with form access can manage secrets. */
-    const hasClientSecretCreateAccess: boolean =
-        !isEnforceClientSecretPermissionEnabled || hasClientSecretCreatePermission;
+        applicationFeatureConfig?.subFeatures?.applicationClientSecretManagement?.scopes?.create ?? []);
 
     const { isFAPIApplication, fapiProfile: initialFapiProfile } = initialValues;
     const [ selectedFapiProfile, setSelectedFapiProfile ] = useState<FapiProfile | null>(
@@ -5650,8 +5647,10 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                             && !isPublicClient
                             && !isSystemApplication
                             && !isDefaultApplication
-                            && (!isEnforceClientSecretPermissionEnabled
-                                || hasClientSecretReadPermission)
+                            && (isMultipleClientSecretsEnabled
+                                ? hasClientSecretReadPermission
+                                : (!isEnforceClientSecretPermissionEnabled
+                                    || hasClientSecretReadPermission))
                             && (
                                 <Grid.Row columns={ 2 } data-componentid={ `${ testId }-oidc-client-secret` }>
                                     <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
@@ -5671,9 +5670,9 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                                             multipleClientSecretsConfigured={
                                                                 initialValues?.multipleClientSecretsConfigured
                                                             }
-                                                            readOnly={ readOnly || !hasClientSecretCreateAccess }
                                                             hideSecretValue={ isClientSecretHashEnabled }
                                                             onUpdate={ onUpdate }
+                                                            readOnly={ readOnly }
                                                             data-componentid={
                                                                 `${ componentId }-client-secrets-section`
                                                             }

--- a/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
+++ b/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
@@ -130,6 +130,7 @@ import {
 } from "../../models/application-inbound";
 import { ApplicationManagementUtils } from "../../utils/application-management-utils";
 import { AccessTokenAttributeOption } from "../access-token-attribute-option";
+import ClientSecretsSection from "../client-secrets/client-secrets-section";
 import { ApplicationCertificateWrapper } from "../settings/certificate/application-certificate-wrapper";
 import "./inbound-oidc-form.scss";
 
@@ -234,6 +235,8 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
 
     const isClientSecretHashEnabled: boolean = useSelector((state: AppState) =>
         state.config.ui.isClientSecretHashEnabled);
+    const isMultipleClientSecretsEnabled: boolean = useSelector((state: AppState) =>
+        Boolean(state?.config?.ui?.features?.applications?.properties?.isMultipleClientSecretsEnabled));
     const orgType: OrganizationType = useSelector((state: AppState) =>
         state?.organization?.organizationType);
     const currentOrganization: OrganizationResponseInterface = useSelector((state: AppState) =>
@@ -5651,14 +5654,34 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                     <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
                                         <Form.Field>
                                             <label>
-                                                {
-                                                    t("applications:forms.inboundOIDC.fields" +
-                                                        ".clientSecret.label")
-                                                }
+                                                { t("applications:forms.inboundOIDC.fields.clientSecret.label") }
                                             </label>
                                             {
-                                                isClientSecretHashEnabled
+                                                isMultipleClientSecretsEnabled
                                                     ? (
+                                                        <ClientSecretsSection
+                                                            appId={ application?.id }
+                                                            clientSecret={ initialValues?.clientSecret }
+                                                            clientSecretExpiresAt={
+                                                                initialValues?.clientSecretExpiresAt
+                                                            }
+                                                            multipleClientSecretsConfigured={
+                                                                initialValues?.multipleClientSecretsConfigured
+                                                            }
+                                                            hasCreatePermission={
+                                                                !isEnforceClientSecretPermissionEnabled
+                                                                || hasClientSecretCreatePermission
+                                                            }
+                                                            readOnly={ readOnly }
+                                                            hideSecretValue={ isClientSecretHashEnabled }
+                                                            onUpdate={ onUpdate }
+                                                            data-componentid={
+                                                                `${ componentId }-client-secrets-section`
+                                                            }
+                                                        />
+                                                    )
+                                                    : isClientSecretHashEnabled
+                                                        ? (
                                                         <>
                                                             <Message
                                                                 visible

--- a/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
+++ b/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
@@ -275,6 +275,9 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
         applicationFeatureConfig?.subFeatures?.applicationClientSecretManagement?.scopes?.read);
     const hasClientSecretCreatePermission: boolean = useRequiredScopes(
         applicationFeatureConfig?.subFeatures?.applicationClientSecretManagement?.scopes?.create);
+    /* Only enforced when the feature flag is on; otherwise everyone with form access can manage secrets. */
+    const hasClientSecretCreateAccess: boolean =
+        !isEnforceClientSecretPermissionEnabled || hasClientSecretCreatePermission;
 
     const { isFAPIApplication, fapiProfile: initialFapiProfile } = initialValues;
     const [ selectedFapiProfile, setSelectedFapiProfile ] = useState<FapiProfile | null>(
@@ -5668,11 +5671,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                                             multipleClientSecretsConfigured={
                                                                 initialValues?.multipleClientSecretsConfigured
                                                             }
-                                                            hasCreatePermission={
-                                                                !isEnforceClientSecretPermissionEnabled
-                                                                || hasClientSecretCreatePermission
-                                                            }
-                                                            readOnly={ readOnly }
+                                                            readOnly={ readOnly || !hasClientSecretCreateAccess }
                                                             hideSecretValue={ isClientSecretHashEnabled }
                                                             onUpdate={ onUpdate }
                                                             data-componentid={

--- a/features/admin.applications.v1/components/settings/access-configuration.tsx
+++ b/features/admin.applications.v1/components/settings/access-configuration.tsx
@@ -1056,7 +1056,6 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
 
         return (
             <RevokeAllClientSecretsDangerZone
-                clientId={ oidcConfig?.clientId }
                 readOnly={ readOnly }
                 onRevokeAll={ handleRevokeAllClientSecrets }
                 data-componentid={ `${ componentId }-revoke-all-danger-zone` }

--- a/features/admin.applications.v1/components/settings/access-configuration.tsx
+++ b/features/admin.applications.v1/components/settings/access-configuration.tsx
@@ -73,6 +73,7 @@ import CustomApplicationTemplate
     from "../../data/application-templates/templates/custom-application/custom-application.json";
 import CustomProtocolApplicationTemplate from
     "../../data/application-templates/templates/custom-protocol-application/custom-protocol-application.json";
+import useClientSecretManagement from "../../hooks/use-client-secret-management";
 import {
     ApplicationInterface,
     ApplicationTemplateIdTypes,
@@ -247,8 +248,7 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
     const tenantName: string = store.getState().config.deployment.tenant;
     const allowMultipleProtocol: boolean = useSelector(
         (state: AppState) => state.config.deployment.allowMultipleAppProtocols);
-    const isMultipleClientSecretsEnabled: boolean = useSelector((state: AppState) =>
-        Boolean(state?.config?.ui?.features?.applications?.properties?.isMultipleClientSecretsEnabled));
+    const { maxSecretCount } = useClientSecretManagement();
 
     const [ selectedProtocol, setSelectedProtocol ] = useState<SupportedAuthProtocolTypes | string>(undefined);
     const [ inboundProtocolList, setInboundProtocolList ] = useState<string[]>([]);
@@ -1040,11 +1040,20 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
         const oidcConfig: OIDCDataInterface = inboundProtocolConfig?.[ SupportedAuthProtocolTypes.OIDC ];
 
         /*
-         * Public clients (SPAs, mobile apps) authenticate without a client secret, so there is
-         * nothing to revoke or regenerate for them. System and default applications are excluded
-         * as well, to mirror the client secrets listing.
+         * The multi-protocol layout renders every configured protocol at once, so OIDC just needs to
+         * be one of them; the single-protocol view shows only the selected protocol.
          */
-        if (!isMultipleClientSecretsEnabled
+        const isOIDCProtocolInView: boolean = inboundProtocolList.length > 1
+            ? inboundProtocolList.includes(SupportedAuthProtocolTypes.OIDC)
+            : [ SupportedAuthProtocolTypes.OIDC, SupportedAuthProtocolTypes.OAUTH2_OIDC ]
+                .includes(selectedProtocol as SupportedAuthProtocolTypes);
+
+        /*
+         * Hidden unless multiple secrets are enabled and OIDC is in view; also skipped for public
+         * clients, system/default applications, and revoked configurations.
+         */
+        if (!(maxSecretCount > 1)
+            || !isOIDCProtocolInView
             || isSystemApplication
             || isDefaultApplication
             || !oidcConfig?.clientId

--- a/features/admin.applications.v1/components/settings/access-configuration.tsx
+++ b/features/admin.applications.v1/components/settings/access-configuration.tsx
@@ -84,6 +84,7 @@ import {
     OIDCMetadataInterface,
     SAML2ConfigurationInterface,
     SAMLConfigModes,
+    State,
     SupportedAuthProtocolMetaTypes,
     SupportedAuthProtocolTypes,
     SupportedCustomAuthProtocolTypes
@@ -91,6 +92,7 @@ import {
 import { AuthProtocolMetaInterface } from "../../models/reducer-state";
 import { setAuthProtocolMeta } from "../../store/actions/application";
 import { ApplicationManagementUtils } from "../../utils/application-management-utils";
+import RevokeAllClientSecretsDangerZone from "../client-secrets/revoke-all-client-secrets-danger-zone";
 import { InboundFormFactory } from "../forms/inbound-form-factory";
 import { ApplicationCreateWizard } from "../wizard/application-create-wizard";
 
@@ -245,6 +247,8 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
     const tenantName: string = store.getState().config.deployment.tenant;
     const allowMultipleProtocol: boolean = useSelector(
         (state: AppState) => state.config.deployment.allowMultipleAppProtocols);
+    const isMultipleClientSecretsEnabled: boolean = useSelector((state: AppState) =>
+        Boolean(state?.config?.ui?.features?.applications?.properties?.isMultipleClientSecretsEnabled));
 
     const [ selectedProtocol, setSelectedProtocol ] = useState<SupportedAuthProtocolTypes | string>(undefined);
     const [ inboundProtocolList, setInboundProtocolList ] = useState<string[]>([]);
@@ -468,6 +472,31 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
                     level: AlertLevels.ERROR,
                     message: t("applications:notifications.regenerateSecret" +
                         ".genericError.message")
+                }));
+            });
+    };
+
+    /**
+     * Revokes all client secrets of the application and regenerates a new one.
+     */
+    const handleRevokeAllClientSecrets = (): void => {
+        regenerateClientSecret(appId)
+            .then((response: AxiosResponse<OIDCDataInterface>) => {
+                dispatch(addAlert({
+                    description: t("applications:clientSecrets.notifications.revokeAll.success.description"),
+                    level: AlertLevels.SUCCESS,
+                    message: t("applications:clientSecrets.notifications.revokeAll.success.message")
+                }));
+
+                onApplicationSecretRegenerate(response.data);
+                onUpdate(appId);
+            })
+            .catch((error: AxiosError<HttpErrorResponseDataInterface>) => {
+                dispatch(addAlert({
+                    description: error?.response?.data?.description
+                        ?? t("applications:clientSecrets.notifications.revokeAll.genericError.description"),
+                    level: AlertLevels.ERROR,
+                    message: t("applications:clientSecrets.notifications.revokeAll.genericError.message")
                 }));
             });
     };
@@ -1002,6 +1031,40 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
     };
 
     /**
+     * Resolves the client secrets danger zone for OIDC applications.
+     *
+     * @returns Revoke all client secrets danger zone, or null.
+     */
+    const resolveClientSecretsDangerZone = (): ReactElement => {
+
+        const oidcConfig: OIDCDataInterface = inboundProtocolConfig?.[ SupportedAuthProtocolTypes.OIDC ];
+
+        /*
+         * Public clients (SPAs, mobile apps) authenticate without a client secret, so there is
+         * nothing to revoke or regenerate for them. System and default applications are excluded
+         * as well, to mirror the client secrets listing.
+         */
+        if (!isMultipleClientSecretsEnabled
+            || isSystemApplication
+            || isDefaultApplication
+            || !oidcConfig?.clientId
+            || oidcConfig?.publicClient
+            || oidcConfig?.state === State.REVOKED) {
+
+            return null;
+        }
+
+        return (
+            <RevokeAllClientSecretsDangerZone
+                clientId={ oidcConfig?.clientId }
+                readOnly={ readOnly }
+                onRevokeAll={ handleRevokeAllClientSecrets }
+                data-componentid={ `${ componentId }-revoke-all-danger-zone` }
+            />
+        );
+    };
+
+    /**
      * Resolve protocol display name when there are multiple protocols.
      *
      * @param protocol - Protocol name.
@@ -1381,6 +1444,7 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
                                     <Grid.Row>
                                         <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
                                             { resolveInboundProtocolSettingsForm() }
+                                            { resolveClientSecretsDangerZone() }
                                         </Grid.Column>
                                     </Grid.Row>
                                 )

--- a/features/admin.applications.v1/components/settings/access-configuration.tsx
+++ b/features/admin.applications.v1/components/settings/access-configuration.tsx
@@ -1056,8 +1056,8 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
 
         return (
             <RevokeAllClientSecretsDangerZone
-                readOnly={ readOnly }
                 onRevokeAll={ handleRevokeAllClientSecrets }
+                readOnly={ readOnly || !hasApplicationUpdatePermissions }
                 data-componentid={ `${ componentId }-revoke-all-danger-zone` }
             />
         );

--- a/features/admin.applications.v1/hooks/use-client-secret-management.ts
+++ b/features/admin.applications.v1/hooks/use-client-secret-management.ts
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { FeatureAccessConfigInterface, useRequiredScopes } from "@wso2is/access-control";
+import { AppState } from "@wso2is/admin.core.v1/store";
+import { isFeatureEnabled } from "@wso2is/core/helpers";
+import { useSelector } from "react-redux";
+import {
+    ApplicationFeatureDictionaryKeys,
+    ApplicationManagementConstants
+} from "../constants/application-management";
+
+/**
+ * Return type for the `useClientSecretManagement` hook.
+ */
+interface UseClientSecretManagementInterface {
+    /**
+     * Whether client secret permission enforcement is enabled (the inverse of the skip-enforce
+     * configuration), which governs the legacy single-secret path and the regenerate action.
+     */
+    isEnforceClientSecretPermissionEnabled: boolean;
+    /**
+     * Whether the user holds the client secret view scope.
+     */
+    hasClientSecretReadPermission: boolean;
+    /**
+     * Whether the user holds the client secret create scope (also authorizes regeneration).
+     */
+    hasClientSecretCreatePermission: boolean;
+    /**
+     * Whether the user holds the client secret delete scope.
+     */
+    hasClientSecretDeletePermission: boolean;
+    /**
+     * Maximum number of client secrets an application can hold. A count above one enables the
+     * multiple client secrets experience; one keeps the legacy single-secret view.
+     */
+    maxSecretCount: number;
+}
+
+/**
+ * Resolves the multiple client secrets feature configuration and the user's client secret permissions.
+ *
+ * @returns `UseClientSecretManagementInterface`
+ */
+const useClientSecretManagement = (): UseClientSecretManagementInterface => {
+
+    const applicationFeatureConfig: FeatureAccessConfigInterface = useSelector(
+        (state: AppState): FeatureAccessConfigInterface => state?.config?.ui?.features?.applications);
+    const maxSecretCount: number = useSelector((state: AppState): number =>
+        state?.config?.ui?.features?.applications?.properties?.multipleClientSecretsMaxCount as number);
+
+    const isEnforceClientSecretPermissionEnabled: boolean = isFeatureEnabled(
+        applicationFeatureConfig,
+        ApplicationManagementConstants.FEATURE_DICTIONARY.get(
+            ApplicationFeatureDictionaryKeys.ApplicationEditEnforceClientSecretPermission) ?? ""
+    );
+
+    const hasClientSecretReadPermission: boolean = useRequiredScopes(
+        applicationFeatureConfig?.subFeatures?.applicationClientSecretManagement?.scopes?.read ?? []);
+    const hasClientSecretCreatePermission: boolean = useRequiredScopes(
+        applicationFeatureConfig?.subFeatures?.applicationClientSecretManagement?.scopes?.create ?? []);
+    const hasClientSecretDeletePermission: boolean = useRequiredScopes(
+        applicationFeatureConfig?.subFeatures?.applicationClientSecretManagement?.scopes?.delete ?? []);
+
+    return {
+        hasClientSecretCreatePermission,
+        hasClientSecretDeletePermission,
+        hasClientSecretReadPermission,
+        isEnforceClientSecretPermissionEnabled,
+        maxSecretCount
+    };
+};
+
+export default useClientSecretManagement;

--- a/features/admin.applications.v1/models/application-inbound.ts
+++ b/features/admin.applications.v1/models/application-inbound.ts
@@ -261,6 +261,7 @@ export enum ClientSecretStatus {
 export interface ClientSecretInterface {
     secretId?: string;
     secretValue?: string;
+    // Expiry of the client secret in Unix epoch seconds (0 when it does not expire).
     expiresAt?: number;
     status?: ClientSecretStatus;
     latest?: boolean;
@@ -278,6 +279,7 @@ export interface ClientSecretListInterface {
  * Request payload for creating a new client secret.
  */
 export interface ClientSecretCreationRequestInterface {
+    // Requested expiry of the client secret in Unix epoch seconds (omit for a non-expiring secret).
     expiresAt?: number;
 }
 

--- a/features/admin.applications.v1/models/application-inbound.ts
+++ b/features/admin.applications.v1/models/application-inbound.ts
@@ -221,6 +221,8 @@ interface OIDCLogoutConfigurationInterface {
 export interface OIDCDataInterface {
     clientId?: string;
     clientSecret?: string;
+    clientSecretExpiresAt?: number;
+    multipleClientSecretsConfigured?: boolean;
     state?: State;
     grantTypes?: string[];
     callbackURLs?: string[];
@@ -243,6 +245,52 @@ export interface OIDCDataInterface {
     hybridFlow?: HybridFlowConfigurationInterface;
     cibaAuthenticationRequest?: CIBAAuthenticationConfigurationInterface;
     issuer?: AllowedIssuerInterface;
+}
+
+/**
+ * Server-reported status of a client secret.
+ */
+export enum ClientSecretStatus {
+    ACTIVE = "ACTIVE",
+    EXPIRED = "EXPIRED"
+}
+
+/**
+ * Metadata of a single OAuth2/OIDC client secret.
+ */
+export interface ClientSecretInterface {
+    secretId?: string;
+    secretValue?: string;
+    expiresAt?: number;
+    status?: ClientSecretStatus;
+    latest?: boolean;
+}
+
+/**
+ * List of client secrets attached to an application.
+ */
+export interface ClientSecretListInterface {
+    count?: number;
+    list?: ClientSecretInterface[];
+}
+
+/**
+ * Request payload for creating a new client secret.
+ */
+export interface ClientSecretCreationRequestInterface {
+    expiresAt?: number;
+}
+
+/**
+ * Expiration presets offered when generating a new client secret.
+ */
+export enum ClientSecretExpirationOption {
+    THIRTY_DAYS = "30",
+    SIXTY_DAYS = "60",
+    NINETY_DAYS = "90",
+    ONE_EIGHTY_DAYS = "180",
+    CUSTOM = "custom",
+    NO_EXPIRATION = "No expiration"
 }
 
 /**

--- a/features/admin.applications.v1/pages/application-edit.tsx
+++ b/features/admin.applications.v1/pages/application-edit.tsx
@@ -1098,12 +1098,18 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
             } }
             alertBanner={ (
                 <>
-                    <SecretExpiryBanner
-                        appId={ applicationId }
-                        isOIDCApplication={ inboundProtocolList?.includes(SupportedAuthProtocolTypes.OIDC) }
-                        isPublicClient={ applicationInboundConfigs?.publicClient }
-                        data-componentid={ `${ componentId }-secret-expiry-banner` }
-                    />
+                    { applicationInboundConfigs && (
+                        <SecretExpiryBanner
+                            appId={ applicationId }
+                            isOIDCApplication={ inboundProtocolList?.includes(SupportedAuthProtocolTypes.OIDC) }
+                            isPublicClient={ applicationInboundConfigs.publicClient }
+                            latestClientSecretExpiresAt={ applicationInboundConfigs.clientSecretExpiresAt }
+                            multipleClientSecretsConfigured={
+                                applicationInboundConfigs.multipleClientSecretsConfigured
+                            }
+                            data-componentid={ `${ componentId }-secret-expiry-banner` }
+                        />
+                    ) }
                     { resolveAlertBanner() }
                 </>
             ) }

--- a/features/admin.applications.v1/pages/application-edit.tsx
+++ b/features/admin.applications.v1/pages/application-edit.tsx
@@ -76,6 +76,7 @@ import { Icon, Label } from "semantic-ui-react";
 import { updateApplicationDetails } from "../api/application";
 import { useGetApplication } from "../api/use-get-application";
 import useGetApplicationInboundConfigs from "../api/use-get-application-inbound-configs";
+import SecretExpiryBanner from "../components/banners/secret-expiry-banner";
 import { EditApplication } from "../components/edit-application";
 import { InboundProtocolDefaultFallbackTemplates } from "../components/meta/inbound-protocols.meta";
 import { ApplicationManagementConstants } from "../constants/application-management";
@@ -1095,7 +1096,17 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                 text: isConnectedAppsRedirect ? t("idp:connectedApps.applicationEdit.back",
                     { idpName: callBackIdpName }) : t("console:develop.pages.applicationsEdit.backButton")
             } }
-            alertBanner={ resolveAlertBanner() }
+            alertBanner={ (
+                <>
+                    <SecretExpiryBanner
+                        appId={ applicationId }
+                        isOIDCApplication={ inboundProtocolList?.includes(SupportedAuthProtocolTypes.OIDC) }
+                        isPublicClient={ applicationInboundConfigs?.publicClient }
+                        data-componentid={ `${ componentId }-secret-expiry-banner` }
+                    />
+                    { resolveAlertBanner() }
+                </>
+            ) }
             titleTextAlign="left"
             bottomMargin={ false }
             pageHeaderMaxWidth={ true }

--- a/modules/i18n/src/models/namespaces/applications-ns.ts
+++ b/modules/i18n/src/models/namespaces/applications-ns.ts
@@ -232,6 +232,7 @@ export interface ApplicationsNS {
         expiryBanner: {
             title: string;
             description: string;
+            viewDetails: string;
         };
         notifications: {
             generateSecret: {

--- a/modules/i18n/src/models/namespaces/applications-ns.ts
+++ b/modules/i18n/src/models/namespaces/applications-ns.ts
@@ -170,6 +170,111 @@ export interface ApplicationsNS {
         };
         placeholder: string;
     };
+    clientSecrets: {
+        rotationInfo: string;
+        generateButton: string;
+        viewPreviousSecrets: string;
+        hidePreviousSecrets: string;
+        maxCountReachedHint: string;
+        status: {
+            active: string;
+            expiresSoon: string;
+            expired: string;
+        };
+        expiry: {
+            expiresOn: string;
+            expiredOn: string;
+            neverExpires: string;
+        };
+        confirmations: {
+            deleteSecret: {
+                assertionHint: string;
+                header: string;
+                message: string;
+                content: string;
+            };
+        };
+        wizard: {
+            heading: string;
+            subHeading: string;
+            expiration: {
+                label: string;
+                options: {
+                    days: string;
+                    neverExpire: string;
+                    custom: string;
+                };
+            };
+            customExpiry: {
+                label: string;
+                placeholder: string;
+                validations: {
+                    required: string;
+                    invalid: string;
+                };
+            };
+            expiryWarning: string;
+            generateButton: string;
+        };
+        dangerZone: {
+            revokeAll: {
+                actionTitle: string;
+                header: string;
+                subheader: string;
+                confirmation: {
+                    assertionHint: string;
+                    header: string;
+                    message: string;
+                    content: string;
+                };
+            };
+        };
+        expiryBanner: {
+            title: string;
+            description: string;
+        };
+        notifications: {
+            generateSecret: {
+                error: {
+                    message: string;
+                };
+                success: {
+                    description: string;
+                    message: string;
+                };
+                genericError: {
+                    description: string;
+                    message: string;
+                };
+            };
+            deleteSecret: {
+                success: {
+                    description: string;
+                    message: string;
+                };
+                genericError: {
+                    description: string;
+                    message: string;
+                };
+            };
+            revokeAll: {
+                success: {
+                    description: string;
+                    message: string;
+                };
+                genericError: {
+                    description: string;
+                    message: string;
+                };
+            };
+            getSecrets: {
+                genericError: {
+                    description: string;
+                    message: string;
+                };
+            };
+        };
+    };
     confirmations: {
         addSocialLogin: {
             content: string;

--- a/modules/i18n/src/models/namespaces/applications-ns.ts
+++ b/modules/i18n/src/models/namespaces/applications-ns.ts
@@ -171,21 +171,20 @@ export interface ApplicationsNS {
         placeholder: string;
     };
     clientSecrets: {
-        rotationInfo: string;
+        rotationWarning: string;
         generateButton: string;
+        hashedDisclaimer: string;
         viewPreviousSecret: string;
         viewPreviousSecrets: string;
         hidePreviousSecret: string;
         hidePreviousSecrets: string;
         maxCountReachedHint: string;
-        status: {
-            active: string;
-            expiresSoon: string;
-            expired: string;
-        };
         expiry: {
-            expiresOn: string;
+            expired: string;
+            expiredAgo: string;
             expiredOn: string;
+            expiresIn: string;
+            expiresOn: string;
             neverExpires: string;
         };
         confirmations: {

--- a/modules/i18n/src/models/namespaces/applications-ns.ts
+++ b/modules/i18n/src/models/namespaces/applications-ns.ts
@@ -173,7 +173,9 @@ export interface ApplicationsNS {
     clientSecrets: {
         rotationInfo: string;
         generateButton: string;
+        viewPreviousSecret: string;
         viewPreviousSecrets: string;
+        hidePreviousSecret: string;
         hidePreviousSecrets: string;
         maxCountReachedHint: string;
         status: {
@@ -232,7 +234,7 @@ export interface ApplicationsNS {
         expiryBanner: {
             title: string;
             description: string;
-            viewDetails: string;
+            viewSecrets: string;
         };
         notifications: {
             generateSecret: {

--- a/modules/i18n/src/translations/en-US/portals/applications.ts
+++ b/modules/i18n/src/translations/en-US/portals/applications.ts
@@ -229,9 +229,10 @@ export const applications: ApplicationsNS = {
             description: "One or more client secrets are expiring soon. Please rotate them to prevent " +
                 "authentication failures and application downtime.",
             title: "Client Secrets Expiring Soon",
-            viewDetails: "View details"
+            viewSecrets: "View secrets"
         },
         generateButton: "Generate New Secret",
+        hidePreviousSecret: "Hide Previous Client Secret",
         hidePreviousSecrets: "Hide Previous Client Secrets",
         maxCountReachedHint: "You have reached the maximum of {{count}} client secrets. Delete an existing " +
             "secret to generate a new one.",
@@ -283,6 +284,7 @@ export const applications: ApplicationsNS = {
             expired: "Expired",
             expiresSoon: "Expires Soon"
         },
+        viewPreviousSecret: "View Previous Client Secret",
         viewPreviousSecrets: "View Previous Client Secrets",
         wizard: {
             customExpiry: {

--- a/modules/i18n/src/translations/en-US/portals/applications.ts
+++ b/modules/i18n/src/translations/en-US/portals/applications.ts
@@ -196,8 +196,9 @@ export const applications: ApplicationsNS = {
         confirmations: {
             deleteSecret: {
                 assertionHint: "Please confirm your action.",
-                content: "If you delete this client secret, the application will no longer be able to " +
-                    "authenticate. However, active tokens and authorization codes will not be revoked.",
+                content: "If you delete this client secret, clients using it will no longer be able to " +
+                    "authenticate with it. Any other client secrets of the application remain valid, and " +
+                    "active tokens will not be revoked.",
                 header: "Are you sure?",
                 message: "This action is irreversible and permanently deletes the client secret. " +
                     "Please proceed with caution."
@@ -207,31 +208,36 @@ export const applications: ApplicationsNS = {
             revokeAll: {
                 actionTitle: "Revoke All",
                 confirmation: {
-                    assertionHint: "Please confirm your action.",
-                    content: "If you revoke all client secrets, all associated access tokens, refresh tokens, " +
-                        "and authorization codes will also be revoked, and active authentication flows will " +
-                        "fail. Please ensure you update your application with the new client secret.",
-                    header: "Are you sure?",
-                    message: "This action is irreversible and permanently revokes all the client secrets. " +
-                        "Please proceed with caution."
+                    assertionHint: "I understand this action is irreversible.",
+                    content: "Every tokens issued with the old secrets will also be revoked, and active " +
+                        "authentication flows will fail. Be sure to update your application with the " +
+                        "new client secret.",
+                    header: "Revoke all client secrets and generate a new one?",
+                    message: "This action is irreversible. All existing client secrets are permanently revoked " +
+                        "and replaced with a single new client secret."
                 },
-                header: "Revoke All Client Secrets",
-                subheader: "Once the existing secrets are revoked, they cannot be recovered. A new secret will " +
-                    "be generated, and authentication flows using the old secrets will no longer work."
+                header: "Revoke all & generate a new client secret",
+                subheader: "Permanently revokes every existing client secret and generates a single new one. " +
+                    "Authentication flows still using the old secrets will fail until you update your application."
             }
         },
         expiry: {
+            expired: "Expired",
+            expiredAgo: "Expired {{duration}} ago",
             expiredOn: "Expired on {{date}}",
+            expiresIn: "Expires in {{duration}}",
             expiresOn: "Expires on {{date}}",
             neverExpires: "Never expires"
         },
         expiryBanner: {
-            description: "One or more client secrets are expiring soon. Please rotate them to prevent " +
-                "authentication failures and application downtime.",
-            title: "Client Secrets Expiring Soon",
-            viewSecrets: "View secrets"
+            description: "At least one client secret is expiring soon. Rotate your secret to " +
+                "prevent authentication failures and application downtime.",
+            title: "Client Secret Expiring Soon",
+            viewSecrets: "View secret"
         },
         generateButton: "Generate New Secret",
+        hashedDisclaimer: "Client secret is hashed and cannot be viewed. If you need a new value, " +
+            "generate a new client secret.",
         hidePreviousSecret: "Hide Previous Client Secret",
         hidePreviousSecrets: "Hide Previous Client Secrets",
         maxCountReachedHint: "You have reached the maximum of {{count}} client secrets. Delete an existing " +
@@ -277,13 +283,9 @@ export const applications: ApplicationsNS = {
                 }
             }
         },
-        rotationInfo: "Use multiple secrets for seamless rotation. Generate a new secret, update your " +
-            "application, and delete the old one or allow it to expire.",
-        status: {
-            active: "Active",
-            expired: "Expired",
-            expiresSoon: "Expires Soon"
-        },
+        rotationWarning: "Multiple client secrets enable seamless rotation, but keeping old secrets " +
+            "active longer than necessary increases security exposure. Remove old secrets once rotation " +
+            "is complete.",
         viewPreviousSecret: "View Previous Client Secret",
         viewPreviousSecrets: "View Previous Client Secrets",
         wizard: {
@@ -360,7 +362,7 @@ export const applications: ApplicationsNS = {
                 assertionHint: "",
                 content: "",
                 header: "OAuth Application Credentials",
-                message: "The consumer secret value will be displayed in plain text only once. " +
+                message: "The client secret value will be displayed in plain text only once. " +
                     "Please make sure to copy and save it somewhere safe."
             }
         },

--- a/modules/i18n/src/translations/en-US/portals/applications.ts
+++ b/modules/i18n/src/translations/en-US/portals/applications.ts
@@ -207,8 +207,7 @@ export const applications: ApplicationsNS = {
             revokeAll: {
                 actionTitle: "Revoke All",
                 confirmation: {
-                    assertionHint: "Please type <1>{{id}}</1> to revoke all the client secrets and " +
-                        "regenerate a new one.",
+                    assertionHint: "Please confirm your action.",
                     content: "If you revoke all client secrets, all associated access tokens, refresh tokens, " +
                         "and authorization codes will also be revoked, and active authentication flows will " +
                         "fail. Please ensure you update your application with the new client secret.",
@@ -229,7 +228,8 @@ export const applications: ApplicationsNS = {
         expiryBanner: {
             description: "One or more client secrets are expiring soon. Please rotate them to prevent " +
                 "authentication failures and application downtime.",
-            title: "Client Secrets Expiring Soon"
+            title: "Client Secrets Expiring Soon",
+            viewDetails: "View details"
         },
         generateButton: "Generate New Secret",
         hidePreviousSecrets: "Hide Previous Client Secrets",

--- a/modules/i18n/src/translations/en-US/portals/applications.ts
+++ b/modules/i18n/src/translations/en-US/portals/applications.ts
@@ -192,6 +192,122 @@ export const applications: ApplicationsNS = {
         },
         placeholder: "Search applications by name, client ID, or issuer"
     },
+    clientSecrets: {
+        confirmations: {
+            deleteSecret: {
+                assertionHint: "Please confirm your action.",
+                content: "If you delete this client secret, the application will no longer be able to " +
+                    "authenticate. However, active tokens and authorization codes will not be revoked.",
+                header: "Are you sure?",
+                message: "This action is irreversible and permanently deletes the client secret. " +
+                    "Please proceed with caution."
+            }
+        },
+        dangerZone: {
+            revokeAll: {
+                actionTitle: "Revoke All",
+                confirmation: {
+                    assertionHint: "Please type <1>{{id}}</1> to revoke all the client secrets and " +
+                        "regenerate a new one.",
+                    content: "If you revoke all client secrets, all associated access tokens, refresh tokens, " +
+                        "and authorization codes will also be revoked, and active authentication flows will " +
+                        "fail. Please ensure you update your application with the new client secret.",
+                    header: "Are you sure?",
+                    message: "This action is irreversible and permanently revokes all the client secrets. " +
+                        "Please proceed with caution."
+                },
+                header: "Revoke All Client Secrets",
+                subheader: "Once the existing secrets are revoked, they cannot be recovered. A new secret will " +
+                    "be generated, and authentication flows using the old secrets will no longer work."
+            }
+        },
+        expiry: {
+            expiredOn: "Expired on {{date}}",
+            expiresOn: "Expires on {{date}}",
+            neverExpires: "Never expires"
+        },
+        expiryBanner: {
+            description: "One or more client secrets are expiring soon. Please rotate them to prevent " +
+                "authentication failures and application downtime.",
+            title: "Client Secrets Expiring Soon"
+        },
+        generateButton: "Generate New Secret",
+        hidePreviousSecrets: "Hide Previous Client Secrets",
+        maxCountReachedHint: "You have reached the maximum of {{count}} client secrets. Delete an existing " +
+            "secret to generate a new one.",
+        notifications: {
+            deleteSecret: {
+                genericError: {
+                    description: "An error occurred while deleting the client secret.",
+                    message: "Something went wrong"
+                },
+                success: {
+                    description: "The client secret was deleted successfully.",
+                    message: "Client secret deleted"
+                }
+            },
+            generateSecret: {
+                error: {
+                    message: "Generation error"
+                },
+                genericError: {
+                    description: "An error occurred while generating the client secret.",
+                    message: "Something went wrong"
+                },
+                success: {
+                    description: "A new client secret was generated successfully.",
+                    message: "Client secret generated"
+                }
+            },
+            getSecrets: {
+                genericError: {
+                    description: "An error occurred while retrieving the client secrets.",
+                    message: "Something went wrong"
+                }
+            },
+            revokeAll: {
+                genericError: {
+                    description: "An error occurred while revoking the client secrets.",
+                    message: "Something went wrong"
+                },
+                success: {
+                    description: "All client secrets were revoked and a new secret was generated.",
+                    message: "Client secrets revoked"
+                }
+            }
+        },
+        rotationInfo: "Use multiple secrets for seamless rotation. Generate a new secret, update your " +
+            "application, and delete the old one or allow it to expire.",
+        status: {
+            active: "Active",
+            expired: "Expired",
+            expiresSoon: "Expires Soon"
+        },
+        viewPreviousSecrets: "View Previous Client Secrets",
+        wizard: {
+            customExpiry: {
+                label: "Custom Expiry Time (days)",
+                placeholder: "Enter the number of days",
+                validations: {
+                    invalid: "Enter a valid number of days.",
+                    required: "Enter the number of days until the secret expires."
+                }
+            },
+            expiration: {
+                label: "Expiration",
+                options: {
+                    custom: "Custom",
+                    days: "{{count}} days",
+                    neverExpire: "Never expires"
+                }
+            },
+            expiryWarning: "You can't change a client secret's expiry time after it's generated, so choose the " +
+                "expiration carefully.",
+            generateButton: "Generate",
+            heading: "Generate Client Secret",
+            subHeading: "Generate a new client secret for this application. Existing secrets remain valid."
+        }
+    },
     confirmations: {
         addSocialLogin: {
             content : "To add a new social login, we will need to route you to a different page and " +


### PR DESCRIPTION
### Purpose

Introduces a capacity-gated UI for managing **multiple client secrets** per OAuth/OIDC application in the Console, enabling seamless secret rotation (generate a new secret, roll over, then delete/expire the old one) without downtime.

### Overview of changes

The feature is surfaced on the **OIDC protocol tab** of the application edit view and is enabled purely by capacity: when the configured maximum secret count is above one. With a count of one, the legacy single-secret UI is untouched.

  **OIDC protocol tab (`ClientSecretsSection`)**
  - Shows the **current (latest) secret** with a **Generate New Secret** action.
  - **Generate** modal with expiration options (30 / 60 / 90 / 180 days, custom whole days, or never expires).
  - Expandable, lazily-loaded **Previous Client Secrets** list (scrollable beyond 3), each with a **delete** action, and a rotation **security warning** advising removal of old secrets once rotation completes.
  - Each secret carries a colour-coded **expiry status text** — "Expires in X" (warning colour within the 14-day window), "Expired X ago" (error colour), or "Never expires" — with the exact expiry date shown on hover.
  - Proactively disables the generate button once the configured max count is reached (with a tooltip); the server `409` is the authoritative backstop.
  - Supports **client-secret hashing** mode — an info disclaimer replaces the values, and the newly generated plaintext secret (with the client ID) is revealed once in a modal; the page refresh is deferred until the reveal is dismissed.

  **Application page**
  - **Secret expiry banner** shown when a secret is about to expire (14-day window), with a "View secrets" action to the protocol tab. The latest secret is evaluated from the already-loaded OIDC response, so the secrets list is fetched only when the latest secret alone cannot decide and multiple secrets are configured — single-secret applications never trigger a list call.

  **Danger zone**
  - **Revoke all & generate a new client secret** — revokes every secret and regenerates a fresh one (error-styled, checkbox confirmation). Scoped to the OIDC protocol view.

  **APIs (`api/application.ts`, `useGetOAuthClientSecrets`)**
  - `GET  /inbound-protocols/oidc/secrets` — list secrets (SWR hook)
  - `POST /inbound-protocols/oidc/secrets` — create a secret (`{ expiresAt? }`, epoch seconds)
  - `DELETE /inbound-protocols/oidc/secrets/{id}` — delete a secret

  **Permissions**
  - The **latest secret** display follows the existing behaviour: with client-secret permission enforcement off, application view access suffices; with enforcement on, the client secret view scope is required.
  - The **/secrets surface** (previous secrets list and its fetches) always requires the dedicated view scope (`internal_application_mgt_client_secret_view`) — no list call is made without it.
  - **Generate** requires the create scope (`internal_application_mgt_client_secret_create`), **delete** requires the delete scope (`internal_application_mgt_client_secret_delete`), and **revoke-all** (regenerate) reuses the create scope.

### Configuration

Console config lives under the applications feature (rendered from the toml at server startup). Driven by the framework deployment.toml — the maximum secret count is the single switch (default 2; set to 1 to keep the legacy single-secret experience):

```
  [oauth.multiple_client_secrets]
  max_secret_count = 2
```

### Screen Recordings

- [Secret limit = 1] When the user has the client secrets view, create, delete a permissions.

https://github.com/user-attachments/assets/9840ffc4-fd1e-4924-af51-1f421470377f




- [Secret limit = 2] When the user has the client secrets view, create, delete a permissions.

https://github.com/user-attachments/assets/940a37d6-4d63-42cb-85d5-70f6fe97892f

- [Secret limit = 3] When the user has the client secrets view, create, delete a permissions.


https://github.com/user-attachments/assets/cfa39d72-e987-4a0d-a37d-127762419f1d



- [Secret limit = 2] When the user has application view and client secret view permissions only

https://github.com/user-attachments/assets/efd2d7db-7099-4d26-8c70-18f8189753bc



- [Secret limit = 1 | Hash persistence mode] When the user has the client secrets view, create, delete a permissions.


https://github.com/user-attachments/assets/dbbf28f9-e05f-4ea3-89ae-05414cd8eb53



- [Secret limit = 2 | Hash persistence mode] When the user has the client secrets view, create, delete a permissions.

https://github.com/user-attachments/assets/83b3360b-947e-4f93-b36e-7434c699d8db




### Related PRs
 - https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/3284
 - https://github.com/wso2/identity-api-server/pull/1154
 - https://github.com/wso2/carbon-identity-framework/pull/8226
