### PR TITLE
Fix connector deletion connected application list consistency

### DIFF
--- a/.changeset/fix-connector-deletion-connected-application-list.md
+++ b/.changeset/fix-connector-deletion-connected-application-list.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.connections.v1": patch
+---
+
+Display connected applications as a numbered list in connector deletion confirmation dialogs.

--- a/features/admin.connections.v1/components/__tests__/connected-applications-list.test.tsx
+++ b/features/admin.connections.v1/components/__tests__/connected-applications-list.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import ConnectedApplicationsList from "../connected-applications-list";
+
+afterEach(cleanup);
+
+describe("Connected applications list", () => {
+    it("renders the loader while connected applications are loading", () => {
+        render(<ConnectedApplicationsList applications={ [] } isLoading={ true } />);
+
+        expect(screen.getByTestId("content-loader")).toBeDefined();
+        expect(screen.queryAllByRole("listitem")).toHaveLength(0);
+    });
+
+    it("renders an ordered empty list when there are no connected applications", () => {
+        render(<ConnectedApplicationsList applications={ [] } isLoading={ false } />);
+
+        expect(screen.getByRole("list").classList.contains("ordered")).toBe(true);
+        expect(screen.queryAllByRole("listitem")).toHaveLength(0);
+    });
+
+    it("renders one connected application as an ordered list item", () => {
+        render(<ConnectedApplicationsList
+            applications={ [ "Sales Portal" ] }
+            isLoading={ false }
+        />);
+
+        expect(screen.getByRole("list").classList.contains("ordered")).toBe(true);
+        expect(screen.getAllByRole("listitem")).toHaveLength(1);
+        expect(screen.getByRole("listitem").textContent).toBe("Sales Portal");
+    });
+
+    it("renders multiple connected applications as ordered list items", () => {
+        render(<ConnectedApplicationsList
+            applications={ [ "Sales Portal", "Support Portal", "Partner Portal" ] }
+            isLoading={ false }
+        />);
+
+        expect(screen.getByRole("list").classList.contains("ordered")).toBe(true);
+        expect(screen.getAllByRole("listitem")).toHaveLength(3);
+        expect(screen.getAllByRole("listitem").map((item: HTMLElement) => item.textContent)).toEqual([
+            "Sales Portal", "Support Portal", "Partner Portal"
+        ]);
+    });
+});

--- a/features/admin.connections.v1/components/__tests__/connected-applications-list.test.tsx
+++ b/features/admin.connections.v1/components/__tests__/connected-applications-list.test.tsx
@@ -16,35 +16,47 @@
  * under the License.
  */
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@wso2is/unit-testing/utils";
 import React from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import ConnectedApplicationsList from "../connected-applications-list";
