### PR TITLE
Fix unhandled IllegalArgumentException on blank username in recovery portal

### DIFF
--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/username-resolver.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/username-resolver.jsp
@@ -27,11 +27,13 @@
 <%
     String username = Encode.forJava(request.getParameter("username"));
     String userTenantHint = (Encode.forJava(request.getParameter("t")) != "null") ? Encode.forJava(request.getParameter("t")) : null;
-    if (StringUtils.isNotBlank(userTenantHint)) {
-        username = MultitenantUtils.getTenantAwareUsername(username);
-        username = UserCoreUtil.addTenantDomainToEntry(username, userTenantHint);
-    } else {
-        username = UserCoreUtil.addTenantDomainToEntry(username, userTenant);
+    if (StringUtils.isNotBlank(username)) {
+        if (StringUtils.isNotBlank(userTenantHint)) {
+            username = MultitenantUtils.getTenantAwareUsername(username);
+            username = UserCoreUtil.addTenantDomainToEntry(username, userTenantHint);
+        } else {
+            username = UserCoreUtil.addTenantDomainToEntry(username, userTenant);
+        }
     }
     request.setAttribute("resolvedUsername", username);
 %>


### PR DESCRIPTION
## Issue

A `POST` to `/accountrecoveryendpoint/verify.do` carrying an empty `username` parameter
(`username=`) throws an unhandled `IllegalArgumentException` and logs multiple ERROR lines per
request.

`username-resolver.jsp` passes the username straight to `UserCoreUtil.addTenantDomainToEntry()`,
which throws a message-less `IllegalArgumentException` when the entry is empty. Neither the
tenant-hint branch nor the default branch checks the username first. The endpoint is
unauthenticated, so any client can trigger it.

## Fix

Guard on `username` above the branch, so both paths are covered.

The resolved value is only consumed by `recovery.jsp`, which already guards with
`StringUtils.isNotBlank(username)` before reading `resolvedUsername` — so the resolver was failing
while computing a value that would have been discarded. The guard mirrors that existing check; for a
non-blank username the path is unchanged.

## Testing

Verified against a local IS 7.4.0 pack: `username=` returns 500 with 2 ERROR lines before the change
and 200 with none after. Valid, absent, and whitespace-only usernames are unaffected.