### PR TITLE
Fix search in the external attribute mapping dropdown

### DIFF
--- a/.changeset/fix-external-claim-mapping-dropdown-search.md
+++ b/.changeset/fix-external-claim-mapping-dropdown-search.md
@@ -1,5 +1,6 @@
 ---
 "@wso2is/admin.claims.v1": patch
+"@wso2is/console": patch
 ---
 
 Fix the search of the "User Attribute to map to" dropdown in the external attribute mapping edit form always returning "No results found."

--- a/.changeset/fix-external-claim-mapping-dropdown-search.md
+++ b/.changeset/fix-external-claim-mapping-dropdown-search.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.claims.v1": patch
+---
+
+Fix the search of the "User Attribute to map to" dropdown in the external attribute mapping edit form always returning "No results found."

--- a/features/admin.claims.v1/components/edit/external-dialect/edit-external-claim.tsx
+++ b/features/admin.claims.v1/components/edit/external-dialect/edit-external-claim.tsx
@@ -28,7 +28,7 @@ import React, { FunctionComponent, ReactElement, useEffect, useState } from "rea
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { Dispatch } from "redux";
-import { Grid } from "semantic-ui-react";
+import { DropdownItemProps, Grid } from "semantic-ui-react";
 import { getAnExternalClaim, updateAnExternalClaim } from "../../../api";
 import { ClaimManagementConstants } from "../../../constants";
 import { AddExternalClaim } from "../../../models";
@@ -234,6 +234,35 @@ export const EditExternalClaim: FunctionComponent<EditExternalClaimsPropsInterfa
         });
     };
 
+    /**
+     * Filters the local attribute dropdown options against the search query.
+     *
+     * The dropdown options are rendered with a JSX element as the `text` prop. Hence the default
+     * search of the dropdown, which matches the query against `option.text`, can never match any
+     * option. This filters the options using the display name and the claim URI of the underlying
+     * local attribute instead.
+     *
+     * @param options - Dropdown options to be filtered.
+     * @param query - The search query entered by the user.
+     *
+     * @returns The filtered dropdown options.
+     */
+    const filterLocalClaimOptions = (options: DropdownItemProps[], query: string): DropdownItemProps[] => {
+        if (!query) {
+            return options;
+        }
+
+        const searchQuery: string = query.toLowerCase();
+
+        return options?.filter((option: DropdownItemProps) => {
+            const matchingClaim: Claim = filteredLocalClaims?.find(
+                (localClaim: Claim) => localClaim?.claimURI === option?.value);
+
+            return matchingClaim?.displayName?.toLowerCase().includes(searchQuery)
+                || matchingClaim?.claimURI?.toLowerCase().includes(searchQuery);
+        });
+    };
+
     return (
         <Forms
             onSubmit={ (values: Map<string, FormValue>) => {
@@ -320,7 +349,7 @@ export const EditExternalClaim: FunctionComponent<EditExternalClaimsPropsInterfa
                             requiredErrorMessage={ t("claims:external.forms." +
                                 "localAttribute.requiredErrorMessage") }
                             placeholder={ t("claims:external.forms.attributeURI.placeholder") }
-                            search
+                            search={ filterLocalClaimOptions }
                             loading={ isClaimsLoading }
                             value={ wizard ? addedClaim.mappedLocalClaimURI : claim?.mappedLocalClaimURI }
                             children={


### PR DESCRIPTION
### Purpose

The search box of the "User Attribute to map to" dropdown in the external attribute mapping edit form (Console → Attributes → OpenID Connect / SCIM / ... → edit a mapping) always renders **"No results found."**, no matter what is typed.

**Root cause:** `edit-external-claim.tsx` passes the boolean `search` prop while every option's `text` is a JSX element (display name + claim URI). Semantic UI React's default search filters the options with

```js
// Dropdown/utils/getMenuOptions.js
const re = new RegExp(_.escapeRegExp(strippedQuery), "i");
filteredOptions = _.filter(filteredOptions, (opt) => re.test(opt.text));
```

and `RegExp.test()` stringifies the React element to `"[object Object]"`, so no realistic query can ever match an option.

The sibling add form (`add/add-external-claim.tsx`) already works around this with a custom `search` function; the edit form never got the same treatment.

**Fix:** pass a custom `search` filter that matches the query against the display name and the claim URI of the underlying local attribute instead of the JSX option text. `EditExternalClaim` backs both the inline edit row of the attribute mapping list and the edit row of the add-dialect wizard, so both paths are fixed.

Before / after for the query `depart`:

| | |
|---|---|
| Before | "No results found." — 0 options |
| After | "Department — http://wso2.org/claims/department" |

### Related Issues
- https://github.com/wso2/product-is/issues/28249

### Related PRs
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets