### PR TITLE
Add new agent widgets to Moesif dashboards

### DIFF
--- a/.changeset/moesif-agent-widgets.md
+++ b/.changeset/moesif-agent-widgets.md
@@ -1,5 +1,6 @@
 ---
 "@wso2is/admin.analytics.v1": patch
+"@wso2is/console": patch
 ---
 
 Add Active Agent Sessions, Agent Token Distribution and Agent Usage by Users widgets to the Moesif agent dashboard

--- a/.changeset/moesif-agent-widgets.md
+++ b/.changeset/moesif-agent-widgets.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.analytics.v1": patch
+---
+
+Add Active Agent Sessions, Agent Token Distribution and Agent Usage by Users widgets to the Moesif agent dashboard

--- a/features/admin.analytics.v1/assets/moesif-dashboard-essentials.json
+++ b/features/admin.analytics.v1/assets/moesif-dashboard-essentials.json
@@ -4468,10 +4468,9 @@
                   }
                 },
                 "aggs": {
-                  "weight|sum": {
-                    "sum": {
-                      "field": "weight",
-                      "missing": 1
+                  "_id|cardinality": {
+                    "cardinality": {
+                      "field": "_id"
                     }
                   }
                 }
@@ -4525,18 +4524,16 @@
                   }
                 },
                 "aggs": {
-                  "weight|sum": {
-                    "sum": {
-                      "field": "weight",
-                      "missing": 1
+                  "_id|cardinality": {
+                    "cardinality": {
+                      "field": "_id"
                     }
                   }
                 }
               },
-              "weight|sum": {
-                "sum": {
-                  "field": "weight",
-                  "missing": 1
+              "_id|cardinality": {
+                "cardinality": {
+                  "field": "_id"
                 }
               }
             }
@@ -4549,13 +4546,13 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][0][filters][1][id]=2714f5ec&evtcf[filtersGroups][0][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=eq&evtcf[filtersGroups][0][filters][1][value][0]=false&evtcf[filtersGroups][0][filters][2][id]=b84a7b60&evtcf[filtersGroups][0][filters][2][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=contains&evtcf[filtersGroups][0][filters][2][value][0]=AGENT&evtcf[filtersGroups][1][filters][0][id]=ad5ef950&evtcf[filtersGroups][1][filters][0][field]=action_name.raw&evtcf[filtersGroups][1][filters][0][name]=&evtcf[filtersGroups][1][filters][0][op]=contains&evtcf[filtersGroups][1][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][1][filters][1][id]=0e44fc56&evtcf[filtersGroups][1][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][1][filters][1][name]=&evtcf[filtersGroups][1][filters][1][op]=eq&evtcf[filtersGroups][1][filters][1][value][0]=false&evtcf[filtersGroups][1][filters][2][id]=83cacaad&evtcf[filtersGroups][1][filters][2][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][2][name]=&evtcf[filtersGroups][1][filters][2][op]=exists&evtcf[filtersGroups][1][filters][2][value]=&evtcf[filtersGroups][1][filters][3][id]=c919c6ab&evtcf[filtersGroups][1][filters][3][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][3][name]=&evtcf[filtersGroups][1][filters][3][op]=not_contain&evtcf[filtersGroups][1][filters][3][value][0]=NOT_AVAILABLE&seg[metrics][0][metricName]=sum%28events%29&seg[chartType]=pie&seg[segments][0][name]=Agent%20Tokens&seg[segments][0][filterGroups][0][id]=f78dc78f&seg[segments][0][filterGroups][0][filters][0][id]=f2a252dc&seg[segments][0][filterGroups][0][filters][0][field]=action_name.raw&seg[segments][0][filterGroups][0][filters][0][name]=&seg[segments][0][filterGroups][0][filters][0][op]=contains&seg[segments][0][filterGroups][0][filters][0][value][0]=OAuth-Token-Issuance&seg[segments][0][filterGroups][0][filters][1][id]=ed20a788&seg[segments][0][filterGroups][0][filters][1][field]=metadata.existingTokenUsed&seg[segments][0][filterGroups][0][filters][1][name]=&seg[segments][0][filterGroups][0][filters][1][op]=eq&seg[segments][0][filterGroups][0][filters][1][value][0]=false&seg[segments][0][filterGroups][0][filters][2][id]=f6996751&seg[segments][0][filterGroups][0][filters][2][field]=metadata.userStoreDomain.raw&seg[segments][0][filterGroups][0][filters][2][name]=&seg[segments][0][filterGroups][0][filters][2][op]=contains&seg[segments][0][filterGroups][0][filters][2][value][0]=AGENT&seg[segments][1][name]=Agent%20Tokens%20%20as%20Actors&seg[segments][1][filterGroups][0][id]=af80a108&seg[segments][1][filterGroups][0][filters][0][id]=4c082064&seg[segments][1][filterGroups][0][filters][0][field]=action_name.raw&seg[segments][1][filterGroups][0][filters][0][name]=&seg[segments][1][filterGroups][0][filters][0][op]=contains&seg[segments][1][filterGroups][0][filters][0][value][0]=OAuth-Token-Issuance&seg[segments][1][filterGroups][0][filters][1][id]=c6abf3f9&seg[segments][1][filterGroups][0][filters][1][field]=metadata.existingTokenUsed&seg[segments][1][filterGroups][0][filters][1][name]=&seg[segments][1][filterGroups][0][filters][1][op]=eq&seg[segments][1][filterGroups][0][filters][1][value][0]=false&seg[segments][1][filterGroups][0][filters][2][id]=4c43859d&seg[segments][1][filterGroups][0][filters][2][field]=metadata.actor.raw&seg[segments][1][filterGroups][0][filters][2][name]=&seg[segments][1][filterGroups][0][filters][2][op]=exists&seg[segments][1][filterGroups][0][filters][2][value]=&seg[segments][1][filterGroups][0][filters][3][id]=46a2fb34&seg[segments][1][filterGroups][0][filters][3][field]=metadata.actor.raw&seg[segments][1][filterGroups][0][filters][3][name]=&seg[segments][1][filterGroups][0][filters][3][op]=not_contain&seg[segments][1][filterGroups][0][filters][3][value][0]=NOT_AVAILABLE",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][0][filters][1][id]=2714f5ec&evtcf[filtersGroups][0][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=eq&evtcf[filtersGroups][0][filters][1][value][0]=false&evtcf[filtersGroups][0][filters][2][id]=b84a7b60&evtcf[filtersGroups][0][filters][2][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=contains&evtcf[filtersGroups][0][filters][2][value][0]=AGENT&evtcf[filtersGroups][1][filters][0][id]=ad5ef950&evtcf[filtersGroups][1][filters][0][field]=action_name.raw&evtcf[filtersGroups][1][filters][0][name]=&evtcf[filtersGroups][1][filters][0][op]=contains&evtcf[filtersGroups][1][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][1][filters][1][id]=0e44fc56&evtcf[filtersGroups][1][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][1][filters][1][name]=&evtcf[filtersGroups][1][filters][1][op]=eq&evtcf[filtersGroups][1][filters][1][value][0]=false&evtcf[filtersGroups][1][filters][2][id]=83cacaad&evtcf[filtersGroups][1][filters][2][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][2][name]=&evtcf[filtersGroups][1][filters][2][op]=exists&evtcf[filtersGroups][1][filters][2][value]=&evtcf[filtersGroups][1][filters][3][id]=c919c6ab&evtcf[filtersGroups][1][filters][3][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][3][name]=&evtcf[filtersGroups][1][filters][3][op]=not_contain&evtcf[filtersGroups][1][filters][3][value][0]=NOT_AVAILABLE&seg[metrics][0][metricName]=count%28event_id%29&seg[chartType]=pie&seg[segments][0][name]=Agent%20Tokens&seg[segments][0][filterGroups][0][id]=f78dc78f&seg[segments][0][filterGroups][0][filters][0][id]=f2a252dc&seg[segments][0][filterGroups][0][filters][0][field]=action_name.raw&seg[segments][0][filterGroups][0][filters][0][name]=&seg[segments][0][filterGroups][0][filters][0][op]=contains&seg[segments][0][filterGroups][0][filters][0][value][0]=OAuth-Token-Issuance&seg[segments][0][filterGroups][0][filters][1][id]=ed20a788&seg[segments][0][filterGroups][0][filters][1][field]=metadata.existingTokenUsed&seg[segments][0][filterGroups][0][filters][1][name]=&seg[segments][0][filterGroups][0][filters][1][op]=eq&seg[segments][0][filterGroups][0][filters][1][value][0]=false&seg[segments][0][filterGroups][0][filters][2][id]=f6996751&seg[segments][0][filterGroups][0][filters][2][field]=metadata.userStoreDomain.raw&seg[segments][0][filterGroups][0][filters][2][name]=&seg[segments][0][filterGroups][0][filters][2][op]=contains&seg[segments][0][filterGroups][0][filters][2][value][0]=AGENT&seg[segments][1][name]=Agent%20Tokens%20%20as%20Actors&seg[segments][1][filterGroups][0][id]=af80a108&seg[segments][1][filterGroups][0][filters][0][id]=4c082064&seg[segments][1][filterGroups][0][filters][0][field]=action_name.raw&seg[segments][1][filterGroups][0][filters][0][name]=&seg[segments][1][filterGroups][0][filters][0][op]=contains&seg[segments][1][filterGroups][0][filters][0][value][0]=OAuth-Token-Issuance&seg[segments][1][filterGroups][0][filters][1][id]=c6abf3f9&seg[segments][1][filterGroups][0][filters][1][field]=metadata.existingTokenUsed&seg[segments][1][filterGroups][0][filters][1][name]=&seg[segments][1][filterGroups][0][filters][1][op]=eq&seg[segments][1][filterGroups][0][filters][1][value][0]=false&seg[segments][1][filterGroups][0][filters][2][id]=4c43859d&seg[segments][1][filterGroups][0][filters][2][field]=metadata.actor.raw&seg[segments][1][filterGroups][0][filters][2][name]=&seg[segments][1][filterGroups][0][filters][2][op]=exists&seg[segments][1][filterGroups][0][filters][2][value]=&seg[segments][1][filterGroups][0][filters][3][id]=46a2fb34&seg[segments][1][filterGroups][0][filters][3][field]=metadata.actor.raw&seg[segments][1][filterGroups][0][filters][3][name]=&seg[segments][1][filterGroups][0][filters][3][op]=not_contain&seg[segments][1][filterGroups][0][filters][3][value][0]=NOT_AVAILABLE",
       "analyticType": "seg",
       "chartType": "pie",
       "settings": {
         "metrics": [
           {
-            "metricName": "sum(events)"
+            "metricName": "count(event_id)"
           }
         ],
         "chartType": "pie",
@@ -4754,7 +4751,7 @@
                   "size": 5,
                   "min_doc_count": 1,
                   "order": {
-                    "weight|sum": "desc"
+                    "_id|cardinality": "desc"
                   },
                   "missing": "(none)"
                 },
@@ -4765,31 +4762,28 @@
                       "size": 5,
                       "min_doc_count": 1,
                       "order": {
-                        "weight|sum": "desc"
+                        "_id|cardinality": "desc"
                       },
                       "missing": "(none)"
                     },
                     "aggs": {
-                      "weight|sum": {
-                        "sum": {
-                          "field": "weight",
-                          "missing": 1
+                      "_id|cardinality": {
+                        "cardinality": {
+                          "field": "_id"
                         }
                       }
                     }
                   },
-                  "weight|sum": {
-                    "sum": {
-                      "field": "weight",
-                      "missing": 1
+                  "_id|cardinality": {
+                    "cardinality": {
+                      "field": "_id"
                     }
                   }
                 }
               },
-              "weight|sum": {
-                "sum": {
-                  "field": "weight",
-                  "missing": 1
+              "_id|cardinality": {
+                "cardinality": {
+                  "field": "_id"
                 }
               }
             }
@@ -4802,7 +4796,7 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][0][filters][1][id]=804033d6&evtcf[filtersGroups][0][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=eq&evtcf[filtersGroups][0][filters][1][value][0]=false&evtcf[filtersGroups][0][filters][2][id]=4558e4e7&evtcf[filtersGroups][0][filters][2][field]=metadata.actor.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=exists&evtcf[filtersGroups][0][filters][2][value]=&evtcf[filtersGroups][0][filters][3][id]=09a65a7e&evtcf[filtersGroups][0][filters][3][field]=metadata.actor.raw&evtcf[filtersGroups][0][filters][3][name]=&evtcf[filtersGroups][0][filters][3][op]=not_contain&evtcf[filtersGroups][0][filters][3][value][0]=NOT_AVAILABLE&seg[groups][0][field]=metadata.actor.raw&seg[groups][0][func]=terms&seg[groups][0][by]=metric&seg[groups][1][field]=metadata.userId.raw&seg[groups][1][func]=terms&seg[groups][1][by]=metric&seg[metrics][0][metricName]=sum%28events%29&seg[chartType]=bar",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][0][filters][1][id]=804033d6&evtcf[filtersGroups][0][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=eq&evtcf[filtersGroups][0][filters][1][value][0]=false&evtcf[filtersGroups][0][filters][2][id]=4558e4e7&evtcf[filtersGroups][0][filters][2][field]=metadata.actor.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=exists&evtcf[filtersGroups][0][filters][2][value]=&evtcf[filtersGroups][0][filters][3][id]=09a65a7e&evtcf[filtersGroups][0][filters][3][field]=metadata.actor.raw&evtcf[filtersGroups][0][filters][3][name]=&evtcf[filtersGroups][0][filters][3][op]=not_contain&evtcf[filtersGroups][0][filters][3][value][0]=NOT_AVAILABLE&seg[groups][0][field]=metadata.actor.raw&seg[groups][0][func]=terms&seg[groups][0][by]=metric&seg[groups][1][field]=metadata.userId.raw&seg[groups][1][func]=terms&seg[groups][1][by]=metric&seg[metrics][0][metricName]=count%28event_id%29&seg[chartType]=bar",
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
@@ -4820,7 +4814,7 @@
         ],
         "metrics": [
           {
-            "metricName": "sum(events)"
+            "metricName": "count(event_id)"
           }
         ],
         "chartType": "bar"

--- a/features/admin.analytics.v1/assets/moesif-dashboard-essentials.json
+++ b/features/admin.analytics.v1/assets/moesif-dashboard-essentials.json
@@ -2915,10 +2915,9 @@
               }
             },
             "aggs": {
-              "weight|sum": {
-                "sum": {
-                  "field": "weight",
-                  "missing": 1
+              "_id|cardinality": {
+                "cardinality": {
+                  "field": "_id"
                 }
               }
             }
@@ -2932,7 +2931,7 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evtcf[filtersGroups][0][filters][1][id]=a2892735&evtcf[filtersGroups][0][filters][1][field]=metadata.userstoreDomain.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=AGENT&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=%20",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evtcf[filtersGroups][0][filters][1][id]=a2892735&evtcf[filtersGroups][0][filters][1][field]=metadata.userstoreDomain.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=AGENT&seg[metrics][0][metricName]=count%28event_id%29&seg[metrics][0][customName]=%20",
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
@@ -2945,7 +2944,7 @@
         },
         "metrics": [
           {
-            "metricName": "sum(events)"
+            "metricName": "count(event_id)"
           }
         ]
       }
@@ -4137,10 +4136,9 @@
               }
             },
             "aggs": {
-              "weight|sum": {
-                "sum": {
-                  "field": "weight",
-                  "missing": 1
+              "_id|cardinality": {
+                "cardinality": {
+                  "field": "_id"
                 }
               }
             }
@@ -4153,7 +4151,7 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evtcf[filtersGroups][0][filters][1][id]=a2892735&evtcf[filtersGroups][0][filters][1][field]=metadata.userstoreDomain.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=AGENT&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=%20",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evtcf[filtersGroups][0][filters][1][id]=a2892735&evtcf[filtersGroups][0][filters][1][field]=metadata.userstoreDomain.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=AGENT&seg[metrics][0][metricName]=count%28event_id%29&seg[metrics][0][customName]=%20",
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
@@ -4166,7 +4164,7 @@
         },
         "metrics": [
           {
-            "metricName": "sum(events)"
+            "metricName": "count(event_id)"
           }
         ]
       }

--- a/features/admin.analytics.v1/assets/moesif-dashboard-essentials.json
+++ b/features/admin.analytics.v1/assets/moesif-dashboard-essentials.json
@@ -3954,10 +3954,16 @@
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
+        "singleValueSettings": {
+          "chartHeight": "80",
+          "hideLabel": "true",
+          "trendIndicator": {
+            "isIncreasementGreen": "true"
+          }
+        },
         "metrics": [
           {
-            "metricName": "count(event_id)",
-            "customName": " "
+            "metricName": "count(event_id)"
           }
         ]
       }
@@ -4067,13 +4073,18 @@
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
+        "singleValueSettings": {
+          "chartHeight": "80",
+          "hideLabel": "true",
+          "trendIndicator": {
+            "isIncreasementGreen": "true"
+          }
+        },
         "metrics": [
           {
-            "metricName": "count(distinct(user_id))",
-            "customName": " "
+            "metricName": "count(distinct(user_id))"
           }
-        ],
-        "segments": ""
+        ]
       }
     },
     {
@@ -4146,10 +4157,16 @@
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
+        "singleValueSettings": {
+          "chartHeight": "80",
+          "hideLabel": "true",
+          "trendIndicator": {
+            "isIncreasementGreen": "true"
+          }
+        },
         "metrics": [
           {
-            "metricName": "sum(events)",
-            "customName": " "
+            "metricName": "sum(events)"
           }
         ]
       }
@@ -4239,11 +4256,17 @@
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
+        "singleValueSettings": {
+          "chartHeight": "80",
+          "hideLabel": "true",
+          "trendIndicator": {
+            "isIncreasementGreen": "true"
+          }
+        },
         "metrics": [
           {
             "field": "metadata.sessionId.raw",
-            "func": "cardinality",
-            "customName": " "
+            "func": "cardinality"
           }
         ]
       }

