### PR TITLE
Prefetch API resource collections to speed up console role permissions grid

### DIFF
--- a/.changeset/prefetch-console-role-api-resource-collections.md
+++ b/.changeset/prefetch-console-role-api-resource-collections.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.console-settings.v1": patch
+"@wso2is/console": patch
+---
+
+Prefetch API resource collections when the console roles list loads, so the granular permissions grid in the create/edit role views renders instantly instead of waiting on that request the first time a wizard is opened in a session.

--- a/features/admin.console-settings.v1/components/console-roles/console-roles-list.tsx
+++ b/features/admin.console-settings.v1/components/console-roles/console-roles-list.tsx
@@ -26,6 +26,7 @@ import { useDispatch } from "react-redux";
 import { Dispatch } from "redux";
 import ConsoleRolesListLayout from "./console-roles-list-layout";
 import CreateConsoleRoleWizard from "./create-console-role-wizard/create-console-role-wizard";
+import useGetAPIResourceCollections from "../../api/use-get-api-resource-collections";
 import useConsoleRoles from "../../hooks/use-console-roles";
 
 /**
@@ -66,6 +67,13 @@ const ConsoleRolesList: FunctionComponent<ConsoleRolesListInterface> = (
     } = useConsoleRoles(true, listItemLimit, listOffset, searchQuery);
 
     const { isSubOrganization } = useGetCurrentOrganizationType();
+
+    // Warms the SWR cache for the API resource collections consumed by the create/edit role
+    // permissions grids. On first visit (notably in cloud deployments) this request is slow, so
+    // firing it while the roles list is on screen means it has usually resolved by the time the
+    // user opens the create wizard or an existing role, instead of blocking that view.
+    useGetAPIResourceCollections(true, "type eq tenant", "apiResources");
+    useGetAPIResourceCollections(true, "type eq organization", "apiResources");
 
     /**
      * The following useEffect is used to handle if any error occurs while fetching the roles list.


### PR DESCRIPTION
## Summary
- On the console settings > Roles page, opening the "New Role" wizard (or an existing role's permissions view) for the first time in a session is noticeably slow to render the granular permissions grid, especially in cloud deployments. Subsequent opens in the same session are near-instant.
- Root cause: `useGetAPIResourceCollections` is an SWR-backed hook that only starts its network request when the wizard/edit view mounts, i.e. the moment the user opens it. The heavy client-side processing in the permissions form is already memoized, so the visible delay is purely the first network round trip; later opens hit the SWR cache and render immediately.
- Fix: fire the same two `useGetAPIResourceCollections` calls (tenant and organization API resource collections) from `console-roles-list.tsx`, which mounts as soon as the Roles tab is opened — before the user clicks "New Role". Since the SWR cache key is identical to the one used by both the create wizard and the edit-role-permissions view, this warms the cache while the user is still browsing the list, so the grid is typically ready by the time they open either flow.
- No behavior change, no new request shape — purely moves an existing request earlier.

## Test plan
- [x] `pnpm lint` on the changed file
- [ ] Manually verify in a cloud-like deployment: open the Roles tab, then immediately open "New Role" — permissions grid should render without a noticeable delay
- [ ] Verify the roles list itself still loads/paginates/searches correctly (unaffected by the added hook calls)
- [ ] Verify editing an existing role's permissions still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)