+
+const COMPONENT_ID: string = "connected-applications-list";
 
 afterEach(cleanup);
 
 describe("Connected applications list", () => {
     it("renders the loader while connected applications are loading", () => {
-        render(<ConnectedApplicationsList applications={ [] } isLoading={ true } />);
+        render(<ConnectedApplicationsList
+            applications={ [] }
+            data-componentid={ COMPONENT_ID }
+            isLoading={ true }
+        />);
 
-        expect(screen.getByTestId("content-loader")).toBeDefined();
+        expect(screen.getByTestId(`${ COMPONENT_ID }-loader`)).toBeDefined();
         expect(screen.queryAllByRole("listitem")).toHaveLength(0);
     });
 
     it("renders an ordered empty list when there are no connected applications", () => {
-        render(<ConnectedApplicationsList applications={ [] } isLoading={ false } />);
+        render(<ConnectedApplicationsList
+            applications={ [] }
+            data-componentid={ COMPONENT_ID }
+            isLoading={ false }
+        />);
 
-        expect(screen.getByRole("list").classList.contains("ordered")).toBe(true);
+        expect(screen.getByTestId(COMPONENT_ID)).toBeDefined();
+        expect(screen.getByRole("list")).toBeDefined();
         expect(screen.queryAllByRole("listitem")).toHaveLength(0);
     });
 
     it("renders one connected application as an ordered list item", () => {
         render(<ConnectedApplicationsList
             applications={ [ "Sales Portal" ] }
+            data-componentid={ COMPONENT_ID }
             isLoading={ false }
         />);
 
-        expect(screen.getByRole("list").classList.contains("ordered")).toBe(true);
+        expect(screen.getByRole("list")).toBeDefined();
         expect(screen.getAllByRole("listitem")).toHaveLength(1);
         expect(screen.getByRole("listitem").textContent).toBe("Sales Portal");
     });
@@ -52,10 +64,11 @@ describe("Connected applications list", () => {
     it("renders multiple connected applications as ordered list items", () => {
         render(<ConnectedApplicationsList
             applications={ [ "Sales Portal", "Support Portal", "Partner Portal" ] }
+            data-componentid={ COMPONENT_ID }
             isLoading={ false }
         />);
 
-        expect(screen.getByRole("list").classList.contains("ordered")).toBe(true);
+        expect(screen.getByRole("list")).toBeDefined();
         expect(screen.getAllByRole("listitem")).toHaveLength(3);
         expect(screen.getAllByRole("listitem").map((item: HTMLElement) => item.textContent)).toEqual([
             "Sales Portal", "Support Portal", "Partner Portal"

--- a/features/admin.connections.v1/components/authenticator-grid.tsx
+++ b/features/admin.connections.v1/components/authenticator-grid.tsx
@@ -17,8 +17,6 @@
  */
 
 import Divider from "@oxygen-ui/react/Divider";
-import List from "@oxygen-ui/react/List";
-import ListItem from "@oxygen-ui/react/ListItem";
 import { useRequiredScopes } from "@wso2is/access-control";
 import { getApplicationDetails } from "@wso2is/admin.applications.v1/api/application";
 import {
@@ -41,7 +39,6 @@ import { AlertLevels, LoadableComponentInterface, TestableComponentInterface,
 import { addAlert } from "@wso2is/core/store";
 import {
     ConfirmationModal,
-    ContentLoader,
     EmptyPlaceholder,
     LinkButton,
     PrimaryButton,
@@ -84,6 +81,7 @@ import {
     ConnectionTypes
 } from "../models/connection";
 import { ConnectionsManagementUtils, handleConnectionDeleteError } from "../utils/connection-utils";
+import ConnectedApplicationsList from "./connected-applications-list";
 
 /**
  * Proptypes for the Authenticators Grid component.
@@ -721,18 +719,10 @@ export const AuthenticatorGrid: FunctionComponent<AuthenticatorGridPropsInterfac
                             { t("authenticationProvider:confirmations." +
                                 "deleteIDPWithConnectedApps.content") }
                             <Divider hidden />
-                            <List className="ml-6">
-                                {
-                                    isConnectedAppsLoading ? (
-                                        <ContentLoader/>
-                                    ) :
-                                        connectedApps?.map((app: string, index: number) => {
-                                            return (
-                                                <ListItem key={ index }>{ app }</ListItem>
-                                            );
-                                        })
-                                }
-                            </List>
+                            <ConnectedApplicationsList
+                                applications={ connectedApps }
+                                isLoading={ isConnectedAppsLoading }
+                            />
                         </ConfirmationModal.Content>
                     </ConfirmationModal>
                 )

--- a/features/admin.connections.v1/components/connected-applications-list.tsx
+++ b/features/admin.connections.v1/components/connected-applications-list.tsx
@@ -16,11 +16,12 @@
  * under the License.
  */
 
+import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import { ContentLoader } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement } from "react";
 import { List } from "semantic-ui-react";
 
-interface ConnectedApplicationsListPropsInterface {
+interface ConnectedApplicationsListPropsInterface extends IdentifiableComponentInterface {
     applications?: string[];
     isLoading: boolean;
 }
@@ -37,14 +38,15 @@ const ConnectedApplicationsList: FunctionComponent<ConnectedApplicationsListProp
 
     const {
         applications,
-        isLoading
+        isLoading,
+        [ "data-componentid" ]: componentId = "connected-applications-list"
     } = props;
 
     return (
-        <List ordered className="ml-6">
+        <List ordered className="ml-6" data-componentid={ componentId }>
             {
                 isLoading ? (
-                    <ContentLoader />
+                    <ContentLoader data-componentid={ `${ componentId }-loader` } />
                 ) : applications?.map((application: string, index: number) => (
                     <List.Item key={ index }>{ application }</List.Item>
                 ))

--- a/features/admin.connections.v1/components/connected-applications-list.tsx
+++ b/features/admin.connections.v1/components/connected-applications-list.tsx
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ContentLoader } from "@wso2is/react-components";
+import React, { FunctionComponent, ReactElement } from "react";
+import { List } from "semantic-ui-react";
+
+interface ConnectedApplicationsListPropsInterface {
+    applications?: string[];
+    isLoading: boolean;
+}
+
+/**
+ * Renders the applications connected to a connector deletion target.
+ *
+ * @param props - Props injected to the component.
+ * @returns Connected applications list.
+ */
+const ConnectedApplicationsList: FunctionComponent<ConnectedApplicationsListPropsInterface> = (
+    props: ConnectedApplicationsListPropsInterface
+): ReactElement => {
+
+    const {
+        applications,
+        isLoading
+    } = props;
+
+    return (
+        <List ordered className="ml-6">
+            {
+                isLoading ? (
+                    <ContentLoader />
+                ) : applications?.map((application: string, index: number) => (
+                    <List.Item key={ index }>{ application }</List.Item>
+                ))
+            }
+        </List>
+    );
+};
+
+export default ConnectedApplicationsList;

--- a/features/admin.connections.v1/components/edit/settings/general-settings.tsx
+++ b/features/admin.connections.v1/components/edit/settings/general-settings.tsx
@@ -26,13 +26,13 @@ import { AlertLevels, TestableComponentInterface,
     HttpErrorResponseDataInterface
 } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { ConfirmationModal, ContentLoader, DangerZone, DangerZoneGroup } from "@wso2is/react-components";
+import { ConfirmationModal, DangerZone, DangerZoneGroup } from "@wso2is/react-components";
 import { AxiosError } from "axios";
 import React, { FormEvent, FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Dispatch } from "redux";
-import { CheckboxProps, Divider, List } from "semantic-ui-react";
+import { CheckboxProps, Divider } from "semantic-ui-react";
 import {
     deleteConnection,
     deleteCustomAuthenticator,
@@ -50,6 +50,7 @@ import {
     handleConnectionUpdateError,
     handleGetConnectionListCallError
 } from "../../../utils/connection-utils";
+import ConnectedApplicationsList from "../../connected-applications-list";
 import { GeneralDetailsForm } from "../forms";
 import { CustomAuthenticatorGeneralDetailsForm } from "../forms/custom-authenticator-general-details-form";
 
@@ -607,15 +608,10 @@ export const GeneralSettings: FunctionComponent<GeneralSettingsInterface> = (
                     <ConfirmationModal.Content data-testid={ `${testId}-delete-idp-confirmation` }>
                         { t("authenticationProvider:confirmations.deleteIDPWithConnectedApps.content") }
                         <Divider hidden />
-                        <List ordered className="ml-6">
-                            { isAppsLoading ? (
-                                <ContentLoader />
-                            ) : (
-                                connectedApps?.map((app: string, index: number) => (
-                                    <List.Item key={ index }>{ app }</List.Item>
-                                ))
-                            ) }
-                        </List>
+                        <ConnectedApplicationsList
+                            applications={ connectedApps }
+                            isLoading={ isAppsLoading }
+                        />
                     </ConfirmationModal.Content>
                 </ConfirmationModal>
             ) }


### PR DESCRIPTION
### Purpose

Make connector-deletion dialogs display connected applications consistently as a numbered list. Both entry points now use the established Semantic UI `List ordered` presentation while preserving their existing deletion behavior.

### Related Issues

- Fixes wso2/product-is#22945

### Related PRs

- N/A

### Verification

- Added focused regression coverage for loading, zero, one, and multiple connected applications.
- `corepack pnpm exec eslint ...`: passed with 0 errors; 14 existing warnings remain in legacy parent files.
- `corepack pnpm typecheck`: passed for the repository's configured type-check projects.
- `corepack pnpm build:modules`: passed.
- `corepack pnpm exec rollup --config rollup.config.cjs` in `features/admin.connections.v1`: passed with existing non-fatal workspace warnings.
- `git diff --check`: passed.
- The normal Vitest command discovers the new test but is blocked before collection by the repository's pre-existing undeclared `msw` dependency. The same failure was reproduced from a fresh locked `origin/master` checkout, so the full suite is not claimed as passed.

### Checklist

- [x] Unit tests provided.
- [x] Confirmed that this PR does not commit secrets.

## Developer Checklist (Mandatory)

- [ ] Complete the Developer Checklist in the related `product-is` issue to track any behavioral change or migration impact.