### PR TITLE
Omit default port when constructing the callback URL

### DIFF
--- a/apps/authentication-portal/src/main/webapp/basicauth.jsp
+++ b/apps/authentication-portal/src/main/webapp/basicauth.jsp
@@ -15,6 +15,8 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   --%>
+<%@ page import="org.apache.commons.httpclient.HttpURL" %>
+<%@ page import="org.apache.commons.httpclient.HttpsURL" %>
 <%@ page import="org.apache.cxf.jaxrs.client.Client" %>
 <%@ page import="org.apache.cxf.configuration.jsse.TLSClientParameters" %>
 <%@ page import="org.apache.cxf.transport.http.HTTPConduit" %>
@@ -435,7 +437,11 @@
                 int serverPort = request.getServerPort();
                 String uri = (String) request.getAttribute(JAVAX_SERVLET_FORWARD_REQUEST_URI);
                 String prmstr = URLDecoder.decode(((String) request.getAttribute(JAVAX_SERVLET_FORWARD_QUERY_STRING)), UTF_8);
-                urlWithoutEncoding = scheme + "://" +serverName + ":" + serverPort + uri + "?" + prmstr;
+                if ((scheme == "http" && serverPort == HttpURL.DEFAULT_PORT) || (scheme == "https" && serverPort == HttpsURL.DEFAULT_PORT)) {
+                    urlWithoutEncoding = scheme + "://" + serverName + uri + "?" + prmstr;
+                } else {
+                    urlWithoutEncoding = scheme + "://" + serverName + ":" + serverPort + uri + "?" + prmstr;
+                }
             }
 
             urlEncodedURL = URLEncoder.encode(urlWithoutEncoding, UTF_8);


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
`basicauth.jsp` unconditionally appends the server port when building the callback URL. When the server runs behind a proxy on the default HTTPS port, this produces `https://<host>:443/...`, which fails host validation because the expected value is built via `ServiceURLBuilder` and omits default ports.

This adds a guard so the port suffix is skipped for `https`+443 and `http`+80. Non-default ports are unaffected.


### Related Issues
https://github.com/wso2/api-manager/issues/5159

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
