### PR TITLE
Remove heading semantics from branding preview placeholder

### DIFF
--- a/.changeset/quiet-pans-grab.md
+++ b/.changeset/quiet-pans-grab.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.branding.v1": patch
+---
+
+Remove heading semantics from the decorative branding preview placeholder.

--- a/.changeset/quiet-pans-grab.md
+++ b/.changeset/quiet-pans-grab.md
@@ -1,5 +1,6 @@
 ---
 "@wso2is/admin.branding.v1": patch
+"@wso2is/console": patch
 ---
 
 Remove heading semantics from the decorative branding preview placeholder.

--- a/features/admin.branding.v1/components/preview/sign-in-box/fragments/__tests__/common-fragment.test.tsx
+++ b/features/admin.branding.v1/components/preview/sign-in-box/fragments/__tests__/common-fragment.test.tsx
@@ -16,14 +16,19 @@
  * under the License.
  */
 
-import { render, screen } from "@testing-library/react";
+import { render, screen } from "@wso2is/unit-testing/utils";
 import React from "react";
 import "@testing-library/jest-dom";
 import CommonFragment from "../common-fragment";
 
 describe("CommonFragment", (): void => {
     it("renders the decorative header placeholder without heading semantics", (): void => {
-        const { container }: { container: HTMLElement } = render(<CommonFragment />);
+        const { container }: { container: HTMLElement } = render(
+            <CommonFragment data-componentid="branding-preview-common-fragment" />,
+            {
+                featureConfig: {}
+            }
+        );
         const headerPlaceholder: Element | null = container.querySelector(".ui.header");
         const commonFragment: Element | null = container.querySelector(
             "[data-componentid='branding-preview-common-fragment']"

--- a/features/admin.branding.v1/components/preview/sign-in-box/fragments/__tests__/common-fragment.test.tsx
+++ b/features/admin.branding.v1/components/preview/sign-in-box/fragments/__tests__/common-fragment.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import "@testing-library/jest-dom";
+import CommonFragment from "../common-fragment";
+
+describe("CommonFragment", (): void => {
+    it("renders the decorative header placeholder without heading semantics", (): void => {
+        const { container }: { container: HTMLElement } = render(<CommonFragment />);
+        const headerPlaceholder: Element | null = container.querySelector(".ui.header");
+        const commonFragment: Element | null = container.querySelector(
+            "[data-componentid='branding-preview-common-fragment']"
+        );
+
+        expect(screen.queryByRole("heading", { level: 3 })).not.toBeInTheDocument();
+        expect(headerPlaceholder).toBeInTheDocument();
+        expect(headerPlaceholder?.tagName.toLowerCase()).toBe("div");
+        expect(commonFragment).toBeInTheDocument();
+    });
+});

--- a/features/admin.branding.v1/components/preview/sign-in-box/fragments/common-fragment.tsx
+++ b/features/admin.branding.v1/components/preview/sign-in-box/fragments/common-fragment.tsx
@@ -38,7 +38,7 @@ const CommonFragment: FunctionComponent<CommonFragmentInterface> = (
 
     return (
         <div data-componentid={ componentId }>
-            <h3 className="ui header"></h3>
+            <div className="ui header"></div>
 
             <div className="segment-form">
                 <div className="ui large form">


### PR DESCRIPTION
﻿## Purpose
This PR removes the semantic heading element from the decorative common placeholder used in the branding preview sign-in box.

The placeholder did not contain text and does not represent a real document heading. Replacing the empty `h3` with a `div` preserves the existing `ui header` styling hook while avoiding an inaccessible empty heading. I did not add an `aria-label`, because there is no actual heading text to announce; concrete preview screens such as the basic-auth fragment render their own localized headings.

## Related Issues/PRs
- Fixes wso2/product-is#27884

## Implementation Notes
- Root cause: `CommonFragment` rendered an empty `h3` as a visual placeholder, creating a heading with no accessible text.
- Semantic decision: this element is a decorative/skeleton placeholder, not a meaningful heading.
- Visual behavior: the `ui header` class is retained on a non-heading element to preserve styling.
- Regression coverage: added a focused component test that asserts no level-3 heading is exposed and that the placeholder remains rendered as a `div`.
- Changeset: added a patch changeset for `@wso2is/admin.branding.v1`.

## Verification
- `pnpm install --frozen-lockfile` - passed using local pnpm `11.16.0` and Node `v24.14.0`; the repository requires pnpm `>=10` and Node `>=20`, while CI pins pnpm `10.33.0`.
- Red/green focused test - proven. With the old `h3`, the new test failed because a level-3 heading was present; after the fix, it passed.
- `./node_modules/.bin/vitest.CMD run features/admin.branding.v1/components/preview/sign-in-box/fragments/__tests__/common-fragment.test.tsx --environment jsdom --globals` - passed, 1 test.
- `./node_modules/.bin/eslint.CMD features/admin.branding.v1/components/preview/sign-in-box/fragments/common-fragment.tsx features/admin.branding.v1/components/preview/sign-in-box/fragments/__tests__/common-fragment.test.tsx` - passed.
- `nx show project @wso2is/admin.branding.v1 --json` - passed; the package exposes no focused Nx build/typecheck targets.
- `nx run-many --target=build --projects=access-control,dynamic-forms,core,forms,form,i18n,react-components,theme,validation` - passed for the shared module prerequisites available in the repo graph.
- `git diff --check` - passed.
- `git diff --cached --check` - passed.
- `git status --short` - clean after commit.

## Checks Not Proven Locally
- React Doctor local red/green is UNPROVEN. I found only `.github/workflows/react-doctor.yml`, which uses the `millionco/react-doctor@v2` GitHub Action; no supported local command is exposed by the repository.
- Running the shared feature Vitest config was blocked before test collection by an unresolved `msw` import from `modules/unit-testing/__mocks__/server/server.ts` in this local dependency layout. The focused component test was therefore run directly with jsdom.
- Standalone package typecheck/build attempts were blocked by existing workspace resolution issues unrelated to this fragment: `tsc --noEmit -p features/admin.branding.v1/tsconfig.json` reported unresolved workspace package imports, and the package Rollup build failed resolving an existing cross-feature import from `components/branding-page-layout.tsx`.
