### PR TITLE
Remove connector setup logo backdrop

### DIFF
--- a/.changeset/old-pandas-fetch.md
+++ b/.changeset/old-pandas-fetch.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/admin.connections.v1": patch
+---
+
+Remove logo gradient backdrop in connection edit pages

--- a/features/admin.connections.v1/pages/authenticator-edit.tsx
+++ b/features/admin.connections.v1/pages/authenticator-edit.tsx
@@ -36,7 +36,16 @@ import {
     TabPageLayout,
     useDocumentation
 } from "@wso2is/react-components";
-import React, { Fragment, FunctionComponent, ReactElement, ReactNode, useEffect, useRef, useState } from "react";
+import React, {
+    CSSProperties,
+    Fragment,
+    FunctionComponent,
+    ReactElement,
+    ReactNode,
+    useEffect,
+    useRef,
+    useState
+} from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { RouteComponentProps } from "react-router";
@@ -49,6 +58,12 @@ import { CommonAuthenticatorConstants } from "../constants/common-authenticator-
 import { AuthenticatorMeta } from "../meta/authenticator-meta";
 import { AuthenticatorLabels } from "../models/authenticators";
 import { CustomAuthConnectionInterface } from "../models/connection";
+
+/**
+ * Clears the gradient backdrop `AppAvatar` renders behind square avatars, so the connector
+ * logo on this page is shown on its own.
+ */
+const CONNECTOR_LOGO_STYLES: CSSProperties = { background: "transparent" };
 
 /**
  * Proptypes for the Custom Local Authenticator edit page component.
@@ -212,6 +227,7 @@ const AuthenticatorEditPage: FunctionComponent<AuthenticatorEditPagePropsInterfa
                 name={ connector?.displayName }
                 image={ connector?.image || AuthenticatorMeta.getCustomAuthenticatorIcon() }
                 size="tiny"
+                style={ CONNECTOR_LOGO_STYLES }
             />
         );
     };

--- a/features/admin.connections.v1/pages/connection-edit.tsx
+++ b/features/admin.connections.v1/pages/connection-edit.tsx
@@ -46,7 +46,16 @@ import {
 import { AxiosError } from "axios";
 import get from "lodash-es/get";
 import orderBy from "lodash-es/orderBy";
-import React, { Fragment, FunctionComponent, ReactElement, ReactNode, useEffect, useRef, useState } from "react";
+import React, {
+    CSSProperties,
+    Fragment,
+    FunctionComponent,
+    ReactElement,
+    ReactNode,
+    useEffect,
+    useRef,
+    useState
+} from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { RouteComponentProps } from "react-router";
@@ -70,6 +79,12 @@ import {
 } from "../models/connection";
 import { ConnectionTemplateManagementUtils } from "../utils/connection-template-utils";
 import { ConnectionsManagementUtils, handleGetConnectionsMetaDataError } from "../utils/connection-utils";
+
+/**
+ * Clears the gradient backdrop `AppAvatar` renders behind square avatars, so the connector
+ * logo on this page is shown on its own.
+ */
+const CONNECTOR_LOGO_STYLES: CSSProperties = { background: "transparent" };
 
 /**
  * Proptypes for the IDP edit page component.
@@ -586,6 +601,7 @@ const ConnectionEditPage: FunctionComponent<ConnectionEditPagePropsInterface> = 
                             connector?.image
                         ) }
                         size="tiny"
+                        style={ CONNECTOR_LOGO_STYLES }
                     />
                 );
             }
@@ -605,6 +621,7 @@ const ConnectionEditPage: FunctionComponent<ConnectionEditPagePropsInterface> = 
                         )
                 }
                 size="tiny"
+                style={ CONNECTOR_LOGO_STYLES }
             />
         );
     };


### PR DESCRIPTION
## Purpose

The connection setup page (/connections/<idp-id> and its local-authenticator equivalent) renders the connector logo inside an AppAvatar, which the theme paints with a square orange gradient backdrop. This removal clears that backdrop so the logo is shown on its own. 

1. **Branding guidelines** - The logos rendered here belong to third parties like Google, Microsoft, Apple etc. Nearly every one of those vendors' brand guidelines specifies the approved backgrounds their mark may be placed on, and a tinted, product-coloured panel is not among them. Rendering the asset unmodified, on a neutral surface, is the compliant default.

2. **What you see is what you get** - The backdrop is applied here and essentially nowhere else that these same logos appear — the connections list, the connection template picker, the create wizard, and the sign-in flow builder all render the identical asset with no fill behind it. The logo the admin provides should be the logo the admin sees.