### PR TITLE
Add dropdown inputs to connection create and edit templates

### DIFF
--- a/.changeset/lovely-poems-do.md
+++ b/.changeset/lovely-poems-do.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/admin.connections.v1": patch
+"@wso2is/forms": patch
+"@wso2is/i18n": patch
+---
+
+Add support for `select`/`dropdown` fields in connection create and edittemplates, including a `useDynamicFieldOptions` hook that resolves fieldoptions from existing connections declared via `optionsSource` metadata.

--- a/.changeset/lovely-poems-do.md
+++ b/.changeset/lovely-poems-do.md
@@ -1,7 +1,8 @@
 ---
-"@wso2is/admin.connections.v1": patch
-"@wso2is/forms": patch
+"@wso2is/admin.connections.v1": minor
+"@wso2is/console": patch
+"@wso2is/forms": minor
 "@wso2is/i18n": patch
 ---
 
-Add support for `select`/`dropdown` fields in connection create and edittemplates, including a `useDynamicFieldOptions` hook that resolves fieldoptions from existing connections declared via `optionsSource` metadata.
+Add support for `select` fields in connection create and edit templates, including a `useDynamicFieldOptions` hook that resolves field options from existing connections declared via `optionsSource` metadata.

--- a/features/admin.connections.v1/components/create/add-connection-wizard.tsx
+++ b/features/admin.connections.v1/components/create/add-connection-wizard.tsx
@@ -69,6 +69,7 @@ import {
 import { CommonAuthenticatorConstants } from "../../constants/common-authenticator-constants";
 import { ConnectionUIConstants } from "../../constants/connection-ui-constants";
 import { FederatedAuthenticatorConstants } from "../../constants/federated-authenticator-constants";
+import useDynamicFieldOptions from "../../hooks/use-dynamic-field-options";
 import {
     CommonPluggableComponentPropertyInterface,
     ConnectionInterface,
@@ -136,6 +137,13 @@ export const CreateConnectionWizard: FC<CreateConnectionWizardPropsInterface> = 
         isLoading: isConnectionMetaDataFetchRequestLoading,
         error: connectionMetaDataFetchRequestError
     } = useGetConnectionMetaData(template?.id);
+
+    /**
+     * Resolves the options of the create form fields that source them from another resource.
+     */
+    const { fields: resolvedCreateFormFields } = useDynamicFieldOptions(
+        connectionMetaData?.create?.modal?.form?.fields
+    );
 
     let submitAdvanceForm: () => void;
     let triggerPreviousForm: () => void;
@@ -750,7 +758,7 @@ export const CreateConnectionWizard: FC<CreateConnectionWizardPropsInterface> = 
                             uncontrolledForm={ true }
                         >
                             <DynamicWizardPage>
-                                { renderFormFields(modifyFormFields(connectionMetaData?.create?.modal?.form?.fields)) }
+                                { renderFormFields(modifyFormFields(resolvedCreateFormFields)) }
                             </DynamicWizardPage>
                         </DynamicWizard>
                         {

--- a/features/admin.connections.v1/components/edit/forms/authenticator-settings-form.tsx
+++ b/features/admin.connections.v1/components/edit/forms/authenticator-settings-form.tsx
@@ -31,6 +31,7 @@ import React, { FC, ReactNode, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { Icon, SemanticICONS } from "semantic-ui-react";
 import { FederatedAuthenticatorConstants } from "../../../constants/federated-authenticator-constants";
+import useDynamicFieldOptions from "../../../hooks/use-dynamic-field-options";
 import {
     AuthenticatorSettingsFormModes,
     CommonAuthenticatorFormFieldMetaInterface,
@@ -45,6 +46,11 @@ import "./authenticator-settings-form.scss";
  */
 interface AuthenticatorSettingsFormPropsInterface extends TestableComponentInterface {
     connectorSettings: any;
+    /**
+     * Resource id of the connection being edited.
+     * Used to resolve settings fields that reference other connections.
+     */
+    connectionId?: string;
     /**
      * The intended mode of the authenticator form.
      * If the mode is "EDIT", the form will be used in the edit view and will rely on metadata for readonly states, etc.
@@ -132,6 +138,7 @@ export const AuthenticatorSettingsForm: FC<AuthenticatorSettingsFormPropsInterfa
 ): any => {
 
     const {
+        connectionId,
         connectorSettings,
         metadata,
         initialValues: originalInitialValues,
@@ -145,6 +152,17 @@ export const AuthenticatorSettingsForm: FC<AuthenticatorSettingsFormPropsInterfa
     const [ formFields, setFormFields ] = useState<any>(undefined);
     const [ initialValues, setInitialValues ] = useState<any>(undefined);
     const [ settings, setSettings ] = useState<any>(undefined);
+
+    /**
+     * Resolves the options of the settings fields that source them from another resource.
+     */
+    const { fields: resolvedSettingsFields } = useDynamicFieldOptions(
+        settings?.edit?.tabs?.settings,
+        {
+            currentConnectionId: connectionId,
+            currentValues: initialValues
+        }
+    );
 
     /**
      * Flattens and resolved form initial values and field metadata.
@@ -285,7 +303,7 @@ export const AuthenticatorSettingsForm: FC<AuthenticatorSettingsFormPropsInterfa
      */
     const renderFormFields = () => {
         if (settings) {
-            return renderDynamicFormFields(settings?.edit?.tabs?.settings);
+            return renderDynamicFormFields(resolvedSettingsFields);
         } else if (formFields) {
             const fields: DynamicInputElementsInterface[] = [];
 

--- a/features/admin.connections.v1/components/edit/forms/authenticator-settings-form.tsx
+++ b/features/admin.connections.v1/components/edit/forms/authenticator-settings-form.tsx
@@ -48,7 +48,6 @@ interface AuthenticatorSettingsFormPropsInterface extends TestableComponentInter
     connectorSettings: any;
     /**
      * Resource id of the connection being edited.
-     * Used to resolve settings fields that reference other connections.
      */
     connectionId?: string;
     /**
@@ -153,9 +152,6 @@ export const AuthenticatorSettingsForm: FC<AuthenticatorSettingsFormPropsInterfa
     const [ initialValues, setInitialValues ] = useState<any>(undefined);
     const [ settings, setSettings ] = useState<any>(undefined);
 
-    /**
-     * Resolves the options of the settings fields that source them from another resource.
-     */
     const { fields: resolvedSettingsFields } = useDynamicFieldOptions(
         settings?.edit?.tabs?.settings,
         {

--- a/features/admin.connections.v1/components/edit/forms/factories/authenticator-form-factory.tsx
+++ b/features/admin.connections.v1/components/edit/forms/factories/authenticator-form-factory.tsx
@@ -103,6 +103,10 @@ interface AuthenticatorFormFactoryInterface extends TestableComponentInterface {
      * Connection setting section meta data.
      */
     connectionSettingsMetaData: any;
+    /**
+     * Resource id of the connection being edited.
+     */
+    connectionId?: string;
 }
 
 /**
@@ -117,6 +121,7 @@ export const AuthenticatorFormFactory: FunctionComponent<AuthenticatorFormFactor
 
     const {
         authenticator,
+        connectionId,
         connectionSettingsMetaData,
         metadata,
         mode,
@@ -357,6 +362,7 @@ export const AuthenticatorFormFactory: FunctionComponent<AuthenticatorFormFactor
         default:
             return (
                 <AuthenticatorSettingsForm
+                    connectionId={ connectionId }
                     connectorSettings={ connectionSettingsMetaData }
                     mode={ mode }
                     initialValues={ initialValues }

--- a/features/admin.connections.v1/components/edit/settings/authenticator-settings.tsx
+++ b/features/admin.connections.v1/components/edit/settings/authenticator-settings.tsx
@@ -1005,6 +1005,7 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
 
             return (
                 <AuthenticatorFormFactory
+                    connectionId={ identityProvider.id }
                     connectionSettingsMetaData={ connectionSettingsMetaData }
                     mode={ AuthenticatorSettingsFormModes.EDIT }
                     authenticator={ authenticator }

--- a/features/admin.connections.v1/hooks/use-dynamic-field-options.ts
+++ b/features/admin.connections.v1/hooks/use-dynamic-field-options.ts
@@ -31,36 +31,17 @@ import {
  * Supported option sources of a dynamic `select` field.
  */
 enum DynamicFieldOptionsSourceTypes {
-    /**
-     * Options are the connections of the organization, optionally narrowed down by the
-     * authenticator they use and the template they were created from.
-     */
-    CONNECTIONS = "connections"
+    IDENTITY_PROVIDERS = "identity-providers"
 }
 
 /**
  * Declaration of where the options of a dynamic `select` field come from.
  */
 interface DynamicFieldOptionsSourceInterface {
-    /**
-     * Type of the source. Only `connections` is supported at the moment.
-     */
     type: DynamicFieldOptionsSourceTypes | string;
-    /**
-     * Only list connections having a federated authenticator with this id.
-     */
     authenticatorId?: string;
-    /**
-     * Only list connections created from this connection template.
-     */
     templateId?: string;
-    /**
-     * Attribute of a connection persisted as the value of the field. Defaults to `id`.
-     */
     valueField?: string;
-    /**
-     * Attribute of a connection displayed as the label of an option. Defaults to `name`.
-     */
     labelField?: string;
 }
 
@@ -68,25 +49,10 @@ interface DynamicFieldOptionsSourceInterface {
  * Attributes of a dynamic form field this hook reads or rewrites.
  */
 interface DynamicFieldInterface {
-    /**
-     * Name of the field, also the key its value is persisted under.
-     */
     name?: string;
-    /**
-     * Placeholder of the field, replaced while the options are being resolved.
-     */
     placeholder?: string;
-    /**
-     * Whether the field is read only.
-     */
     readOnly?: boolean;
-    /**
-     * Declaration of where the options of the field come from, if any.
-     */
     optionsSource?: DynamicFieldOptionsSourceInterface;
-    /**
-     * Renderer specific attributes declared by the connector metadata.
-     */
     [ key: string ]: unknown;
 }
 
@@ -94,13 +60,7 @@ interface DynamicFieldInterface {
  * Context of the form the fields are rendered in.
  */
 interface DynamicFieldOptionsContextInterface {
-    /**
-     * Resource id of the connection being edited, if any.
-     */
     currentConnectionId?: string;
-    /**
-     * Values the form was initialized with, keyed by field name.
-     */
     currentValues?: Record<string, unknown>;
 }
 
@@ -108,13 +68,7 @@ interface DynamicFieldOptionsContextInterface {
  * Return type of {@link useDynamicFieldOptions}.
  */
 interface DynamicFieldOptionsResultInterface {
-    /**
-     * The given fields, with the options of every `optionsSource` backed field resolved.
-     */
     fields: DynamicFieldInterface[];
-    /**
-     * Whether the options are still being resolved.
-     */
     isLoading: boolean;
 }
 
@@ -132,7 +86,7 @@ const useDynamicFieldOptions = (
     const [ isResolvingTemplateIds, setIsResolvingTemplateIds ] = useState<boolean>(false);
 
     /**
-     * Sources declared by the given fields. Empty for every form that does not use the feature.
+     * Sources declared by the given fields.
      */
     const sources: DynamicFieldOptionsSourceInterface[] = useMemo(() => {
         if (!Array.isArray(fields)) {
@@ -142,7 +96,7 @@ const useDynamicFieldOptions = (
         return fields
             .map((field: DynamicFieldInterface) => field?.optionsSource)
             .filter((source: DynamicFieldOptionsSourceInterface) =>
-                source?.type === DynamicFieldOptionsSourceTypes.CONNECTIONS);
+                source?.type === DynamicFieldOptionsSourceTypes.IDENTITY_PROVIDERS);
     }, [ fields ]);
 
     const shouldFetchConnections: boolean = sources.length > 0;
@@ -169,11 +123,10 @@ const useDynamicFieldOptions = (
     );
 
     /**
-     * Connections that satisfy every filter of a source that can be evaluated on the list response.
+     * Connections that satisfy every filter of a source.
      */
     const getCandidates = (source: DynamicFieldOptionsSourceInterface): StrictConnectionInterface[] => {
         return connections.filter((connection: StrictConnectionInterface) => {
-            // The connection being edited is never a valid option for itself.
             if (connection?.id === context?.currentConnectionId) {
                 return false;
             }
@@ -193,8 +146,7 @@ const useDynamicFieldOptions = (
     };
 
     /**
-     * Ids of the candidates whose template id has to be looked up, since the connections list
-     * response does not carry it.
+     * Ids of the candidates whose template id has to be looked up.
      */
     const idsRequiringTemplateId: string[] = useMemo(() => {
         const ids: Set<string> = new Set<string>();
@@ -264,7 +216,7 @@ const useDynamicFieldOptions = (
         return fields.map((field: DynamicFieldInterface) => {
             const source: DynamicFieldOptionsSourceInterface = field?.optionsSource;
 
-            if (source?.type !== DynamicFieldOptionsSourceTypes.CONNECTIONS) {
+            if (source?.type !== DynamicFieldOptionsSourceTypes.IDENTITY_PROVIDERS) {
                 return field;
             }
 

--- a/features/admin.connections.v1/hooks/use-dynamic-field-options.ts
+++ b/features/admin.connections.v1/hooks/use-dynamic-field-options.ts
@@ -55,10 +55,6 @@ interface DynamicFieldOptionsSourceInterface {
      */
     templateId?: string;
     /**
-     * Exclude the connection that is currently being edited from the list.
-     */
-    excludeCurrent?: boolean;
-    /**
      * Attribute of a connection persisted as the value of the field. Defaults to `id`.
      */
     valueField?: string;
@@ -177,7 +173,12 @@ const useDynamicFieldOptions = (
      */
     const getCandidates = (source: DynamicFieldOptionsSourceInterface): StrictConnectionInterface[] => {
         return connections.filter((connection: StrictConnectionInterface) => {
-            if (source?.excludeCurrent && connection?.id === context?.currentConnectionId) {
+            // The connection being edited is never a valid option for itself.
+            if (connection?.id === context?.currentConnectionId) {
+                return false;
+            }
+
+            if (connection?.isEnabled === false) {
                 return false;
             }
 
@@ -297,12 +298,19 @@ const useDynamicFieldOptions = (
 
             if (!isEmpty(persistedValue)
                 && !options.some((option: { value: string }) => option.value === persistedValue)) {
+                const persistedConnection: StrictConnectionInterface = connections.find(
+                    (connection: StrictConnectionInterface) => get(connection, valueField) === persistedValue);
+
                 options.push({
                     text: isLoading
                         ? persistedValue
-                        : t("authenticationProvider:forms.authenticatorSettings.dynamicOptions.unavailable", {
-                            value: persistedValue
-                        }),
+                        : (persistedConnection?.isEnabled === false
+                            ? t("authenticationProvider:forms.authenticatorSettings.dynamicOptions.disabled", {
+                                value: get(persistedConnection, labelField) ?? persistedValue
+                            })
+                            : t("authenticationProvider:forms.authenticatorSettings.dynamicOptions.unavailable", {
+                                value: persistedValue
+                            })),
                     value: persistedValue
                 });
             }

--- a/features/admin.connections.v1/hooks/use-dynamic-field-options.ts
+++ b/features/admin.connections.v1/hooks/use-dynamic-field-options.ts
@@ -69,6 +69,32 @@ interface DynamicFieldOptionsSourceInterface {
 }
 
 /**
+ * Attributes of a dynamic form field this hook reads or rewrites.
+ */
+interface DynamicFieldInterface {
+    /**
+     * Name of the field, also the key its value is persisted under.
+     */
+    name?: string;
+    /**
+     * Placeholder of the field, replaced while the options are being resolved.
+     */
+    placeholder?: string;
+    /**
+     * Whether the field is read only.
+     */
+    readOnly?: boolean;
+    /**
+     * Declaration of where the options of the field come from, if any.
+     */
+    optionsSource?: DynamicFieldOptionsSourceInterface;
+    /**
+     * Renderer specific attributes declared by the connector metadata.
+     */
+    [ key: string ]: unknown;
+}
+
+/**
  * Context of the form the fields are rendered in.
  */
 interface DynamicFieldOptionsContextInterface {
@@ -79,7 +105,7 @@ interface DynamicFieldOptionsContextInterface {
     /**
      * Values the form was initialized with, keyed by field name.
      */
-    currentValues?: Record<string, any>;
+    currentValues?: Record<string, unknown>;
 }
 
 /**
@@ -89,7 +115,7 @@ interface DynamicFieldOptionsResultInterface {
     /**
      * The given fields, with the options of every `optionsSource` backed field resolved.
      */
-    fields: Record<string, any>[];
+    fields: DynamicFieldInterface[];
     /**
      * Whether the options are still being resolved.
      */
@@ -98,22 +124,9 @@ interface DynamicFieldOptionsResultInterface {
 
 /**
  * Resolves the options of dynamic form fields that declare an `optionsSource`.
- *
- * The dynamic form renderer (`@wso2is/forms/legacy` `renderFormFields`) only understands a static
- * `options` array, and a connector's `metadata.json` cannot know the connections of an organization.
- * This hook bridges the two: it reads the declarative `optionsSource` of each field and returns a
- * copy of the fields with a concrete `options` array attached, so a connector can offer a picker of
- * existing connections without any connector specific code in the console.
- *
- * Fields without an `optionsSource` are returned untouched and no request is made.
- *
- * @param fields - Dynamic form field definitions, as read from the connector metadata.
- * @param context - Context of the form the fields are rendered in.
- *
- * @returns The fields with resolved options and the resolution status.
  */
 const useDynamicFieldOptions = (
-    fields: Record<string, any>[],
+    fields: DynamicFieldInterface[],
     context?: DynamicFieldOptionsContextInterface
 ): DynamicFieldOptionsResultInterface => {
 
@@ -131,7 +144,7 @@ const useDynamicFieldOptions = (
         }
 
         return fields
-            .map((field: Record<string, any>) => field?.optionsSource)
+            .map((field: DynamicFieldInterface) => field?.optionsSource)
             .filter((source: DynamicFieldOptionsSourceInterface) =>
                 source?.type === DynamicFieldOptionsSourceTypes.CONNECTIONS);
     }, [ fields ]);
@@ -242,12 +255,12 @@ const useDynamicFieldOptions = (
 
     const isLoading: boolean = isConnectionListLoading || isResolvingTemplateIds;
 
-    const resolvedFields: Record<string, any>[] = useMemo(() => {
+    const resolvedFields: DynamicFieldInterface[] = useMemo(() => {
         if (!Array.isArray(fields)) {
             return fields;
         }
 
-        return fields.map((field: Record<string, any>) => {
+        return fields.map((field: DynamicFieldInterface) => {
             const source: DynamicFieldOptionsSourceInterface = field?.optionsSource;
 
             if (source?.type !== DynamicFieldOptionsSourceTypes.CONNECTIONS) {
@@ -277,7 +290,10 @@ const useDynamicFieldOptions = (
             /*
              * Keep an already persisted value selectable even when it is not part of the resolved options.
              */
-            const persistedValue: string = context?.currentValues?.[ field?.name ];
+            const currentValue: unknown = field?.name
+                ? context?.currentValues?.[ field.name ]
+                : undefined;
+            const persistedValue: string = typeof currentValue === "string" ? currentValue : "";
 
             if (!isEmpty(persistedValue)
                 && !options.some((option: { value: string }) => option.value === persistedValue)) {

--- a/features/admin.connections.v1/hooks/use-dynamic-field-options.ts
+++ b/features/admin.connections.v1/hooks/use-dynamic-field-options.ts
@@ -52,6 +52,8 @@ interface DynamicFieldInterface {
     name?: string;
     placeholder?: string;
     readOnly?: boolean;
+    searchable?: boolean;
+    loading?: boolean;
     optionsSource?: DynamicFieldOptionsSourceInterface;
     [ key: string ]: unknown;
 }
@@ -267,17 +269,18 @@ const useDynamicFieldOptions = (
                 });
             }
 
-            const isUnusable: boolean = isLoading || isEmpty(options);
-
             return {
                 ...field,
+                loading: isLoading,
                 options,
                 placeholder: isLoading
                     ? t("authenticationProvider:forms.authenticatorSettings.dynamicOptions.loading")
                     : (isEmpty(options)
                         ? t("authenticationProvider:forms.authenticatorSettings.dynamicOptions.empty")
                         : field?.placeholder),
-                readOnly: field?.readOnly || isUnusable
+                // Options that are resolved from another resource are always searchable.
+                readOnly: field?.readOnly || (!isLoading && isEmpty(options)),
+                searchable: true
             };
         });
     }, [ fields, connections, templateIdsByConnection, isLoading, context?.currentValues ]);

--- a/features/admin.connections.v1/hooks/use-dynamic-field-options.ts
+++ b/features/admin.connections.v1/hooks/use-dynamic-field-options.ts
@@ -1,0 +1,315 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import get from "lodash-es/get";
+import isEmpty from "lodash-es/isEmpty";
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { getConnectionDetails, useGetConnections } from "../api/connections";
+import {
+    ConnectionInterface,
+    ConnectionListResponseInterface,
+    StrictConnectionInterface
+} from "../models/connection";
+
+/**
+ * Supported option sources of a dynamic `select` field.
+ */
+enum DynamicFieldOptionsSourceTypes {
+    /**
+     * Options are the connections of the organization, optionally narrowed down by the
+     * authenticator they use and the template they were created from.
+     */
+    CONNECTIONS = "connections"
+}
+
+/**
+ * Declaration of where the options of a dynamic `select` field come from.
+ */
+interface DynamicFieldOptionsSourceInterface {
+    /**
+     * Type of the source. Only `connections` is supported at the moment.
+     */
+    type: DynamicFieldOptionsSourceTypes | string;
+    /**
+     * Only list connections having a federated authenticator with this id.
+     */
+    authenticatorId?: string;
+    /**
+     * Only list connections created from this connection template.
+     */
+    templateId?: string;
+    /**
+     * Exclude the connection that is currently being edited from the list.
+     */
+    excludeCurrent?: boolean;
+    /**
+     * Attribute of a connection persisted as the value of the field. Defaults to `id`.
+     */
+    valueField?: string;
+    /**
+     * Attribute of a connection displayed as the label of an option. Defaults to `name`.
+     */
+    labelField?: string;
+}
+
+/**
+ * Context of the form the fields are rendered in.
+ */
+interface DynamicFieldOptionsContextInterface {
+    /**
+     * Resource id of the connection being edited, if any.
+     */
+    currentConnectionId?: string;
+    /**
+     * Values the form was initialized with, keyed by field name.
+     */
+    currentValues?: Record<string, any>;
+}
+
+/**
+ * Return type of {@link useDynamicFieldOptions}.
+ */
+interface DynamicFieldOptionsResultInterface {
+    /**
+     * The given fields, with the options of every `optionsSource` backed field resolved.
+     */
+    fields: Record<string, any>[];
+    /**
+     * Whether the options are still being resolved.
+     */
+    isLoading: boolean;
+}
+
+/**
+ * Resolves the options of dynamic form fields that declare an `optionsSource`.
+ *
+ * The dynamic form renderer (`@wso2is/forms/legacy` `renderFormFields`) only understands a static
+ * `options` array, and a connector's `metadata.json` cannot know the connections of an organization.
+ * This hook bridges the two: it reads the declarative `optionsSource` of each field and returns a
+ * copy of the fields with a concrete `options` array attached, so a connector can offer a picker of
+ * existing connections without any connector specific code in the console.
+ *
+ * Fields without an `optionsSource` are returned untouched and no request is made.
+ *
+ * @param fields - Dynamic form field definitions, as read from the connector metadata.
+ * @param context - Context of the form the fields are rendered in.
+ *
+ * @returns The fields with resolved options and the resolution status.
+ */
+const useDynamicFieldOptions = (
+    fields: Record<string, any>[],
+    context?: DynamicFieldOptionsContextInterface
+): DynamicFieldOptionsResultInterface => {
+
+    const { t } = useTranslation();
+
+    const [ templateIdsByConnection, setTemplateIdsByConnection ] = useState<Record<string, string>>({});
+    const [ isResolvingTemplateIds, setIsResolvingTemplateIds ] = useState<boolean>(false);
+
+    /**
+     * Sources declared by the given fields. Empty for every form that does not use the feature.
+     */
+    const sources: DynamicFieldOptionsSourceInterface[] = useMemo(() => {
+        if (!Array.isArray(fields)) {
+            return [];
+        }
+
+        return fields
+            .map((field: Record<string, any>) => field?.optionsSource)
+            .filter((source: DynamicFieldOptionsSourceInterface) =>
+                source?.type === DynamicFieldOptionsSourceTypes.CONNECTIONS);
+    }, [ fields ]);
+
+    const shouldFetchConnections: boolean = sources.length > 0;
+
+    const {
+        data: connectionsResponse,
+        error: connectionsFetchRequestError
+    } = useGetConnections<ConnectionListResponseInterface>(
+        null,
+        null,
+        undefined,
+        "federatedAuthenticators",
+        shouldFetchConnections,
+        true
+    );
+
+    const isConnectionListLoading: boolean = shouldFetchConnections
+        && !connectionsFetchRequestError
+        && !connectionsResponse;
+
+    const connections: StrictConnectionInterface[] = useMemo(
+        () => connectionsResponse?.identityProviders ?? [],
+        [ connectionsResponse ]
+    );
+
+    /**
+     * Connections that satisfy every filter of a source that can be evaluated on the list response.
+     */
+    const getCandidates = (source: DynamicFieldOptionsSourceInterface): StrictConnectionInterface[] => {
+        return connections.filter((connection: StrictConnectionInterface) => {
+            if (source?.excludeCurrent && connection?.id === context?.currentConnectionId) {
+                return false;
+            }
+
+            if (!source?.authenticatorId) {
+                return true;
+            }
+
+            return connection?.federatedAuthenticators?.authenticators
+                ?.some((authenticator: { authenticatorId?: string }) =>
+                    authenticator?.authenticatorId === source.authenticatorId) ?? false;
+        });
+    };
+
+    /**
+     * Ids of the candidates whose template id has to be looked up, since the connections list
+     * response does not carry it.
+     */
+    const idsRequiringTemplateId: string[] = useMemo(() => {
+        const ids: Set<string> = new Set<string>();
+
+        sources
+            .filter((source: DynamicFieldOptionsSourceInterface) => !isEmpty(source?.templateId))
+            .forEach((source: DynamicFieldOptionsSourceInterface) => {
+                getCandidates(source).forEach((connection: StrictConnectionInterface) => ids.add(connection.id));
+            });
+
+        return Array.from(ids).sort();
+    }, [ sources, connections, context?.currentConnectionId ]);
+
+    const idsRequiringTemplateIdKey: string = idsRequiringTemplateId.join(",");
+
+    /**
+     * Resolves the template id of every candidate.
+     */
+    useEffect(() => {
+        if (isEmpty(idsRequiringTemplateId)) {
+            setTemplateIdsByConnection({});
+            setIsResolvingTemplateIds(false);
+
+            return;
+        }
+
+        let isActive: boolean = true;
+
+        setIsResolvingTemplateIds(true);
+
+        Promise.all(
+            idsRequiringTemplateId.map((id: string) =>
+                getConnectionDetails(id).catch(() => null)
+            )
+        ).then((responses: ConnectionInterface[]) => {
+            if (!isActive) {
+                return;
+            }
+
+            const resolved: Record<string, string> = {};
+
+            responses.forEach((connection: ConnectionInterface, index: number) => {
+                if (connection?.templateId) {
+                    resolved[ idsRequiringTemplateId[ index ] ] = connection.templateId;
+                }
+            });
+
+            setTemplateIdsByConnection(resolved);
+        }).finally(() => {
+            if (isActive) {
+                setIsResolvingTemplateIds(false);
+            }
+        });
+
+        return () => {
+            isActive = false;
+        };
+    }, [ idsRequiringTemplateIdKey ]);
+
+    const isLoading: boolean = isConnectionListLoading || isResolvingTemplateIds;
+
+    const resolvedFields: Record<string, any>[] = useMemo(() => {
+        if (!Array.isArray(fields)) {
+            return fields;
+        }
+
+        return fields.map((field: Record<string, any>) => {
+            const source: DynamicFieldOptionsSourceInterface = field?.optionsSource;
+
+            if (source?.type !== DynamicFieldOptionsSourceTypes.CONNECTIONS) {
+                return field;
+            }
+
+            const valueField: string = source?.valueField ?? "id";
+            const labelField: string = source?.labelField ?? "name";
+
+            const options: { text: string; value: string }[] = getCandidates(source)
+                .filter((connection: StrictConnectionInterface) => {
+                    if (isEmpty(source?.templateId)) {
+                        return true;
+                    }
+
+                    const resolvedTemplateId: string = templateIdsByConnection[ connection.id ];
+
+                    // Drop the connection when its template id could not be resolved.
+                    return resolvedTemplateId === source.templateId;
+                })
+                .map((connection: StrictConnectionInterface) => ({
+                    text: get(connection, labelField) ?? get(connection, "id"),
+                    value: get(connection, valueField)
+                }))
+                .filter((option: { text: string; value: string }) => !isEmpty(option.value));
+
+            /*
+             * Keep an already persisted value selectable even when it is not part of the resolved options.
+             */
+            const persistedValue: string = context?.currentValues?.[ field?.name ];
+
+            if (!isEmpty(persistedValue)
+                && !options.some((option: { value: string }) => option.value === persistedValue)) {
+                options.push({
+                    text: isLoading
+                        ? persistedValue
+                        : t("authenticationProvider:forms.authenticatorSettings.dynamicOptions.unavailable", {
+                            value: persistedValue
+                        }),
+                    value: persistedValue
+                });
+            }
+
+            const isUnusable: boolean = isLoading || isEmpty(options);
+
+            return {
+                ...field,
+                options,
+                placeholder: isLoading
+                    ? t("authenticationProvider:forms.authenticatorSettings.dynamicOptions.loading")
+                    : (isEmpty(options)
+                        ? t("authenticationProvider:forms.authenticatorSettings.dynamicOptions.empty")
+                        : field?.placeholder),
+                readOnly: field?.readOnly || isUnusable
+            };
+        });
+    }, [ fields, connections, templateIdsByConnection, isLoading, context?.currentValues ]);
+
+    return {
+        fields: resolvedFields,
+        isLoading
+    };
+};
+
+export default useDynamicFieldOptions;

--- a/modules/forms/src/components/adapters/searchable-select-field-adapter.tsx
+++ b/modules/forms/src/components/adapters/searchable-select-field-adapter.tsx
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Autocomplete, { AutocompleteRenderInputParams } from "@oxygen-ui/react/Autocomplete";
+import CircularProgress from "@oxygen-ui/react/CircularProgress";
+import FormHelperText from "@oxygen-ui/react/FormHelperText";
+import InputLabel from "@oxygen-ui/react/InputLabel";
+import TextField from "@oxygen-ui/react/TextField";
+import { IdentifiableComponentInterface } from "@wso2is/core/models";
+import React, {
+    FunctionComponent,
+    HTMLAttributes,
+    ReactElement,
+    ReactNode,
+    SyntheticEvent,
+    useMemo
+} from "react";
+import { FieldRenderProps } from "react-final-form";
+
+import "./select-field-adapter.scss";
+
+/**
+ * Interface for the items passed as options.
+ */
+interface DropDownItemInterface {
+    text: ReactNode;
+    value: string;
+}
+
+/**
+ * Props for the SearchableSelectFieldAdapter component.
+ */
+interface SearchableSelectFieldAdapterPropsInterface
+    extends FieldRenderProps<string, HTMLElement, string>, IdentifiableComponentInterface {
+    /**
+     * The label to display above the field.
+     */
+    label: string;
+    /**
+     * Options list for the field.
+     * @see DropDownItemInterface
+     */
+    options: DropDownItemInterface[];
+    /**
+     * Whether the field should take full width.
+     * Defaults to true.
+     */
+    fullWidth?: boolean;
+    /**
+     * Whether the options are still being resolved.
+     * Defaults to false.
+     */
+    loading?: boolean;
+}
+
+/**
+ * Resolves the searchable text of an option.
+ *
+ * @param option - Option to resolve the label of.
+ * @returns Label of the option.
+ */
+const getOptionText = (option: DropDownItemInterface): string =>
+    typeof option?.text === "string" ? option.text : option?.value ?? "";
+
+/**
+ * A single select field adapter with type ahead filtering for use with React Final Form.
+ * Unlike {@link AutocompleteFieldAdapter}, the form value stays the `value` of the selected
+ * option instead of the option itself, which makes it a drop in replacement for
+ * {@link SelectFieldAdapter} when the options have to be searchable.
+ *
+ * @param props - The component props.
+ * @returns The rendered searchable select field component.
+ */
+const SearchableSelectFieldAdapter: FunctionComponent<SearchableSelectFieldAdapterPropsInterface> = (
+    props: SearchableSelectFieldAdapterPropsInterface
+): ReactElement => {
+    const {
+        input,
+        label,
+        meta,
+        fullWidth = true,
+        placeholder,
+        helperText,
+        required,
+        options,
+        loading = false,
+        readOnly = false,
+        "data-componentid": componentId = "searchable-select-field-adapter"
+    } = props;
+
+    const isError: boolean = (meta.error || meta.submitError) && meta.touched;
+
+    /**
+     * Option matching the current form value. Derived on every render so that asynchronously
+     * resolved options and values are always reflected.
+     */
+    const selectedOption: DropDownItemInterface = useMemo(() => {
+        if (!input.value) {
+            return null;
+        }
+
+        return options?.find((option: DropDownItemInterface) => option.value === input.value) ?? null;
+    }, [ options, input.value ]);
+
+    return (
+        <div className="select-field-adapter" data-componentid={ componentId }>
+            <InputLabel htmlFor={ `${input.name}-input` } required={ required }>{ label }</InputLabel>
+            <Autocomplete
+                disablePortal
+                size="small"
+                fullWidth={ fullWidth }
+                disabled={ readOnly }
+                loading={ loading }
+                options={ options ?? [] }
+                value={ selectedOption }
+                getOptionLabel={ getOptionText }
+                isOptionEqualToValue={
+                    (option: DropDownItemInterface, value: DropDownItemInterface) =>
+                        option?.value === value?.value
+                }
+                onChange={ (_: SyntheticEvent, option: DropDownItemInterface) => {
+                    input.onChange(option?.value ?? "");
+                } }
+                onBlur={ input.onBlur }
+                onFocus={ input.onFocus }
+                renderOption={ (
+                    optionProps: HTMLAttributes<HTMLLIElement>,
+                    option: DropDownItemInterface
+                ) => (
+                    <li { ...optionProps } key={ option.value }>
+                        { option.text }
+                    </li>
+                ) }
+                renderInput={ (params: AutocompleteRenderInputParams) => (
+                    <TextField
+                        { ...params }
+                        id={ `${input.name}-input` }
+                        name={ input.name }
+                        margin="dense"
+                        placeholder={ placeholder }
+                        error={ isError }
+                        size="small"
+                        variant="outlined"
+                        fullWidth={ fullWidth }
+                        InputProps={ {
+                            ...params.InputProps,
+                            endAdornment: (
+                                <>
+                                    { loading && <CircularProgress color="inherit" size={ 16 } /> }
+                                    { params.InputProps?.endAdornment }
+                                </>
+                            )
+                        } }
+                    />
+                ) }
+                data-componentid={ `${componentId}-input` }
+            />
+            { isError && (
+                <FormHelperText data-componentid={ `${componentId}-error` } error>
+                    { meta.error || meta.submitError }
+                </FormHelperText>
+            ) }
+            { helperText && (
+                <FormHelperText data-componentid={ `${componentId}-helper-text` }>{ helperText }</FormHelperText>
+            ) }
+        </div>
+    );
+};
+
+export default SearchableSelectFieldAdapter;

--- a/modules/forms/src/components/index.ts
+++ b/modules/forms/src/components/index.ts
@@ -32,6 +32,7 @@ export { default as TextFieldAdapter } from "./adapters/text-field-adapter";
 export { default as __DEPRECATED__SelectFieldAdapter } from "./adapters/__DEPRECATED__select-field-adapter";
 export { default as SelectFieldAdapter } from "./adapters/select-field-adapter";
 export { default as AutocompleteFieldAdapter } from "./adapters/autocomplete-field-adapter";
+export { default as SearchableSelectFieldAdapter } from "./adapters/searchable-select-field-adapter";
 export { default as URLFieldAdapter } from "./adapters/url-field-adapter";
 export { default as CheckboxFieldAdapter } from "./adapters/checkbox-field-adapter";
 export { default as CheckboxGroupFieldAdapter } from "./adapters/checkbox-group-field-adapter";

--- a/modules/forms/src/legacy/dynamic-forms/components/dynamic-form-field.tsx
+++ b/modules/forms/src/legacy/dynamic-forms/components/dynamic-form-field.tsx
@@ -22,6 +22,7 @@ import React, { FC, cloneElement } from "react";
 import { FieldButton } from "./field-button";
 import { FieldCheckbox } from "./field-checkbox";
 import { FieldInput } from "./field-input";
+import { FieldSelect } from "./field-select";
 
 export type DynamicFieldProps = Partial<Omit<OuiTextFieldProps, "type" | "onChange" | "component">> & {
     /**
@@ -46,6 +47,7 @@ type DynamicFieldType = FC<DynamicFieldProps> & {
     Input: typeof FieldInput;
     Button: typeof FieldButton;
     CheckBox: typeof FieldCheckbox;
+    Select: typeof FieldSelect;
 }
 
 export const DynamicField: DynamicFieldType = (props: DynamicFieldProps) => {
@@ -85,3 +87,4 @@ export const DynamicField: DynamicFieldType = (props: DynamicFieldProps) => {
 DynamicField.Input = FieldInput;
 DynamicField.Button = FieldButton;
 DynamicField.CheckBox = FieldCheckbox;
+DynamicField.Select = FieldSelect;

--- a/modules/forms/src/legacy/dynamic-forms/components/field-select.tsx
+++ b/modules/forms/src/legacy/dynamic-forms/components/field-select.tsx
@@ -20,7 +20,7 @@ import FormGroup from "@oxygen-ui/react/FormGroup";
 import { IdentifiableComponentInterface, TestableComponentInterface } from "@wso2is/core/models";
 import { Hint } from "@wso2is/react-components";
 import { FieldState } from "final-form";
-import React, { ReactElement, ReactNode } from "react";
+import React, { FunctionComponent, ReactElement, ReactNode } from "react";
 import { FieldProps, FieldRenderProps, Field as FinalFormField } from "react-final-form";
 import SelectFieldAdapter from "../../../components/adapters/select-field-adapter";
 import { getValidation } from "../utils/validate";
@@ -28,7 +28,7 @@ import { getValidation } from "../utils/validate";
 /**
  * Option of a dynamic select field.
  */
-export interface DynamicFieldOptionInterface {
+interface DynamicFieldOptionInterface {
     /**
      * Text displayed for the option.
      */
@@ -39,7 +39,13 @@ export interface DynamicFieldOptionInterface {
     value: string;
 }
 
-export interface FieldSelectPropsInterface extends Omit<FieldProps<any, any, any>, "component">,
+/**
+ * Value a dynamic select field holds. Multiple selection is not supported.
+ */
+type DynamicSelectFieldValueType = string;
+
+interface FieldSelectPropsInterface
+    extends Omit<FieldProps<DynamicSelectFieldValueType, FieldRenderProps<DynamicSelectFieldValueType>>, "component">,
     IdentifiableComponentInterface, TestableComponentInterface {
 
     /**
@@ -63,9 +69,12 @@ export interface FieldSelectPropsInterface extends Omit<FieldProps<any, any, any
      */
     readOnly?: boolean;
     /**
-     * Validation of the field.
+     * Validation of the field. Resolves to the error message, or to `undefined` when the value is valid.
      */
-    validation?: (value: string | number | any, allValues: Record<string, unknown>) => any;
+    validation?: (
+        value: DynamicSelectFieldValueType,
+        allValues: Record<string, unknown>
+    ) => string | undefined | Promise<string | undefined>;
 }
 
 /**
@@ -73,7 +82,9 @@ export interface FieldSelectPropsInterface extends Omit<FieldProps<any, any, any
  *
  * @param props - Props injected to the component.
  */
-export const FieldSelect = (props: FieldSelectPropsInterface): ReactElement => {
+export const FieldSelect: FunctionComponent<FieldSelectPropsInterface> = (
+    props: FieldSelectPropsInterface
+): ReactElement => {
 
     const {
         hint,
@@ -93,12 +104,14 @@ export const FieldSelect = (props: FieldSelectPropsInterface): ReactElement => {
         <FormGroup>
             <FinalFormField
                 name={ name }
-                parse={ (value: any) => value }
+                parse={ (value: DynamicSelectFieldValueType) => value }
                 initialValue={ initialValue }
-                validate={ (value: any, allValues: Record<string, unknown>, meta: FieldState<any>) =>
-                    getValidation(value, allValues, meta, required, validation)
-                }
-                render={ ({ input, meta }: FieldRenderProps<any>) => (
+                validate={ (
+                    value: DynamicSelectFieldValueType,
+                    allValues: Record<string, unknown>,
+                    meta: FieldState<DynamicSelectFieldValueType>
+                ) => getValidation(value, allValues, meta, required, validation) }
+                render={ ({ input, meta }: FieldRenderProps<DynamicSelectFieldValueType>) => (
                     <SelectFieldAdapter
                         input={ input }
                         meta={ meta }

--- a/modules/forms/src/legacy/dynamic-forms/components/field-select.tsx
+++ b/modules/forms/src/legacy/dynamic-forms/components/field-select.tsx
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import FormGroup from "@oxygen-ui/react/FormGroup";
+import { IdentifiableComponentInterface, TestableComponentInterface } from "@wso2is/core/models";
+import { Hint } from "@wso2is/react-components";
+import { FieldState } from "final-form";
+import React, { ReactElement, ReactNode } from "react";
+import { FieldProps, FieldRenderProps, Field as FinalFormField } from "react-final-form";
+import SelectFieldAdapter from "../../../components/adapters/select-field-adapter";
+import { getValidation } from "../utils/validate";
+
+/**
+ * Option of a dynamic select field.
+ */
+export interface DynamicFieldOptionInterface {
+    /**
+     * Text displayed for the option.
+     */
+    text: ReactNode;
+    /**
+     * Value persisted when the option is selected.
+     */
+    value: string;
+}
+
+export interface FieldSelectPropsInterface extends Omit<FieldProps<any, any, any>, "component">,
+    IdentifiableComponentInterface, TestableComponentInterface {
+
+    /**
+     * Name of the select field.
+     */
+    name: string;
+    /**
+     * Options of the select field.
+     */
+    options?: DynamicFieldOptionInterface[];
+    /**
+     * Label of the select field.
+     */
+    label?: string;
+    /**
+     * Hint of the form field.
+     */
+    hint?: string | ReactElement;
+    /**
+     * Whether the field is read only.
+     */
+    readOnly?: boolean;
+    /**
+     * Validation of the field.
+     */
+    validation?: (value: string | number | any, allValues: Record<string, unknown>) => any;
+}
+
+/**
+ * Implementation of the Select Field component of the dynamic form.
+ *
+ * @param props - Props injected to the component.
+ */
+export const FieldSelect = (props: FieldSelectPropsInterface): ReactElement => {
+
+    const {
+        hint,
+        initialValue,
+        label,
+        name,
+        options,
+        placeholder,
+        readOnly,
+        required,
+        validation,
+        [ "data-componentid" ]: componentId,
+        [ "data-testid" ]: testId
+    } = props;
+
+    return (
+        <FormGroup>
+            <FinalFormField
+                name={ name }
+                parse={ (value: any) => value }
+                initialValue={ initialValue }
+                validate={ (value: any, allValues: Record<string, unknown>, meta: FieldState<any>) =>
+                    getValidation(value, allValues, meta, required, validation)
+                }
+                render={ ({ input, meta }: FieldRenderProps<any>) => (
+                    <SelectFieldAdapter
+                        input={ input }
+                        meta={ meta }
+                        label={ label }
+                        options={ options ?? [] }
+                        placeholder={ placeholder }
+                        required={ required }
+                        readOnly={ readOnly }
+                        data-componentid={ componentId ?? testId ?? `${ name }-select-field` }
+                    />
+                ) }
+            />
+            {
+                hint && (
+                    <Hint compact>
+                        { hint }
+                    </Hint>
+                )
+            }
+        </FormGroup>
+    );
+};

--- a/modules/forms/src/legacy/dynamic-forms/components/field-select.tsx
+++ b/modules/forms/src/legacy/dynamic-forms/components/field-select.tsx
@@ -17,7 +17,7 @@
  */
 
 import FormGroup from "@oxygen-ui/react/FormGroup";
-import { IdentifiableComponentInterface, TestableComponentInterface } from "@wso2is/core/models";
+import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import { Hint } from "@wso2is/react-components";
 import { FieldState } from "final-form";
 import React, { FunctionComponent, ReactElement, ReactNode } from "react";
@@ -29,48 +29,25 @@ import { getValidation } from "../utils/validate";
  * Option of a dynamic select field.
  */
 interface DynamicFieldOptionInterface {
-    /**
-     * Text displayed for the option.
-     */
+
     text: ReactNode;
-    /**
-     * Value persisted when the option is selected.
-     */
     value: string;
 }
 
 /**
- * Value a dynamic select field holds. Multiple selection is not supported.
+ * Value a dynamic select field holds.
  */
 type DynamicSelectFieldValueType = string;
 
 interface FieldSelectPropsInterface
     extends Omit<FieldProps<DynamicSelectFieldValueType, FieldRenderProps<DynamicSelectFieldValueType>>, "component">,
-    IdentifiableComponentInterface, TestableComponentInterface {
+    IdentifiableComponentInterface {
 
-    /**
-     * Name of the select field.
-     */
     name: string;
-    /**
-     * Options of the select field.
-     */
     options?: DynamicFieldOptionInterface[];
-    /**
-     * Label of the select field.
-     */
     label?: string;
-    /**
-     * Hint of the form field.
-     */
     hint?: string | ReactElement;
-    /**
-     * Whether the field is read only.
-     */
     readOnly?: boolean;
-    /**
-     * Validation of the field. Resolves to the error message, or to `undefined` when the value is valid.
-     */
     validation?: (
         value: DynamicSelectFieldValueType,
         allValues: Record<string, unknown>
@@ -79,8 +56,6 @@ interface FieldSelectPropsInterface
 
 /**
  * Implementation of the Select Field component of the dynamic form.
- *
- * @param props - Props injected to the component.
  */
 export const FieldSelect: FunctionComponent<FieldSelectPropsInterface> = (
     props: FieldSelectPropsInterface
@@ -96,8 +71,7 @@ export const FieldSelect: FunctionComponent<FieldSelectPropsInterface> = (
         readOnly,
         required,
         validation,
-        [ "data-componentid" ]: componentId,
-        [ "data-testid" ]: testId
+        [ "data-componentid" ]: componentId
     } = props;
 
     return (
@@ -120,7 +94,7 @@ export const FieldSelect: FunctionComponent<FieldSelectPropsInterface> = (
                         placeholder={ placeholder }
                         required={ required }
                         readOnly={ readOnly }
-                        data-componentid={ componentId ?? testId ?? `${ name }-select-field` }
+                        data-componentid={ componentId ?? `${ name }-select-field` }
                     />
                 ) }
             />

--- a/modules/forms/src/legacy/dynamic-forms/components/field-select.tsx
+++ b/modules/forms/src/legacy/dynamic-forms/components/field-select.tsx
@@ -22,6 +22,7 @@ import { Hint } from "@wso2is/react-components";
 import { FieldState } from "final-form";
 import React, { FunctionComponent, ReactElement, ReactNode } from "react";
 import { FieldProps, FieldRenderProps, Field as FinalFormField } from "react-final-form";
+import SearchableSelectFieldAdapter from "../../../components/adapters/searchable-select-field-adapter";
 import SelectFieldAdapter from "../../../components/adapters/select-field-adapter";
 import { getValidation } from "../utils/validate";
 
@@ -48,6 +49,8 @@ interface FieldSelectPropsInterface
     label?: string;
     hint?: string | ReactElement;
     readOnly?: boolean;
+    searchable?: boolean;
+    loading?: boolean;
     validation?: (
         value: DynamicSelectFieldValueType,
         allValues: Record<string, unknown>
@@ -65,11 +68,13 @@ export const FieldSelect: FunctionComponent<FieldSelectPropsInterface> = (
         hint,
         initialValue,
         label,
+        loading,
         name,
         options,
         placeholder,
         readOnly,
         required,
+        searchable,
         validation,
         [ "data-componentid" ]: componentId
     } = props;
@@ -86,16 +91,32 @@ export const FieldSelect: FunctionComponent<FieldSelectPropsInterface> = (
                     meta: FieldState<DynamicSelectFieldValueType>
                 ) => getValidation(value, allValues, meta, required, validation) }
                 render={ ({ input, meta }: FieldRenderProps<DynamicSelectFieldValueType>) => (
-                    <SelectFieldAdapter
-                        input={ input }
-                        meta={ meta }
-                        label={ label }
-                        options={ options ?? [] }
-                        placeholder={ placeholder }
-                        required={ required }
-                        readOnly={ readOnly }
-                        data-componentid={ componentId ?? `${ name }-select-field` }
-                    />
+                    searchable
+                        ? (
+                            <SearchableSelectFieldAdapter
+                                input={ input }
+                                meta={ meta }
+                                label={ label }
+                                options={ options ?? [] }
+                                placeholder={ placeholder }
+                                required={ required }
+                                readOnly={ readOnly }
+                                loading={ loading }
+                                data-componentid={ componentId ?? `${ name }-select-field` }
+                            />
+                        )
+                        : (
+                            <SelectFieldAdapter
+                                input={ input }
+                                meta={ meta }
+                                label={ label }
+                                options={ options ?? [] }
+                                placeholder={ placeholder }
+                                required={ required }
+                                readOnly={ readOnly }
+                                data-componentid={ componentId ?? `${ name }-select-field` }
+                            />
+                        )
                 ) }
             />
             {

--- a/modules/forms/src/legacy/dynamic-forms/components/index.ts
+++ b/modules/forms/src/legacy/dynamic-forms/components/index.ts
@@ -14,5 +14,6 @@ export type { DynamicFieldProps } from "./dynamic-form-field";
 export * from "./dynamic-wizard";
 export * from "./dynamic-wizard-page";
 export * from "./field-input";
+export * from "./field-select";
 export * from "./field";
 export * from "./utils";

--- a/modules/forms/src/legacy/dynamic-forms/components/utils.tsx
+++ b/modules/forms/src/legacy/dynamic-forms/components/utils.tsx
@@ -104,7 +104,6 @@ export const renderFormFields = (fields: Record<string, any>): ReactElement => {
                     />
                 );
             case "select":
-            case "dropdown":
                 return (
                     <DynamicField.Select
                         key={ fieldProps.name }

--- a/modules/forms/src/legacy/dynamic-forms/components/utils.tsx
+++ b/modules/forms/src/legacy/dynamic-forms/components/utils.tsx
@@ -103,6 +103,17 @@ export const renderFormFields = (fields: Record<string, any>): ReactElement => {
                         { ...omit(fieldProps, "type") }
                     />
                 );
+            case "select":
+            case "dropdown":
+                return (
+                    <DynamicField.Select
+                        key={ fieldProps.name }
+                        name={ fieldProps.name }
+                        label={ fieldProps.label }
+                        options={ fieldProps.options }
+                        { ...omit(fieldProps, [ "type", "options", "optionsSource" ]) }
+                    />
+                );
             default:
                 return (
                     <DynamicField.Input

--- a/modules/i18n/src/models/namespaces/authentication-provider-ns.ts
+++ b/modules/i18n/src/models/namespaces/authentication-provider-ns.ts
@@ -250,6 +250,7 @@ export interface AuthenticationProviderNS {
                 };
             };
             dynamicOptions: {
+                disabled: string;
                 empty: string;
                 loading: string;
                 unavailable: string;

--- a/modules/i18n/src/models/namespaces/authentication-provider-ns.ts
+++ b/modules/i18n/src/models/namespaces/authentication-provider-ns.ts
@@ -249,6 +249,11 @@ export interface AuthenticationProviderNS {
                     };
                 };
             };
+            dynamicOptions: {
+                empty: string;
+                loading: string;
+                unavailable: string;
+            };
             emailOTP: {
                 enableBackupCodes: {
                     hint: string;

--- a/modules/i18n/src/translations/en-US/portals/authentication-provider.ts
+++ b/modules/i18n/src/translations/en-US/portals/authentication-provider.ts
@@ -267,6 +267,11 @@ export const authenticationProvider:AuthenticationProviderNS = {
                     }
                 }
             },
+            dynamicOptions: {
+                empty: "No matching connections available.",
+                loading: "Loading available connections...",
+                unavailable: "{{value}} (unavailable)"
+            },
             emailOTP: {
                 enableBackupCodes: {
                     hint: "Allow users to authenticate with backup codes.",

--- a/modules/i18n/src/translations/en-US/portals/authentication-provider.ts
+++ b/modules/i18n/src/translations/en-US/portals/authentication-provider.ts
@@ -268,6 +268,7 @@ export const authenticationProvider:AuthenticationProviderNS = {
                 }
             },
             dynamicOptions: {
+                disabled: "{{value}} (disabled)",
                 empty: "No matching connections available.",
                 loading: "Loading available connections...",
                 unavailable: "{{value}} (unavailable)"


### PR DESCRIPTION
## Purpose

This pull request introduces support for dynamic `select`/`dropdown` fields in connection create and edit templates, allowing field options to be resolved from existing connections via declarative `optionsSource` metadata. The main implementation is a new `useDynamicFieldOptions` hook, which resolves options for dynamic fields based on current organization connections, and integrates this behavior into both the connection creation wizard and the authenticator settings forms. Additionally, the dynamic form system is extended to support rendering `select` fields.

## Related Issues
- https://github.com/wso2/product-is/issues/28365

## Approach
**Dynamic field options support**

* Added the `useDynamicFieldOptions` hook to resolve dynamic field options for `select` fields from existing connections, supporting filtering by authenticator, template, and exclusion of the current connection.
* Integrated `useDynamicFieldOptions` into the connection creation wizard (`add-connection-wizard.tsx`) and authenticator settings forms (`authenticator-settings-form.tsx`), so that forms can now render dynamic dropdowns whose options are sourced from other connections. 

**Propagation of context for option resolution**

* Plumbed the `connectionId` prop through the authenticator settings and form factory components, ensuring the dynamic options logic can exclude the current connection when necessary. 

**Dynamic form enhancements**

* Extended the legacy dynamic form system to support `select` fields by adding a `FieldSelect` component and registering it in `DynamicField`. 