### PR TITLE
Harden custom branding layout content handling

### DIFF
--- a/identity-apps-core/apps/accounts/src/main/webapp/includes/layout-resolver.jsp
+++ b/identity-apps-core/apps/accounts/src/main/webapp/includes/layout-resolver.jsp
@@ -16,7 +16,53 @@
   ~ under the License.
 --%>
 
+<%@ page import="org.apache.commons.logging.Log" %>
+<%@ page import="org.apache.commons.logging.LogFactory" %>
+
 <%!
+    private static final Log LOG = LogFactory.getLog("layout-resolver");
+
+    private static final String[] REMOTE_RESOURCE_PREFIXES = {
+            "//",
+            "http://", "https://",
+            "ftp://",  "ftps://",  "sftp://",
+            "file:",   "jar:",     "data:"
+    };
+
+    private static final String[] REMOTE_RESOURCE_EXTENSIONS = {".ser", ".html"};
+
+    /**
+    * Returns true if the given string is a remote resource reference (http, https, ftp,
+    * protocol-relative, or any other absolute URI with a scheme). Layout HTML must be
+    * inline markup, not a URL pointing to a remote host.
+    *
+    * @param input The layout HTML content string to inspect.
+    * @return true if the value looks like a remote URL.
+    */
+    public boolean isRemoteResource(String input) {
+        if (StringUtils.isBlank(input)) {
+            return false;
+        }
+        String normalised = input.trim().replace('\\', '/');
+        String lower = normalised.toLowerCase(java.util.Locale.ROOT);
+        for (String prefix : REMOTE_RESOURCE_PREFIXES) {
+            if (lower.startsWith(prefix)) {
+                return true;
+            }
+        }
+        for (String ext : REMOTE_RESOURCE_EXTENSIONS) {
+            if (lower.endsWith(ext)) {
+                return true;
+            }
+        }
+        // Catch-all for any other scheme, including handlers registered at runtime (e.g. OSGi).
+        try {
+            return new java.net.URI(normalised).getScheme() != null;
+        } catch (java.net.URISyntaxException e) {
+            return false;
+        }
+    }
+
     /**
     * Convert the application name by replacing spaces with underscores.
     *
@@ -90,9 +136,15 @@
                                 JSONObject customContent = brandingPreference.getJSONObject(LAYOUT_KEY).getJSONObject(CUSTOM_CONTENT_KEY);
                                 if (customContent != null) {
                                     if (customContent.has(HTML_CONTENT_KEY) && !StringUtils.isBlank(customContent.getString(HTML_CONTENT_KEY))) {
-                                        layout = temp;
-                                        htmlContent = customContent.getString(HTML_CONTENT_KEY);
-                                        layoutFileRelativePath = htmlContent;
+                                        String candidateHtml = customContent.getString(HTML_CONTENT_KEY);
+                                        if (isRemoteResource(candidateHtml)) {
+                                            LOG.warn("Custom layout HTML content contains a remote URL reference. " +
+                                                    "Falling back to the default layout.");
+                                        } else {
+                                            layout = temp;
+                                            htmlContent = candidateHtml;
+                                            layoutFileRelativePath = htmlContent;
+                                        }
                                     }
                                     if (customContent.has(CSS_CONTENT_KEY) && !StringUtils.isBlank(customContent.getString(CSS_CONTENT_KEY))) {
                                         cssContent = customContent.getString(CSS_CONTENT_KEY);

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/layout-resolver.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/layout-resolver.jsp
@@ -16,7 +16,53 @@
   ~ under the License.
 --%>
 
+<%@ page import="org.apache.commons.logging.Log" %>
+<%@ page import="org.apache.commons.logging.LogFactory" %>
+
 <%!
+    private static final Log LOG = LogFactory.getLog("layout-resolver");
+
+    private static final String[] REMOTE_RESOURCE_PREFIXES = {
+            "//",
+            "http://", "https://",
+            "ftp://",  "ftps://",  "sftp://",
+            "file:",   "jar:",     "data:"
+    };
+
+    private static final String[] REMOTE_RESOURCE_EXTENSIONS = {".ser", ".html"};
+
+    /**
+    * Returns true if the given string is a remote resource reference (http, https, ftp,
+    * protocol-relative, or any other absolute URI with a scheme). Layout HTML must be
+    * inline markup, not a URL pointing to a remote host.
+    *
+    * @param input The layout HTML content string to inspect.
+    * @return true if the value looks like a remote URL.
+    */
+    public boolean isRemoteResource(String input) {
+        if (StringUtils.isBlank(input)) {
+            return false;
+        }
+        String normalised = input.trim().replace('\\', '/');
+        String lower = normalised.toLowerCase(java.util.Locale.ROOT);
+        for (String prefix : REMOTE_RESOURCE_PREFIXES) {
+            if (lower.startsWith(prefix)) {
+                return true;
+            }
+        }
+        for (String ext : REMOTE_RESOURCE_EXTENSIONS) {
+            if (lower.endsWith(ext)) {
+                return true;
+            }
+        }
+        // Catch-all for any other scheme, including handlers registered at runtime (e.g. OSGi).
+        try {
+            return new java.net.URI(normalised).getScheme() != null;
+        } catch (java.net.URISyntaxException e) {
+            return false;
+        }
+    }
+
     /**
     * Convert the application name by replacing spaces with underscores.
     *
@@ -90,9 +136,15 @@
                                 JSONObject customContent = brandingPreference.getJSONObject(LAYOUT_KEY).getJSONObject(CUSTOM_CONTENT_KEY);
                                 if (customContent != null) {
                                     if (customContent.has(HTML_CONTENT_KEY) && !StringUtils.isBlank(customContent.getString(HTML_CONTENT_KEY))) {
-                                        layout = temp;
-                                        htmlContent = customContent.getString(HTML_CONTENT_KEY);
-                                        layoutFileRelativePath = htmlContent;
+                                        String candidateHtml = customContent.getString(HTML_CONTENT_KEY);
+                                        if (isRemoteResource(candidateHtml)) {
+                                            LOG.warn("Custom layout HTML content contains a remote URL reference. " +
+                                                    "Falling back to the default layout.");
+                                        } else {
+                                            layout = temp;
+                                            htmlContent = candidateHtml;
+                                            layoutFileRelativePath = htmlContent;
+                                        }
                                     }
                                     if (customContent.has(CSS_CONTENT_KEY) && !StringUtils.isBlank(customContent.getString(CSS_CONTENT_KEY))) {
                                         cssContent = customContent.getString(CSS_CONTENT_KEY);

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/layout-resolver.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/layout-resolver.jsp
@@ -16,7 +16,53 @@
   ~ under the License.
 --%>
 
+<%@ page import="org.apache.commons.logging.Log" %>
+<%@ page import="org.apache.commons.logging.LogFactory" %>
+
 <%!
+    private static final Log LOG = LogFactory.getLog("layout-resolver");
+
+    private static final String[] REMOTE_RESOURCE_PREFIXES = {
+            "//",
+            "http://", "https://",
+            "ftp://",  "ftps://",  "sftp://",
+            "file:",   "jar:",     "data:"
+    };
+
+    private static final String[] REMOTE_RESOURCE_EXTENSIONS = {".ser", ".html"};
+
+    /**
+    * Returns true if the given string is a remote resource reference (http, https, ftp,
+    * protocol-relative, or any other absolute URI with a scheme). Layout HTML must be
+    * inline markup, not a URL pointing to a remote host.
+    *
+    * @param input The layout HTML content string to inspect.
+    * @return true if the value looks like a remote URL.
+    */
+    public boolean isRemoteResource(String input) {
+        if (StringUtils.isBlank(input)) {
+            return false;
+        }
+        String normalised = input.trim().replace('\\', '/');
+        String lower = normalised.toLowerCase(java.util.Locale.ROOT);
+        for (String prefix : REMOTE_RESOURCE_PREFIXES) {
+            if (lower.startsWith(prefix)) {
+                return true;
+            }
+        }
+        for (String ext : REMOTE_RESOURCE_EXTENSIONS) {
+            if (lower.endsWith(ext)) {
+                return true;
+            }
+        }
+        // Catch-all for any other scheme, including handlers registered at runtime (e.g. OSGi).
+        try {
+            return new java.net.URI(normalised).getScheme() != null;
+        } catch (java.net.URISyntaxException e) {
+            return false;
+        }
+    }
+
     /**
     * Convert the application name by replacing spaces with underscores.
     *
@@ -90,9 +136,15 @@
                                 JSONObject customContent = brandingPreference.getJSONObject(LAYOUT_KEY).getJSONObject(CUSTOM_CONTENT_KEY);
                                 if (customContent != null) {
                                     if (customContent.has(HTML_CONTENT_KEY) && !StringUtils.isBlank(customContent.getString(HTML_CONTENT_KEY))) {
-                                        layout = temp;
-                                        htmlContent = customContent.getString(HTML_CONTENT_KEY);
-                                        layoutFileRelativePath = htmlContent;
+                                        String candidateHtml = customContent.getString(HTML_CONTENT_KEY);
+                                        if (isRemoteResource(candidateHtml)) {
+                                            LOG.warn("Custom layout HTML content contains a remote URL reference. " +
+                                                    "Falling back to the default layout.");
+                                        } else {
+                                            layout = temp;
+                                            htmlContent = candidateHtml;
+                                            layoutFileRelativePath = htmlContent;
+                                        }
                                     }
                                     if (customContent.has(CSS_CONTENT_KEY) && !StringUtils.isBlank(customContent.getString(CSS_CONTENT_KEY))) {
                                         cssContent = customContent.getString(CSS_CONTENT_KEY);

--- a/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/layout-resolver.jsp
+++ b/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/layout-resolver.jsp
@@ -16,7 +16,53 @@
   ~ under the License.
 --%>
 
+<%@ page import="org.apache.commons.logging.Log" %>
+<%@ page import="org.apache.commons.logging.LogFactory" %>
+
 <%!
+    private static final Log LOG = LogFactory.getLog("layout-resolver");
+
+    private static final String[] REMOTE_RESOURCE_PREFIXES = {
+            "//",
+            "http://", "https://",
+            "ftp://",  "ftps://",  "sftp://",
+            "file:",   "jar:",     "data:"
+    };
+
+    private static final String[] REMOTE_RESOURCE_EXTENSIONS = {".ser", ".html"};
+
+    /**
+    * Returns true if the given string is a remote resource reference (http, https, ftp,
+    * protocol-relative, or any other absolute URI with a scheme). Layout HTML must be
+    * inline markup, not a URL pointing to a remote host.
+    *
+    * @param input The layout HTML content string to inspect.
+    * @return true if the value looks like a remote URL.
+    */
+    public boolean isRemoteResource(String input) {
+        if (StringUtils.isBlank(input)) {
+            return false;
+        }
+        String normalised = input.trim().replace('\\', '/');
+        String lower = normalised.toLowerCase(java.util.Locale.ROOT);
+        for (String prefix : REMOTE_RESOURCE_PREFIXES) {
+            if (lower.startsWith(prefix)) {
+                return true;
+            }
+        }
+        for (String ext : REMOTE_RESOURCE_EXTENSIONS) {
+            if (lower.endsWith(ext)) {
+                return true;
+            }
+        }
+        // Catch-all for any other scheme, including handlers registered at runtime (e.g. OSGi).
+        try {
+            return new java.net.URI(normalised).getScheme() != null;
+        } catch (java.net.URISyntaxException e) {
+            return false;
+        }
+    }
+
     /**
     * Convert the application name by replacing spaces with underscores.
     *
@@ -90,9 +136,15 @@
                                 JSONObject customContent = brandingPreference.getJSONObject(LAYOUT_KEY).getJSONObject(CUSTOM_CONTENT_KEY);
                                 if (customContent != null) {
                                     if (customContent.has(HTML_CONTENT_KEY) && !StringUtils.isBlank(customContent.getString(HTML_CONTENT_KEY))) {
-                                        layout = temp;
-                                        htmlContent = customContent.getString(HTML_CONTENT_KEY);
-                                        layoutFileRelativePath = htmlContent;
+                                        String candidateHtml = customContent.getString(HTML_CONTENT_KEY);
+                                        if (isRemoteResource(candidateHtml)) {
+                                            LOG.warn("Custom layout HTML content contains a remote URL reference. " +
+                                                    "Falling back to the default layout.");
+                                        } else {
+                                            layout = temp;
+                                            htmlContent = candidateHtml;
+                                            layoutFileRelativePath = htmlContent;
+                                        }
                                     }
                                     if (customContent.has(CSS_CONTENT_KEY) && !StringUtils.isBlank(customContent.getString(CSS_CONTENT_KEY))) {
                                         cssContent = customContent.getString(CSS_CONTENT_KEY);

--- a/identity-apps-core/components/org.wso2.identity.apps.taglibs.layout.controller/src/main/java/org/wso2/identity/apps/taglibs/layout/controller/core/LocalTemplateEngine.java
+++ b/identity-apps-core/components/org.wso2.identity.apps.taglibs.layout.controller/src/main/java/org/wso2/identity/apps/taglibs/layout/controller/core/LocalTemplateEngine.java
@@ -24,6 +24,7 @@ import org.wso2.identity.apps.taglibs.layout.controller.compiler.parsers.Default
 import org.wso2.identity.apps.taglibs.layout.controller.compiler.parsers.Parser;
 
 import java.io.IOException;
+import java.io.ObjectInputFilter;
 import java.io.ObjectInputStream;
 import java.io.Writer;
 import java.net.URL;
@@ -69,6 +70,10 @@ public class LocalTemplateEngine implements TemplateEngine {
 
         if (executor == null && compiledObject == null) {
             try (ObjectInputStream objectReader = new ObjectInputStream(layoutFile.openStream())) {
+                objectReader.setObjectInputFilter(ObjectInputFilter.Config.createFilter(
+                        "org.wso2.identity.apps.taglibs.layout.controller.compiler.identifiers.*" +
+                        ";java.lang.String" +
+                        ";!*"));
                 compiledObject = (ExecutableIdentifier) objectReader.readObject();
                 executor = new DefaultExecutor(data);
             } catch (IOException | ClassNotFoundException exception) {


### PR DESCRIPTION
## Summary
- Restrict object deserialization in the layout template engine to a fixed allowlist of expected classes
- Reject remote URL references in custom layout HTML content and fall back to the default layout, with a warning logged

## Test plan
- [x] Custom branding layout with local/inline content renders as before
- [x] Custom branding layout with a remote URL reference is rejected and the default layout is served