### PR TITLE
Fix: update consent management heading

### DIFF
--- a/.changeset/consent-management-heading.md
+++ b/.changeset/consent-management-heading.md
@@ -1,0 +1,10 @@
+\---
+
+"@wso2is/i18n": patch
+
+\---
+
+
+
+Updated the MyAccount Consent Management heading from "Manage Consents" to "Consent Management".
+

--- a/modules/i18n/src/translations/en-US/portals/myaccount.ts
+++ b/modules/i18n/src/translations/en-US/portals/myaccount.ts
@@ -1901,7 +1901,7 @@ export const myAccount: MyAccountNS = {
             },
             description:
                 "Review consents granted to each application and revoke them as needed.",
-            heading: "Manage Consents",
+            heading: "Consent Management",
             placeholders: {
                 emptyConsentList: {
                     heading: "You have not granted consent to any application"


### PR DESCRIPTION
### Purpose

Updated the MyAccount Consent Management page heading from "Manage Consents" to "Consent Management" for better clarity.

### Related Issues

- Fixes #28268

### Related PRs

- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributors)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](https://github.com/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks

- [ ] Followed secure coding standards in [http://wso2.com/technical-reports/wso2-secure-engineering-guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)

- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.