### PR TITLE
Fix readOnly prop logic in ShareUserForm component

### DIFF
--- a/.changeset/easy-moles-rest.md
+++ b/.changeset/easy-moles-rest.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.users.v1": patch
+"@wso2is/console": patch
+---
+
+Fix readOnly prop logic in ShareUserForm component

--- a/features/admin.users.v1/components/edit-user.tsx
+++ b/features/admin.users.v1/components/edit-user.tsx
@@ -128,6 +128,9 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
     const usersFeatureConfig: FeatureAccessConfigInterface = useSelector((state: AppState) => {
         return state.config.ui.features?.users;
     });
+    const isSAASDeployment: boolean = useSelector(
+        (state: AppState) => state?.config?.ui?.isSAASDeployment
+    );
     const isUserGroupsEnabled: boolean = isFeatureEnabled(
         usersFeatureConfig,
         UserManagementConstants.FEATURE_DICTIONARY.get(UserFeatureDictionaryKeys.UserGroups)
@@ -331,7 +334,7 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
                     <ResourceTab.Pane controlledSegmentation attached={ false }>
                         <ShareUserForm
                             user={ user }
-                            readOnly={ !hasSharedAccessUpdatePermission }
+                            readOnly={ (!isSAASDeployment && isReadOnly) || !hasSharedAccessUpdatePermission }
                             enableConsoleAdminRole={ enableConsoleAdminRole }
                         />
                     </ResourceTab.Pane>
@@ -344,6 +347,7 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
         user,
         isUserGroupsEnabled,
         isSharedAccessEnabled,
+        isSAASDeployment,
         hasSharedAccessReadPermission,
         hasSharedAccessUpdatePermission,
         connectorProperties,


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
Fixes an issue where non-super-admin users were able to edit the 'Shared Access' tab on a super admin's profile. This change ensures the shared access configurations remain read-only for unauthorized users.

### Related Issue
- https://github.com/wso2/product-is/issues/27728