--- a/features/admin.analytics.v1/assets/moesif-dashboard-essentials.json
+++ b/features/admin.analytics.v1/assets/moesif-dashboard-essentials.json
@@ -74,7 +74,12 @@
         [
           "6a5e36ee8473bc558cd9b196",
           "6a5e2d4ce57d307b8ba6d53e",
-          "6a5e2d30e57d307b8ba6d53a"
+          "6a5e2d30e57d307b8ba6d53a",
+          "6a70ad034006641071c04ad6"
+        ],
+        [
+          "6a70ab0487769f0271938e8e",
+          "6a70a9de87769f0271938e7d"
         ],
         [
           "6a5e45698473bc558cd9b202"
@@ -4147,6 +4152,657 @@
             "customName": " "
           }
         ]
+      }
+    },
+    {
+      "_id": "6a70ad034006641071c04ad6",
+      "type": "events",
+      "name": "Active Agent Sessions",
+      "args": "",
+      "es_query": {
+        "post_filter": {
+          "bool": {
+            "must": [
+              {
+                "terms": {
+                  "action_name.raw": [
+                    "User-Session"
+                  ]
+                }
+              },
+              {
+                "terms": {
+                  "metadata.userStoreDomain.raw": [
+                    "AGENT"
+                  ]
+                }
+              },
+              {
+                "range": {
+                  "metadata.terminationTimestamp": {
+                    "gt": "now-0m/m",
+                    "time_zone": "Asia/Colombo"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "size": 0,
+        "aggs": {
+          "seg": {
+            "filter": {
+              "bool": {
+                "must": [
+                  {
+                    "terms": {
+                      "action_name.raw": [
+                        "User-Session"
+                      ]
+                    }
+                  },
+                  {
+                    "terms": {
+                      "metadata.userStoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  },
+                  {
+                    "range": {
+                      "metadata.terminationTimestamp": {
+                        "gt": "now-0m/m",
+                        "time_zone": "Asia/Colombo"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "aggs": {
+              "metadata__sessionId|cardinality": {
+                "cardinality": {
+                  "field": "metadata.sessionId.raw"
+                }
+              }
+            }
+          }
+        }
+      },
+      "dateRange": {
+        "from": "-7d",
+        "to": "now"
+      },
+      "view": "segment",
+      "funnel_query": {},
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Session&evtcf[filtersGroups][0][filters][1][id]=33b2c176&evtcf[filtersGroups][0][filters][1][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=AGENT&evtcf[filtersGroups][0][filters][2][id]=9522531d&evtcf[filtersGroups][0][filters][2][field]=metadata.terminationTimestamp&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=after&evtcf[filtersGroups][0][filters][2][value]=-0m&seg[metrics][0][field]=metadata.sessionId.raw&seg[metrics][0][func]=cardinality&seg[metrics][0][customName]=%20",
+      "analyticType": "seg",
+      "chartType": "bar",
+      "settings": {
+        "metrics": [
+          {
+            "field": "metadata.sessionId.raw",
+            "func": "cardinality",
+            "customName": " "
+          }
+        ]
+      }
+    },
+    {
+      "_id": "6a70ab0487769f0271938e8e",
+      "type": "events",
+      "name": "Agent Token Distribution",
+      "args": "",
+      "es_query": {
+        "post_filter": {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "terms": {
+                        "action_name.raw": [
+                          "OAuth-Token-Issuance"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.existingTokenUsed": [
+                          "false"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.userStoreDomain.raw": [
+                          "AGENT"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "terms": {
+                        "action_name.raw": [
+                          "OAuth-Token-Issuance"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.existingTokenUsed": [
+                          "false"
+                        ]
+                      }
+                    },
+                    {
+                      "bool": {
+                        "should": [
+                          {
+                            "exists": {
+                              "field": "metadata.actor.raw"
+                            }
+                          },
+                          {
+                            "exists": {
+                              "field": "metadata.actor"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "bool": {
+                        "must_not": {
+                          "terms": {
+                            "metadata.actor.raw": [
+                              "NOT_AVAILABLE"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "size": 0,
+        "aggs": {
+          "seg": {
+            "filter": {
+              "bool": {
+                "should": [
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "terms": {
+                            "action_name.raw": [
+                              "OAuth-Token-Issuance"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.existingTokenUsed": [
+                              "false"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.userStoreDomain.raw": [
+                              "AGENT"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "terms": {
+                            "action_name.raw": [
+                              "OAuth-Token-Issuance"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.existingTokenUsed": [
+                              "false"
+                            ]
+                          }
+                        },
+                        {
+                          "bool": {
+                            "should": [
+                              {
+                                "exists": {
+                                  "field": "metadata.actor.raw"
+                                }
+                              },
+                              {
+                                "exists": {
+                                  "field": "metadata.actor"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "bool": {
+                            "must_not": {
+                              "terms": {
+                                "metadata.actor.raw": [
+                                  "NOT_AVAILABLE"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            "aggs": {
+              "segment__Agent Tokens": {
+                "filter": {
+                  "bool": {
+                    "must": [
+                      {
+                        "terms": {
+                          "action_name.raw": [
+                            "OAuth-Token-Issuance"
+                          ]
+                        }
+                      },
+                      {
+                        "terms": {
+                          "metadata.existingTokenUsed": [
+                            "false"
+                          ]
+                        }
+                      },
+                      {
+                        "terms": {
+                          "metadata.userStoreDomain.raw": [
+                            "AGENT"
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                },
+                "aggs": {
+                  "weight|sum": {
+                    "sum": {
+                      "field": "weight",
+                      "missing": 1
+                    }
+                  }
+                }
+              },
+              "segment__Agent Tokens  as Actors": {
+                "filter": {
+                  "bool": {
+                    "must": [
+                      {
+                        "terms": {
+                          "action_name.raw": [
+                            "OAuth-Token-Issuance"
+                          ]
+                        }
+                      },
+                      {
+                        "terms": {
+                          "metadata.existingTokenUsed": [
+                            "false"
+                          ]
+                        }
+                      },
+                      {
+                        "bool": {
+                          "should": [
+                            {
+                              "exists": {
+                                "field": "metadata.actor.raw"
+                              }
+                            },
+                            {
+                              "exists": {
+                                "field": "metadata.actor"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "bool": {
+                          "must_not": {
+                            "terms": {
+                              "metadata.actor.raw": [
+                                "NOT_AVAILABLE"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "aggs": {
+                  "weight|sum": {
+                    "sum": {
+                      "field": "weight",
+                      "missing": 1
+                    }
+                  }
+                }
+              },
+              "weight|sum": {
+                "sum": {
+                  "field": "weight",
+                  "missing": 1
+                }
+              }
+            }
+          }
+        }
+      },
+      "dateRange": {
+        "from": "-52w",
+        "to": "now"
+      },
+      "view": "segment",
+      "funnel_query": {},
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][0][filters][1][id]=2714f5ec&evtcf[filtersGroups][0][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=eq&evtcf[filtersGroups][0][filters][1][value][0]=false&evtcf[filtersGroups][0][filters][2][id]=b84a7b60&evtcf[filtersGroups][0][filters][2][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=contains&evtcf[filtersGroups][0][filters][2][value][0]=AGENT&evtcf[filtersGroups][1][filters][0][id]=ad5ef950&evtcf[filtersGroups][1][filters][0][field]=action_name.raw&evtcf[filtersGroups][1][filters][0][name]=&evtcf[filtersGroups][1][filters][0][op]=contains&evtcf[filtersGroups][1][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][1][filters][1][id]=0e44fc56&evtcf[filtersGroups][1][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][1][filters][1][name]=&evtcf[filtersGroups][1][filters][1][op]=eq&evtcf[filtersGroups][1][filters][1][value][0]=false&evtcf[filtersGroups][1][filters][2][id]=83cacaad&evtcf[filtersGroups][1][filters][2][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][2][name]=&evtcf[filtersGroups][1][filters][2][op]=exists&evtcf[filtersGroups][1][filters][2][value]=&evtcf[filtersGroups][1][filters][3][id]=c919c6ab&evtcf[filtersGroups][1][filters][3][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][3][name]=&evtcf[filtersGroups][1][filters][3][op]=not_contain&evtcf[filtersGroups][1][filters][3][value][0]=NOT_AVAILABLE&seg[metrics][0][metricName]=sum%28events%29&seg[chartType]=pie&seg[segments][0][name]=Agent%20Tokens&seg[segments][0][filterGroups][0][id]=f78dc78f&seg[segments][0][filterGroups][0][filters][0][id]=f2a252dc&seg[segments][0][filterGroups][0][filters][0][field]=action_name.raw&seg[segments][0][filterGroups][0][filters][0][name]=&seg[segments][0][filterGroups][0][filters][0][op]=contains&seg[segments][0][filterGroups][0][filters][0][value][0]=OAuth-Token-Issuance&seg[segments][0][filterGroups][0][filters][1][id]=ed20a788&seg[segments][0][filterGroups][0][filters][1][field]=metadata.existingTokenUsed&seg[segments][0][filterGroups][0][filters][1][name]=&seg[segments][0][filterGroups][0][filters][1][op]=eq&seg[segments][0][filterGroups][0][filters][1][value][0]=false&seg[segments][0][filterGroups][0][filters][2][id]=f6996751&seg[segments][0][filterGroups][0][filters][2][field]=metadata.userStoreDomain.raw&seg[segments][0][filterGroups][0][filters][2][name]=&seg[segments][0][filterGroups][0][filters][2][op]=contains&seg[segments][0][filterGroups][0][filters][2][value][0]=AGENT&seg[segments][1][name]=Agent%20Tokens%20%20as%20Actors&seg[segments][1][filterGroups][0][id]=af80a108&seg[segments][1][filterGroups][0][filters][0][id]=4c082064&seg[segments][1][filterGroups][0][filters][0][field]=action_name.raw&seg[segments][1][filterGroups][0][filters][0][name]=&seg[segments][1][filterGroups][0][filters][0][op]=contains&seg[segments][1][filterGroups][0][filters][0][value][0]=OAuth-Token-Issuance&seg[segments][1][filterGroups][0][filters][1][id]=c6abf3f9&seg[segments][1][filterGroups][0][filters][1][field]=metadata.existingTokenUsed&seg[segments][1][filterGroups][0][filters][1][name]=&seg[segments][1][filterGroups][0][filters][1][op]=eq&seg[segments][1][filterGroups][0][filters][1][value][0]=false&seg[segments][1][filterGroups][0][filters][2][id]=4c43859d&seg[segments][1][filterGroups][0][filters][2][field]=metadata.actor.raw&seg[segments][1][filterGroups][0][filters][2][name]=&seg[segments][1][filterGroups][0][filters][2][op]=exists&seg[segments][1][filterGroups][0][filters][2][value]=&seg[segments][1][filterGroups][0][filters][3][id]=46a2fb34&seg[segments][1][filterGroups][0][filters][3][field]=metadata.actor.raw&seg[segments][1][filterGroups][0][filters][3][name]=&seg[segments][1][filterGroups][0][filters][3][op]=not_contain&seg[segments][1][filterGroups][0][filters][3][value][0]=NOT_AVAILABLE",
+      "analyticType": "seg",
+      "chartType": "pie",
+      "settings": {
+        "metrics": [
+          {
+            "metricName": "sum(events)"
+          }
+        ],
+        "chartType": "pie",
+        "segments": [
+          {
+            "name": "Agent Tokens",
+            "filterGroups": [
+              {
+                "id": "f78dc78f",
+                "filters": [
+                  {
+                    "id": "f2a252dc",
+                    "field": "action_name.raw",
+                    "name": "",
+                    "op": "contains",
+                    "value": [
+                      "OAuth-Token-Issuance"
+                    ]
+                  },
+                  {
+                    "id": "ed20a788",
+                    "field": "metadata.existingTokenUsed",
+                    "name": "",
+                    "op": "eq",
+                    "value": [
+                      "false"
+                    ]
+                  },
+                  {
+                    "id": "f6996751",
+                    "field": "metadata.userStoreDomain.raw",
+                    "name": "",
+                    "op": "contains",
+                    "value": [
+                      "AGENT"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Agent Tokens  as Actors",
+            "filterGroups": [
+              {
+                "id": "af80a108",
+                "filters": [
+                  {
+                    "id": "4c082064",
+                    "field": "action_name.raw",
+                    "name": "",
+                    "op": "contains",
+                    "value": [
+                      "OAuth-Token-Issuance"
+                    ]
+                  },
+                  {
+                    "id": "c6abf3f9",
+                    "field": "metadata.existingTokenUsed",
+                    "name": "",
+                    "op": "eq",
+                    "value": [
+                      "false"
+                    ]
+                  },
+                  {
+                    "id": "4c43859d",
+                    "field": "metadata.actor.raw",
+                    "name": "",
+                    "op": "exists",
+                    "value": ""
+                  },
+                  {
+                    "id": "46a2fb34",
+                    "field": "metadata.actor.raw",
+                    "name": "",
+                    "op": "not_contain",
+                    "value": [
+                      "NOT_AVAILABLE"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "_id": "6a70a9de87769f0271938e7d",
+      "type": "events",
+      "name": "Agent Usage by Users",
+      "args": "",
+      "es_query": {
+        "post_filter": {
+          "bool": {
+            "must": [
+              {
+                "terms": {
+                  "action_name.raw": [
+                    "OAuth-Token-Issuance"
+                  ]
+                }
+              },
+              {
+                "terms": {
+                  "metadata.existingTokenUsed": [
+                    "false"
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "should": [
+                    {
+                      "exists": {
+                        "field": "metadata.actor.raw"
+                      }
+                    },
+                    {
+                      "exists": {
+                        "field": "metadata.actor"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.actor.raw": [
+                        "NOT_AVAILABLE"
+                      ]
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "size": 0,
+        "aggs": {
+          "seg": {
+            "filter": {
+              "bool": {
+                "must": [
+                  {
+                    "terms": {
+                      "action_name.raw": [
+                        "OAuth-Token-Issuance"
+                      ]
+                    }
+                  },
+                  {
+                    "terms": {
+                      "metadata.existingTokenUsed": [
+                        "false"
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "should": [
+                        {
+                          "exists": {
+                            "field": "metadata.actor.raw"
+                          }
+                        },
+                        {
+                          "exists": {
+                            "field": "metadata.actor"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.actor.raw": [
+                            "NOT_AVAILABLE"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "aggs": {
+              "metadata.actor.raw": {
+                "terms": {
+                  "field": "metadata.actor.raw",
+                  "size": 5,
+                  "min_doc_count": 1,
+                  "order": {
+                    "weight|sum": "desc"
+                  },
+                  "missing": "(none)"
+                },
+                "aggs": {
+                  "metadata.userId.raw": {
+                    "terms": {
+                      "field": "metadata.userId.raw",
+                      "size": 5,
+                      "min_doc_count": 1,
+                      "order": {
+                        "weight|sum": "desc"
+                      },
+                      "missing": "(none)"
+                    },
+                    "aggs": {
+                      "weight|sum": {
+                        "sum": {
+                          "field": "weight",
+                          "missing": 1
+                        }
+                      }
+                    }
+                  },
+                  "weight|sum": {
+                    "sum": {
+                      "field": "weight",
+                      "missing": 1
+                    }
+                  }
+                }
+              },
+              "weight|sum": {
+                "sum": {
+                  "field": "weight",
+                  "missing": 1
+                }
+              }
+            }
+          }
+        }
+      },
+      "dateRange": {
+        "from": "-52w",
+        "to": "now"
+      },
+      "view": "segment",
+      "funnel_query": {},
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][0][filters][1][id]=804033d6&evtcf[filtersGroups][0][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=eq&evtcf[filtersGroups][0][filters][1][value][0]=false&evtcf[filtersGroups][0][filters][2][id]=4558e4e7&evtcf[filtersGroups][0][filters][2][field]=metadata.actor.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=exists&evtcf[filtersGroups][0][filters][2][value]=&evtcf[filtersGroups][0][filters][3][id]=09a65a7e&evtcf[filtersGroups][0][filters][3][field]=metadata.actor.raw&evtcf[filtersGroups][0][filters][3][name]=&evtcf[filtersGroups][0][filters][3][op]=not_contain&evtcf[filtersGroups][0][filters][3][value][0]=NOT_AVAILABLE&seg[groups][0][field]=metadata.actor.raw&seg[groups][0][func]=terms&seg[groups][0][by]=metric&seg[groups][1][field]=metadata.userId.raw&seg[groups][1][func]=terms&seg[groups][1][by]=metric&seg[metrics][0][metricName]=sum%28events%29&seg[chartType]=bar",
+      "analyticType": "seg",
+      "chartType": "bar",
+      "settings": {
+        "groups": [
+          {
+            "field": "metadata.actor.raw",
+            "func": "terms",
+            "by": "metric"
+          },
+          {
+            "field": "metadata.userId.raw",
+            "func": "terms",
+            "by": "metric"
+          }
+        ],
+        "metrics": [
+          {
+            "metricName": "sum(events)"
+          }
+        ],
+        "chartType": "bar"
       }
     }
   ]

--- a/features/admin.analytics.v1/assets/moesif-dashboard-free.json
+++ b/features/admin.analytics.v1/assets/moesif-dashboard-free.json
@@ -783,10 +783,9 @@
                             }
                         },
                         "aggs": {
-                            "weight|sum": {
-                                "sum": {
-                                    "field": "weight",
-                                    "missing": 1
+                            "_id|cardinality": {
+                                "cardinality": {
+                                    "field": "_id"
                                 }
                             }
                         }
@@ -800,7 +799,7 @@
             },
             "view": "segment",
             "funnel_query": {},
-            "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evtcf[filtersGroups][0][filters][1][id]=a2892735&evtcf[filtersGroups][0][filters][1][field]=metadata.userstoreDomain.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=AGENT&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=%20",
+            "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evtcf[filtersGroups][0][filters][1][id]=a2892735&evtcf[filtersGroups][0][filters][1][field]=metadata.userstoreDomain.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=AGENT&seg[metrics][0][metricName]=count%28event_id%29&seg[metrics][0][customName]=%20",
             "analyticType": "seg",
             "chartType": "bar",
             "settings": {
@@ -813,7 +812,7 @@
                 },
                 "metrics": [
                     {
-                        "metricName": "sum(events)"
+                        "metricName": "count(event_id)"
                     }
                 ]
             }

--- a/features/admin.analytics.v1/assets/moesif-dashboard-premium.json
+++ b/features/admin.analytics.v1/assets/moesif-dashboard-premium.json
@@ -4468,10 +4468,9 @@
                   }
                 },
                 "aggs": {
-                  "weight|sum": {
-                    "sum": {
-                      "field": "weight",
-                      "missing": 1
+                  "_id|cardinality": {
+                    "cardinality": {
+                      "field": "_id"
                     }
                   }
                 }
@@ -4525,18 +4524,16 @@
                   }
                 },
                 "aggs": {
-                  "weight|sum": {
-                    "sum": {
-                      "field": "weight",
-                      "missing": 1
+                  "_id|cardinality": {
+                    "cardinality": {
+                      "field": "_id"
                     }
                   }
                 }
               },
-              "weight|sum": {
-                "sum": {
-                  "field": "weight",
-                  "missing": 1
+              "_id|cardinality": {
+                "cardinality": {
+                  "field": "_id"
                 }
               }
             }
@@ -4549,13 +4546,13 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][0][filters][1][id]=2714f5ec&evtcf[filtersGroups][0][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=eq&evtcf[filtersGroups][0][filters][1][value][0]=false&evtcf[filtersGroups][0][filters][2][id]=b84a7b60&evtcf[filtersGroups][0][filters][2][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=contains&evtcf[filtersGroups][0][filters][2][value][0]=AGENT&evtcf[filtersGroups][1][filters][0][id]=ad5ef950&evtcf[filtersGroups][1][filters][0][field]=action_name.raw&evtcf[filtersGroups][1][filters][0][name]=&evtcf[filtersGroups][1][filters][0][op]=contains&evtcf[filtersGroups][1][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][1][filters][1][id]=0e44fc56&evtcf[filtersGroups][1][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][1][filters][1][name]=&evtcf[filtersGroups][1][filters][1][op]=eq&evtcf[filtersGroups][1][filters][1][value][0]=false&evtcf[filtersGroups][1][filters][2][id]=83cacaad&evtcf[filtersGroups][1][filters][2][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][2][name]=&evtcf[filtersGroups][1][filters][2][op]=exists&evtcf[filtersGroups][1][filters][2][value]=&evtcf[filtersGroups][1][filters][3][id]=c919c6ab&evtcf[filtersGroups][1][filters][3][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][3][name]=&evtcf[filtersGroups][1][filters][3][op]=not_contain&evtcf[filtersGroups][1][filters][3][value][0]=NOT_AVAILABLE&seg[metrics][0][metricName]=sum%28events%29&seg[chartType]=pie&seg[segments][0][name]=Agent%20Tokens&seg[segments][0][filterGroups][0][id]=f78dc78f&seg[segments][0][filterGroups][0][filters][0][id]=f2a252dc&seg[segments][0][filterGroups][0][filters][0][field]=action_name.raw&seg[segments][0][filterGroups][0][filters][0][name]=&seg[segments][0][filterGroups][0][filters][0][op]=contains&seg[segments][0][filterGroups][0][filters][0][value][0]=OAuth-Token-Issuance&seg[segments][0][filterGroups][0][filters][1][id]=ed20a788&seg[segments][0][filterGroups][0][filters][1][field]=metadata.existingTokenUsed&seg[segments][0][filterGroups][0][filters][1][name]=&seg[segments][0][filterGroups][0][filters][1][op]=eq&seg[segments][0][filterGroups][0][filters][1][value][0]=false&seg[segments][0][filterGroups][0][filters][2][id]=f6996751&seg[segments][0][filterGroups][0][filters][2][field]=metadata.userStoreDomain.raw&seg[segments][0][filterGroups][0][filters][2][name]=&seg[segments][0][filterGroups][0][filters][2][op]=contains&seg[segments][0][filterGroups][0][filters][2][value][0]=AGENT&seg[segments][1][name]=Agent%20Tokens%20%20as%20Actors&seg[segments][1][filterGroups][0][id]=af80a108&seg[segments][1][filterGroups][0][filters][0][id]=4c082064&seg[segments][1][filterGroups][0][filters][0][field]=action_name.raw&seg[segments][1][filterGroups][0][filters][0][name]=&seg[segments][1][filterGroups][0][filters][0][op]=contains&seg[segments][1][filterGroups][0][filters][0][value][0]=OAuth-Token-Issuance&seg[segments][1][filterGroups][0][filters][1][id]=c6abf3f9&seg[segments][1][filterGroups][0][filters][1][field]=metadata.existingTokenUsed&seg[segments][1][filterGroups][0][filters][1][name]=&seg[segments][1][filterGroups][0][filters][1][op]=eq&seg[segments][1][filterGroups][0][filters][1][value][0]=false&seg[segments][1][filterGroups][0][filters][2][id]=4c43859d&seg[segments][1][filterGroups][0][filters][2][field]=metadata.actor.raw&seg[segments][1][filterGroups][0][filters][2][name]=&seg[segments][1][filterGroups][0][filters][2][op]=exists&seg[segments][1][filterGroups][0][filters][2][value]=&seg[segments][1][filterGroups][0][filters][3][id]=46a2fb34&seg[segments][1][filterGroups][0][filters][3][field]=metadata.actor.raw&seg[segments][1][filterGroups][0][filters][3][name]=&seg[segments][1][filterGroups][0][filters][3][op]=not_contain&seg[segments][1][filterGroups][0][filters][3][value][0]=NOT_AVAILABLE",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][0][filters][1][id]=2714f5ec&evtcf[filtersGroups][0][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=eq&evtcf[filtersGroups][0][filters][1][value][0]=false&evtcf[filtersGroups][0][filters][2][id]=b84a7b60&evtcf[filtersGroups][0][filters][2][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=contains&evtcf[filtersGroups][0][filters][2][value][0]=AGENT&evtcf[filtersGroups][1][filters][0][id]=ad5ef950&evtcf[filtersGroups][1][filters][0][field]=action_name.raw&evtcf[filtersGroups][1][filters][0][name]=&evtcf[filtersGroups][1][filters][0][op]=contains&evtcf[filtersGroups][1][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][1][filters][1][id]=0e44fc56&evtcf[filtersGroups][1][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][1][filters][1][name]=&evtcf[filtersGroups][1][filters][1][op]=eq&evtcf[filtersGroups][1][filters][1][value][0]=false&evtcf[filtersGroups][1][filters][2][id]=83cacaad&evtcf[filtersGroups][1][filters][2][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][2][name]=&evtcf[filtersGroups][1][filters][2][op]=exists&evtcf[filtersGroups][1][filters][2][value]=&evtcf[filtersGroups][1][filters][3][id]=c919c6ab&evtcf[filtersGroups][1][filters][3][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][3][name]=&evtcf[filtersGroups][1][filters][3][op]=not_contain&evtcf[filtersGroups][1][filters][3][value][0]=NOT_AVAILABLE&seg[metrics][0][metricName]=count%28event_id%29&seg[chartType]=pie&seg[segments][0][name]=Agent%20Tokens&seg[segments][0][filterGroups][0][id]=f78dc78f&seg[segments][0][filterGroups][0][filters][0][id]=f2a252dc&seg[segments][0][filterGroups][0][filters][0][field]=action_name.raw&seg[segments][0][filterGroups][0][filters][0][name]=&seg[segments][0][filterGroups][0][filters][0][op]=contains&seg[segments][0][filterGroups][0][filters][0][value][0]=OAuth-Token-Issuance&seg[segments][0][filterGroups][0][filters][1][id]=ed20a788&seg[segments][0][filterGroups][0][filters][1][field]=metadata.existingTokenUsed&seg[segments][0][filterGroups][0][filters][1][name]=&seg[segments][0][filterGroups][0][filters][1][op]=eq&seg[segments][0][filterGroups][0][filters][1][value][0]=false&seg[segments][0][filterGroups][0][filters][2][id]=f6996751&seg[segments][0][filterGroups][0][filters][2][field]=metadata.userStoreDomain.raw&seg[segments][0][filterGroups][0][filters][2][name]=&seg[segments][0][filterGroups][0][filters][2][op]=contains&seg[segments][0][filterGroups][0][filters][2][value][0]=AGENT&seg[segments][1][name]=Agent%20Tokens%20%20as%20Actors&seg[segments][1][filterGroups][0][id]=af80a108&seg[segments][1][filterGroups][0][filters][0][id]=4c082064&seg[segments][1][filterGroups][0][filters][0][field]=action_name.raw&seg[segments][1][filterGroups][0][filters][0][name]=&seg[segments][1][filterGroups][0][filters][0][op]=contains&seg[segments][1][filterGroups][0][filters][0][value][0]=OAuth-Token-Issuance&seg[segments][1][filterGroups][0][filters][1][id]=c6abf3f9&seg[segments][1][filterGroups][0][filters][1][field]=metadata.existingTokenUsed&seg[segments][1][filterGroups][0][filters][1][name]=&seg[segments][1][filterGroups][0][filters][1][op]=eq&seg[segments][1][filterGroups][0][filters][1][value][0]=false&seg[segments][1][filterGroups][0][filters][2][id]=4c43859d&seg[segments][1][filterGroups][0][filters][2][field]=metadata.actor.raw&seg[segments][1][filterGroups][0][filters][2][name]=&seg[segments][1][filterGroups][0][filters][2][op]=exists&seg[segments][1][filterGroups][0][filters][2][value]=&seg[segments][1][filterGroups][0][filters][3][id]=46a2fb34&seg[segments][1][filterGroups][0][filters][3][field]=metadata.actor.raw&seg[segments][1][filterGroups][0][filters][3][name]=&seg[segments][1][filterGroups][0][filters][3][op]=not_contain&seg[segments][1][filterGroups][0][filters][3][value][0]=NOT_AVAILABLE",
       "analyticType": "seg",
       "chartType": "pie",
       "settings": {
         "metrics": [
           {
-            "metricName": "sum(events)"
+            "metricName": "count(event_id)"
           }
         ],
         "chartType": "pie",
@@ -4754,7 +4751,7 @@
                   "size": 5,
                   "min_doc_count": 1,
                   "order": {
-                    "weight|sum": "desc"
+                    "_id|cardinality": "desc"
                   },
                   "missing": "(none)"
                 },
@@ -4765,31 +4762,28 @@
                       "size": 5,
                       "min_doc_count": 1,
                       "order": {
-                        "weight|sum": "desc"
+                        "_id|cardinality": "desc"
                       },
                       "missing": "(none)"
                     },
                     "aggs": {
-                      "weight|sum": {
-                        "sum": {
-                          "field": "weight",
-                          "missing": 1
+                      "_id|cardinality": {
+                        "cardinality": {
+                          "field": "_id"
                         }
                       }
                     }
                   },
-                  "weight|sum": {
-                    "sum": {
-                      "field": "weight",
-                      "missing": 1
+                  "_id|cardinality": {
+                    "cardinality": {
+                      "field": "_id"
                     }
                   }
                 }
               },
-              "weight|sum": {
-                "sum": {
-                  "field": "weight",
-                  "missing": 1
+              "_id|cardinality": {
+                "cardinality": {
+                  "field": "_id"
                 }
               }
             }
@@ -4802,7 +4796,7 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][0][filters][1][id]=804033d6&evtcf[filtersGroups][0][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=eq&evtcf[filtersGroups][0][filters][1][value][0]=false&evtcf[filtersGroups][0][filters][2][id]=4558e4e7&evtcf[filtersGroups][0][filters][2][field]=metadata.actor.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=exists&evtcf[filtersGroups][0][filters][2][value]=&evtcf[filtersGroups][0][filters][3][id]=09a65a7e&evtcf[filtersGroups][0][filters][3][field]=metadata.actor.raw&evtcf[filtersGroups][0][filters][3][name]=&evtcf[filtersGroups][0][filters][3][op]=not_contain&evtcf[filtersGroups][0][filters][3][value][0]=NOT_AVAILABLE&seg[groups][0][field]=metadata.actor.raw&seg[groups][0][func]=terms&seg[groups][0][by]=metric&seg[groups][1][field]=metadata.userId.raw&seg[groups][1][func]=terms&seg[groups][1][by]=metric&seg[metrics][0][metricName]=sum%28events%29&seg[chartType]=bar",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][0][filters][1][id]=804033d6&evtcf[filtersGroups][0][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=eq&evtcf[filtersGroups][0][filters][1][value][0]=false&evtcf[filtersGroups][0][filters][2][id]=4558e4e7&evtcf[filtersGroups][0][filters][2][field]=metadata.actor.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=exists&evtcf[filtersGroups][0][filters][2][value]=&evtcf[filtersGroups][0][filters][3][id]=09a65a7e&evtcf[filtersGroups][0][filters][3][field]=metadata.actor.raw&evtcf[filtersGroups][0][filters][3][name]=&evtcf[filtersGroups][0][filters][3][op]=not_contain&evtcf[filtersGroups][0][filters][3][value][0]=NOT_AVAILABLE&seg[groups][0][field]=metadata.actor.raw&seg[groups][0][func]=terms&seg[groups][0][by]=metric&seg[groups][1][field]=metadata.userId.raw&seg[groups][1][func]=terms&seg[groups][1][by]=metric&seg[metrics][0][metricName]=count%28event_id%29&seg[chartType]=bar",
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
@@ -4820,7 +4814,7 @@
         ],
         "metrics": [
           {
-            "metricName": "sum(events)"
+            "metricName": "count(event_id)"
           }
         ],
         "chartType": "bar"

--- a/features/admin.analytics.v1/assets/moesif-dashboard-premium.json
+++ b/features/admin.analytics.v1/assets/moesif-dashboard-premium.json
@@ -2915,10 +2915,9 @@
               }
             },
             "aggs": {
-              "weight|sum": {
-                "sum": {
-                  "field": "weight",
-                  "missing": 1
+              "_id|cardinality": {
+                "cardinality": {
+                  "field": "_id"
                 }
               }
             }
@@ -2932,7 +2931,7 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evtcf[filtersGroups][0][filters][1][id]=a2892735&evtcf[filtersGroups][0][filters][1][field]=metadata.userstoreDomain.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=AGENT&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=%20",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evtcf[filtersGroups][0][filters][1][id]=a2892735&evtcf[filtersGroups][0][filters][1][field]=metadata.userstoreDomain.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=AGENT&seg[metrics][0][metricName]=count%28event_id%29&seg[metrics][0][customName]=%20",
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
@@ -2945,7 +2944,7 @@
         },
         "metrics": [
           {
-            "metricName": "sum(events)"
+            "metricName": "count(event_id)"
           }
         ]
       }
@@ -4137,10 +4136,9 @@
               }
             },
             "aggs": {
-              "weight|sum": {
-                "sum": {
-                  "field": "weight",
-                  "missing": 1
+              "_id|cardinality": {
+                "cardinality": {
+                  "field": "_id"
                 }
               }
             }
@@ -4153,7 +4151,7 @@
       },
       "view": "segment",
       "funnel_query": {},
-      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evtcf[filtersGroups][0][filters][1][id]=a2892735&evtcf[filtersGroups][0][filters][1][field]=metadata.userstoreDomain.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=AGENT&seg[metrics][0][metricName]=sum%28events%29&seg[metrics][0][customName]=%20",
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Registration&evtcf[filtersGroups][0][filters][1][id]=a2892735&evtcf[filtersGroups][0][filters][1][field]=metadata.userstoreDomain.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=AGENT&seg[metrics][0][metricName]=count%28event_id%29&seg[metrics][0][customName]=%20",
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
@@ -4166,7 +4164,7 @@
         },
         "metrics": [
           {
-            "metricName": "sum(events)"
+            "metricName": "count(event_id)"
           }
         ]
       }

--- a/features/admin.analytics.v1/assets/moesif-dashboard-premium.json
+++ b/features/admin.analytics.v1/assets/moesif-dashboard-premium.json
@@ -3954,10 +3954,16 @@
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
+        "singleValueSettings": {
+          "chartHeight": "80",
+          "hideLabel": "true",
+          "trendIndicator": {
+            "isIncreasementGreen": "true"
+          }
+        },
         "metrics": [
           {
-            "metricName": "count(event_id)",
-            "customName": " "
+            "metricName": "count(event_id)"
           }
         ]
       }
@@ -4067,13 +4073,18 @@
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
+        "singleValueSettings": {
+          "chartHeight": "80",
+          "hideLabel": "true",
+          "trendIndicator": {
+            "isIncreasementGreen": "true"
+          }
+        },
         "metrics": [
           {
-            "metricName": "count(distinct(user_id))",
-            "customName": " "
+            "metricName": "count(distinct(user_id))"
           }
-        ],
-        "segments": ""
+        ]
       }
     },
     {
@@ -4146,10 +4157,16 @@
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
+        "singleValueSettings": {
+          "chartHeight": "80",
+          "hideLabel": "true",
+          "trendIndicator": {
+            "isIncreasementGreen": "true"
+          }
+        },
         "metrics": [
           {
-            "metricName": "sum(events)",
-            "customName": " "
+            "metricName": "sum(events)"
           }
         ]
       }
@@ -4239,11 +4256,17 @@
       "analyticType": "seg",
       "chartType": "bar",
       "settings": {
+        "singleValueSettings": {
+          "chartHeight": "80",
+          "hideLabel": "true",
+          "trendIndicator": {
+            "isIncreasementGreen": "true"
+          }
+        },
         "metrics": [
           {
             "field": "metadata.sessionId.raw",
-            "func": "cardinality",
-            "customName": " "
+            "func": "cardinality"
           }
         ]
       }

--- a/features/admin.analytics.v1/assets/moesif-dashboard-premium.json
+++ b/features/admin.analytics.v1/assets/moesif-dashboard-premium.json
@@ -74,7 +74,12 @@
         [
           "6a5e36ee8473bc558cd9b196",
           "6a5e2d4ce57d307b8ba6d53e",
-          "6a5e2d30e57d307b8ba6d53a"
+          "6a5e2d30e57d307b8ba6d53a",
+          "6a70ad034006641071c04ad6"
+        ],
+        [
+          "6a70ab0487769f0271938e8e",
+          "6a70a9de87769f0271938e7d"
         ],
         [
           "6a5e45698473bc558cd9b202"
@@ -4147,6 +4152,657 @@
             "customName": " "
           }
         ]
+      }
+    },
+    {
+      "_id": "6a70ad034006641071c04ad6",
+      "type": "events",
+      "name": "Active Agent Sessions",
+      "args": "",
+      "es_query": {
+        "post_filter": {
+          "bool": {
+            "must": [
+              {
+                "terms": {
+                  "action_name.raw": [
+                    "User-Session"
+                  ]
+                }
+              },
+              {
+                "terms": {
+                  "metadata.userStoreDomain.raw": [
+                    "AGENT"
+                  ]
+                }
+              },
+              {
+                "range": {
+                  "metadata.terminationTimestamp": {
+                    "gt": "now-0m/m",
+                    "time_zone": "Asia/Colombo"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "size": 0,
+        "aggs": {
+          "seg": {
+            "filter": {
+              "bool": {
+                "must": [
+                  {
+                    "terms": {
+                      "action_name.raw": [
+                        "User-Session"
+                      ]
+                    }
+                  },
+                  {
+                    "terms": {
+                      "metadata.userStoreDomain.raw": [
+                        "AGENT"
+                      ]
+                    }
+                  },
+                  {
+                    "range": {
+                      "metadata.terminationTimestamp": {
+                        "gt": "now-0m/m",
+                        "time_zone": "Asia/Colombo"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "aggs": {
+              "metadata__sessionId|cardinality": {
+                "cardinality": {
+                  "field": "metadata.sessionId.raw"
+                }
+              }
+            }
+          }
+        }
+      },
+      "dateRange": {
+        "from": "-7d",
+        "to": "now"
+      },
+      "view": "segment",
+      "funnel_query": {},
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=User-Session&evtcf[filtersGroups][0][filters][1][id]=33b2c176&evtcf[filtersGroups][0][filters][1][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=contains&evtcf[filtersGroups][0][filters][1][value][0]=AGENT&evtcf[filtersGroups][0][filters][2][id]=9522531d&evtcf[filtersGroups][0][filters][2][field]=metadata.terminationTimestamp&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=after&evtcf[filtersGroups][0][filters][2][value]=-0m&seg[metrics][0][field]=metadata.sessionId.raw&seg[metrics][0][func]=cardinality&seg[metrics][0][customName]=%20",
+      "analyticType": "seg",
+      "chartType": "bar",
+      "settings": {
+        "metrics": [
+          {
+            "field": "metadata.sessionId.raw",
+            "func": "cardinality",
+            "customName": " "
+          }
+        ]
+      }
+    },
+    {
+      "_id": "6a70ab0487769f0271938e8e",
+      "type": "events",
+      "name": "Agent Token Distribution",
+      "args": "",
+      "es_query": {
+        "post_filter": {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "terms": {
+                        "action_name.raw": [
+                          "OAuth-Token-Issuance"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.existingTokenUsed": [
+                          "false"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.userStoreDomain.raw": [
+                          "AGENT"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "terms": {
+                        "action_name.raw": [
+                          "OAuth-Token-Issuance"
+                        ]
+                      }
+                    },
+                    {
+                      "terms": {
+                        "metadata.existingTokenUsed": [
+                          "false"
+                        ]
+                      }
+                    },
+                    {
+                      "bool": {
+                        "should": [
+                          {
+                            "exists": {
+                              "field": "metadata.actor.raw"
+                            }
+                          },
+                          {
+                            "exists": {
+                              "field": "metadata.actor"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "bool": {
+                        "must_not": {
+                          "terms": {
+                            "metadata.actor.raw": [
+                              "NOT_AVAILABLE"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "size": 0,
+        "aggs": {
+          "seg": {
+            "filter": {
+              "bool": {
+                "should": [
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "terms": {
+                            "action_name.raw": [
+                              "OAuth-Token-Issuance"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.existingTokenUsed": [
+                              "false"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.userStoreDomain.raw": [
+                              "AGENT"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "terms": {
+                            "action_name.raw": [
+                              "OAuth-Token-Issuance"
+                            ]
+                          }
+                        },
+                        {
+                          "terms": {
+                            "metadata.existingTokenUsed": [
+                              "false"
+                            ]
+                          }
+                        },
+                        {
+                          "bool": {
+                            "should": [
+                              {
+                                "exists": {
+                                  "field": "metadata.actor.raw"
+                                }
+                              },
+                              {
+                                "exists": {
+                                  "field": "metadata.actor"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "bool": {
+                            "must_not": {
+                              "terms": {
+                                "metadata.actor.raw": [
+                                  "NOT_AVAILABLE"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            "aggs": {
+              "segment__Agent Tokens": {
+                "filter": {
+                  "bool": {
+                    "must": [
+                      {
+                        "terms": {
+                          "action_name.raw": [
+                            "OAuth-Token-Issuance"
+                          ]
+                        }
+                      },
+                      {
+                        "terms": {
+                          "metadata.existingTokenUsed": [
+                            "false"
+                          ]
+                        }
+                      },
+                      {
+                        "terms": {
+                          "metadata.userStoreDomain.raw": [
+                            "AGENT"
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                },
+                "aggs": {
+                  "weight|sum": {
+                    "sum": {
+                      "field": "weight",
+                      "missing": 1
+                    }
+                  }
+                }
+              },
+              "segment__Agent Tokens  as Actors": {
+                "filter": {
+                  "bool": {
+                    "must": [
+                      {
+                        "terms": {
+                          "action_name.raw": [
+                            "OAuth-Token-Issuance"
+                          ]
+                        }
+                      },
+                      {
+                        "terms": {
+                          "metadata.existingTokenUsed": [
+                            "false"
+                          ]
+                        }
+                      },
+                      {
+                        "bool": {
+                          "should": [
+                            {
+                              "exists": {
+                                "field": "metadata.actor.raw"
+                              }
+                            },
+                            {
+                              "exists": {
+                                "field": "metadata.actor"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "bool": {
+                          "must_not": {
+                            "terms": {
+                              "metadata.actor.raw": [
+                                "NOT_AVAILABLE"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "aggs": {
+                  "weight|sum": {
+                    "sum": {
+                      "field": "weight",
+                      "missing": 1
+                    }
+                  }
+                }
+              },
+              "weight|sum": {
+                "sum": {
+                  "field": "weight",
+                  "missing": 1
+                }
+              }
+            }
+          }
+        }
+      },
+      "dateRange": {
+        "from": "-52w",
+        "to": "now"
+      },
+      "view": "segment",
+      "funnel_query": {},
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][0][filters][1][id]=2714f5ec&evtcf[filtersGroups][0][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=eq&evtcf[filtersGroups][0][filters][1][value][0]=false&evtcf[filtersGroups][0][filters][2][id]=b84a7b60&evtcf[filtersGroups][0][filters][2][field]=metadata.userStoreDomain.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=contains&evtcf[filtersGroups][0][filters][2][value][0]=AGENT&evtcf[filtersGroups][1][filters][0][id]=ad5ef950&evtcf[filtersGroups][1][filters][0][field]=action_name.raw&evtcf[filtersGroups][1][filters][0][name]=&evtcf[filtersGroups][1][filters][0][op]=contains&evtcf[filtersGroups][1][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][1][filters][1][id]=0e44fc56&evtcf[filtersGroups][1][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][1][filters][1][name]=&evtcf[filtersGroups][1][filters][1][op]=eq&evtcf[filtersGroups][1][filters][1][value][0]=false&evtcf[filtersGroups][1][filters][2][id]=83cacaad&evtcf[filtersGroups][1][filters][2][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][2][name]=&evtcf[filtersGroups][1][filters][2][op]=exists&evtcf[filtersGroups][1][filters][2][value]=&evtcf[filtersGroups][1][filters][3][id]=c919c6ab&evtcf[filtersGroups][1][filters][3][field]=metadata.actor.raw&evtcf[filtersGroups][1][filters][3][name]=&evtcf[filtersGroups][1][filters][3][op]=not_contain&evtcf[filtersGroups][1][filters][3][value][0]=NOT_AVAILABLE&seg[metrics][0][metricName]=sum%28events%29&seg[chartType]=pie&seg[segments][0][name]=Agent%20Tokens&seg[segments][0][filterGroups][0][id]=f78dc78f&seg[segments][0][filterGroups][0][filters][0][id]=f2a252dc&seg[segments][0][filterGroups][0][filters][0][field]=action_name.raw&seg[segments][0][filterGroups][0][filters][0][name]=&seg[segments][0][filterGroups][0][filters][0][op]=contains&seg[segments][0][filterGroups][0][filters][0][value][0]=OAuth-Token-Issuance&seg[segments][0][filterGroups][0][filters][1][id]=ed20a788&seg[segments][0][filterGroups][0][filters][1][field]=metadata.existingTokenUsed&seg[segments][0][filterGroups][0][filters][1][name]=&seg[segments][0][filterGroups][0][filters][1][op]=eq&seg[segments][0][filterGroups][0][filters][1][value][0]=false&seg[segments][0][filterGroups][0][filters][2][id]=f6996751&seg[segments][0][filterGroups][0][filters][2][field]=metadata.userStoreDomain.raw&seg[segments][0][filterGroups][0][filters][2][name]=&seg[segments][0][filterGroups][0][filters][2][op]=contains&seg[segments][0][filterGroups][0][filters][2][value][0]=AGENT&seg[segments][1][name]=Agent%20Tokens%20%20as%20Actors&seg[segments][1][filterGroups][0][id]=af80a108&seg[segments][1][filterGroups][0][filters][0][id]=4c082064&seg[segments][1][filterGroups][0][filters][0][field]=action_name.raw&seg[segments][1][filterGroups][0][filters][0][name]=&seg[segments][1][filterGroups][0][filters][0][op]=contains&seg[segments][1][filterGroups][0][filters][0][value][0]=OAuth-Token-Issuance&seg[segments][1][filterGroups][0][filters][1][id]=c6abf3f9&seg[segments][1][filterGroups][0][filters][1][field]=metadata.existingTokenUsed&seg[segments][1][filterGroups][0][filters][1][name]=&seg[segments][1][filterGroups][0][filters][1][op]=eq&seg[segments][1][filterGroups][0][filters][1][value][0]=false&seg[segments][1][filterGroups][0][filters][2][id]=4c43859d&seg[segments][1][filterGroups][0][filters][2][field]=metadata.actor.raw&seg[segments][1][filterGroups][0][filters][2][name]=&seg[segments][1][filterGroups][0][filters][2][op]=exists&seg[segments][1][filterGroups][0][filters][2][value]=&seg[segments][1][filterGroups][0][filters][3][id]=46a2fb34&seg[segments][1][filterGroups][0][filters][3][field]=metadata.actor.raw&seg[segments][1][filterGroups][0][filters][3][name]=&seg[segments][1][filterGroups][0][filters][3][op]=not_contain&seg[segments][1][filterGroups][0][filters][3][value][0]=NOT_AVAILABLE",
+      "analyticType": "seg",
+      "chartType": "pie",
+      "settings": {
+        "metrics": [
+          {
+            "metricName": "sum(events)"
+          }
+        ],
+        "chartType": "pie",
+        "segments": [
+          {
+            "name": "Agent Tokens",
+            "filterGroups": [
+              {
+                "id": "f78dc78f",
+                "filters": [
+                  {
+                    "id": "f2a252dc",
+                    "field": "action_name.raw",
+                    "name": "",
+                    "op": "contains",
+                    "value": [
+                      "OAuth-Token-Issuance"
+                    ]
+                  },
+                  {
+                    "id": "ed20a788",
+                    "field": "metadata.existingTokenUsed",
+                    "name": "",
+                    "op": "eq",
+                    "value": [
+                      "false"
+                    ]
+                  },
+                  {
+                    "id": "f6996751",
+                    "field": "metadata.userStoreDomain.raw",
+                    "name": "",
+                    "op": "contains",
+                    "value": [
+                      "AGENT"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Agent Tokens  as Actors",
+            "filterGroups": [
+              {
+                "id": "af80a108",
+                "filters": [
+                  {
+                    "id": "4c082064",
+                    "field": "action_name.raw",
+                    "name": "",
+                    "op": "contains",
+                    "value": [
+                      "OAuth-Token-Issuance"
+                    ]
+                  },
+                  {
+                    "id": "c6abf3f9",
+                    "field": "metadata.existingTokenUsed",
+                    "name": "",
+                    "op": "eq",
+                    "value": [
+                      "false"
+                    ]
+                  },
+                  {
+                    "id": "4c43859d",
+                    "field": "metadata.actor.raw",
+                    "name": "",
+                    "op": "exists",
+                    "value": ""
+                  },
+                  {
+                    "id": "46a2fb34",
+                    "field": "metadata.actor.raw",
+                    "name": "",
+                    "op": "not_contain",
+                    "value": [
+                      "NOT_AVAILABLE"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "_id": "6a70a9de87769f0271938e7d",
+      "type": "events",
+      "name": "Agent Usage by Users",
+      "args": "",
+      "es_query": {
+        "post_filter": {
+          "bool": {
+            "must": [
+              {
+                "terms": {
+                  "action_name.raw": [
+                    "OAuth-Token-Issuance"
+                  ]
+                }
+              },
+              {
+                "terms": {
+                  "metadata.existingTokenUsed": [
+                    "false"
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "should": [
+                    {
+                      "exists": {
+                        "field": "metadata.actor.raw"
+                      }
+                    },
+                    {
+                      "exists": {
+                        "field": "metadata.actor"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "must_not": {
+                    "terms": {
+                      "metadata.actor.raw": [
+                        "NOT_AVAILABLE"
+                      ]
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "size": 0,
+        "aggs": {
+          "seg": {
+            "filter": {
+              "bool": {
+                "must": [
+                  {
+                    "terms": {
+                      "action_name.raw": [
+                        "OAuth-Token-Issuance"
+                      ]
+                    }
+                  },
+                  {
+                    "terms": {
+                      "metadata.existingTokenUsed": [
+                        "false"
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "should": [
+                        {
+                          "exists": {
+                            "field": "metadata.actor.raw"
+                          }
+                        },
+                        {
+                          "exists": {
+                            "field": "metadata.actor"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must_not": {
+                        "terms": {
+                          "metadata.actor.raw": [
+                            "NOT_AVAILABLE"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "aggs": {
+              "metadata.actor.raw": {
+                "terms": {
+                  "field": "metadata.actor.raw",
+                  "size": 5,
+                  "min_doc_count": 1,
+                  "order": {
+                    "weight|sum": "desc"
+                  },
+                  "missing": "(none)"
+                },
+                "aggs": {
+                  "metadata.userId.raw": {
+                    "terms": {
+                      "field": "metadata.userId.raw",
+                      "size": 5,
+                      "min_doc_count": 1,
+                      "order": {
+                        "weight|sum": "desc"
+                      },
+                      "missing": "(none)"
+                    },
+                    "aggs": {
+                      "weight|sum": {
+                        "sum": {
+                          "field": "weight",
+                          "missing": 1
+                        }
+                      }
+                    }
+                  },
+                  "weight|sum": {
+                    "sum": {
+                      "field": "weight",
+                      "missing": 1
+                    }
+                  }
+                }
+              },
+              "weight|sum": {
+                "sum": {
+                  "field": "weight",
+                  "missing": 1
+                }
+              }
+            }
+          }
+        }
+      },
+      "dateRange": {
+        "from": "-52w",
+        "to": "now"
+      },
+      "view": "segment",
+      "funnel_query": {},
+      "urlQuery": "?evtcf[filtersGroups][0][filters][0][id]=f0&evtcf[filtersGroups][0][filters][0][field]=action_name.raw&evtcf[filtersGroups][0][filters][0][name]=&evtcf[filtersGroups][0][filters][0][op]=contains&evtcf[filtersGroups][0][filters][0][value][0]=OAuth-Token-Issuance&evtcf[filtersGroups][0][filters][1][id]=804033d6&evtcf[filtersGroups][0][filters][1][field]=metadata.existingTokenUsed&evtcf[filtersGroups][0][filters][1][name]=&evtcf[filtersGroups][0][filters][1][op]=eq&evtcf[filtersGroups][0][filters][1][value][0]=false&evtcf[filtersGroups][0][filters][2][id]=4558e4e7&evtcf[filtersGroups][0][filters][2][field]=metadata.actor.raw&evtcf[filtersGroups][0][filters][2][name]=&evtcf[filtersGroups][0][filters][2][op]=exists&evtcf[filtersGroups][0][filters][2][value]=&evtcf[filtersGroups][0][filters][3][id]=09a65a7e&evtcf[filtersGroups][0][filters][3][field]=metadata.actor.raw&evtcf[filtersGroups][0][filters][3][name]=&evtcf[filtersGroups][0][filters][3][op]=not_contain&evtcf[filtersGroups][0][filters][3][value][0]=NOT_AVAILABLE&seg[groups][0][field]=metadata.actor.raw&seg[groups][0][func]=terms&seg[groups][0][by]=metric&seg[groups][1][field]=metadata.userId.raw&seg[groups][1][func]=terms&seg[groups][1][by]=metric&seg[metrics][0][metricName]=sum%28events%29&seg[chartType]=bar",
+      "analyticType": "seg",
+      "chartType": "bar",
+      "settings": {
+        "groups": [
+          {
+            "field": "metadata.actor.raw",
+            "func": "terms",
+            "by": "metric"
+          },
+          {
+            "field": "metadata.userId.raw",
+            "func": "terms",
+            "by": "metric"
+          }
+        ],
+        "metrics": [
+          {
+            "metricName": "sum(events)"
+          }
+        ],
+        "chartType": "bar"
       }
     }
   ]


### PR DESCRIPTION
## Purpose

Adds three new widgets to the Agent dashboard in both the premium and essentials Moesif dashboard templates:

- **Active Agent Sessions**: count of distinct active agent sessions (cardinality of session id on active User-Session events)
- **Agent Token Distribution**: pie chart of agent tokens vs actor-based tokens
- **Agent Usage by Users**: token issuance grouped by agent and user

The Agent dashboard layout is rearranged to match the convention used by the other dashboards: number tiles in the first row, breakdown charts in the second row, and each time-series graph on its own row.

## Related

- Follow-up to #10550

🤖 Generated with [Claude Code](https://claude.com/claude-code)