### PR TITLE
Use passive listener for link editor scrolling

### DIFF
--- a/.changeset/passive-link-editor-scroll.md
+++ b/.changeset/passive-link-editor-scroll.md
@@ -1,5 +1,6 @@
 ---
 "@wso2is/admin.flow-builder-core.v1": patch
+"@wso2is/console": patch
 ---
 
 Use a passive scroll listener for rich text link editor positioning.

--- a/.changeset/passive-link-editor-scroll.md
+++ b/.changeset/passive-link-editor-scroll.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.flow-builder-core.v1": patch
+---
+
+Use a passive scroll listener for rich text link editor positioning.

--- a/features/admin.flow-builder-core.v1/components/resource-property-panel/rich-text/helper-plugins/link-plugin.tsx
+++ b/features/admin.flow-builder-core.v1/components/resource-property-panel/rich-text/helper-plugins/link-plugin.tsx
@@ -325,6 +325,9 @@ const LinkEditor = (): ReactElement => {
      */
     useEffect(() => {
         const scrollerElem: HTMLElement = document.body;
+        const scrollListenerOptions: AddEventListenerOptions = {
+            passive: true
+        };
 
         const update = (): void => {
             editor.getEditorState().read(() => {
@@ -333,11 +336,11 @@ const LinkEditor = (): ReactElement => {
         };
 
         window.addEventListener("resize", update);
-        scrollerElem.addEventListener("scroll", update);
+        scrollerElem.addEventListener("scroll", update, scrollListenerOptions);
 
         return () => {
             window.removeEventListener("resize", update);
-            scrollerElem.removeEventListener("scroll", update);
+            scrollerElem.removeEventListener("scroll", update, scrollListenerOptions);
         };
     }, [ editor, updateLinkEditor ]);
 


### PR DESCRIPTION
### Purpose
Fix the React Doctor `client-passive-event-listeners` finding for the rich text link editor scroll listener.

Root cause: `features/admin.flow-builder-core.v1/components/resource-property-panel/rich-text/helper-plugins/link-plugin.tsx` registered the body `scroll` listener without `{ passive: true }`:

```ts
scrollerElem.addEventListener(scroll, update);
```

The `update` callback only reads the Lexical editor state and repositions the floating link editor. It does not accept the scroll event, does not call `preventDefault()`, and does not need to block scrolling, so passive mode is safe.

This PR adds a typed `AddEventListenerOptions` constant with `passive: true` and uses it for both `addEventListener` and `removeEventListener`. Cleanup remains correct because listener removal matches by event type, callback, and capture value; using the same options object keeps the intent clear. The resize listener is unchanged.

Patch changesets are included for `@wso2is/admin.flow-builder-core.v1` and `@wso2is/console` per the repository changeset policy for `features` changes.

### Related Issues
- Fixes wso2/product-is#27880

### Related PRs
- N/A

### Verification
- `pnpm dlx pnpm@10.33.0 --version` - Passed, confirmed `10.33.0`.
- `pnpm dlx pnpm@10.33.0 install` - Passed.
- `pnpm dlx pnpm@10.33.0 run build:modules` - Passed.
- `.\node_modules\.bin\eslint.cmd features/admin.flow-builder-core.v1/components/resource-property-panel/rich-text/helper-plugins/link-plugin.tsx` - Passed.
- `git diff --check` - Passed.
- Static red/green check:
  - `origin/master` exact non-passive listener count: `1`.
  - Working tree exact non-passive listener count: `0`.
  - Working tree passive listener count: `1`.
- Confirmed `update` does not accept the scroll event and does not call `preventDefault()`. Existing `preventDefault()` calls in the file are unrelated keyboard/click handlers.
- CodeRabbit changeset policy finding was addressed with a normal follow-up commit adding the `@wso2is/console` changeset entry.

### Checks not completed locally
- Unit test not added: this package does not expose an obvious focused test seam for this Lexical plugin, and adding a browser/Lexical test harness for a listener option change would be disproportionate.
- React Doctor local red/green is **UNPROVEN**: the repository exposes React Doctor through `.github/workflows/react-doctor.yml`, but no supported local command/script was found.
- `..\..\node_modules\.bin\tsc.cmd --noEmit --project tsconfig.json --pretty false` from `features/admin.flow-builder-core.v1` was attempted after dependency install and shared module build, but it fails on existing workspace package/type resolution errors such as `Cannot find module '@wso2is/react-components'` and `Cannot find module '@wso2is/forms/legacy'` outside this change.
- `.\node_modules\.bin\rollup.cmd --config rollup.config.cjs` from `features/admin.flow-builder-core.v1` was attempted after dependency install and shared module build. It emitted the first bundle but failed while bundling declarations on existing generated declaration/style resolution, e.g. `Could not resolve ./visual-flow.scss from dist/esm/types/components/visual-flow/visual-flow.d.ts`.

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.