### PR TITLE
Fix tenant switcher search pagination

### DIFF
--- a/.changeset/fix-tenant-switcher-search.md
+++ b/.changeset/fix-tenant-switcher-search.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.tenants.v1": patch
+"@wso2is/console": patch
+---
+
+Load additional associated tenant pages when a tenant-switcher search has no match in the initial page.

--- a/features/admin.tenants.v1/components/dropdown/tenant-dropdown.tsx
+++ b/features/admin.tenants.v1/components/dropdown/tenant-dropdown.tsx
@@ -48,6 +48,7 @@ import { isFeatureEnabled } from "@wso2is/core/helpers";
 import {
     AlertInterface,
     AlertLevels,
+    HttpErrorResponseDataInterface,
     TestableComponentInterface
 } from "@wso2is/core/models";
 import { addAlert, setTenants } from "@wso2is/core/store";
@@ -219,6 +220,8 @@ const TenantDropdown: FunctionComponent<TenantDropdownInterface> = (props: Tenan
 
     const isAssociatedTenantsRequestInFlight: React.MutableRefObject<boolean> = useRef<boolean>(false);
     const lastAutomaticTenantSearchRequest: React.MutableRefObject<string> = useRef<string>(undefined);
+    const automaticTenantSearchRetryCounts: React.MutableRefObject<Record<string, number>> =
+        useRef<Record<string, number>>({});
 
     const { organizationType } = useGetCurrentOrganizationType();
 
@@ -228,7 +231,7 @@ const TenantDropdown: FunctionComponent<TenantDropdownInterface> = (props: Tenan
 
     const associatedTenantsLimit: number = 15;
 
-    useEffect(() => {
+    useEffect((): void => {
         setAssociatedTenantsOffset(0);
         if (!isPrivilegedUser && saasFeatureStatus !== FeatureStatus.DISABLED) {
             isAssociatedTenantsRequestInFlight.current = true;
@@ -329,8 +332,9 @@ const TenantDropdown: FunctionComponent<TenantDropdownInterface> = (props: Tenan
         setTenantAssociations(association);
     }, [ associatedTenants, currentTenant, defaultTenant, tenantSearchQuery ]);
 
-    useEffect(() => {
+    useEffect((): void => {
         lastAutomaticTenantSearchRequest.current = undefined;
+        automaticTenantSearchRetryCounts.current = {};
     }, [ tenantSearchQuery ]);
 
     const {
@@ -468,7 +472,15 @@ const TenantDropdown: FunctionComponent<TenantDropdownInterface> = (props: Tenan
                         response.associatedTenants.length)
                 );
             })
-            .catch((error: any) => {
+            .catch((error: HttpErrorResponseDataInterface) => {
+                const requestKey: string = `${ tenantSearchQuery }:${ associatedTenantsOffset }`;
+
+                if (lastAutomaticTenantSearchRequest.current === requestKey) {
+                    automaticTenantSearchRetryCounts.current[ requestKey ] =
+                        (automaticTenantSearchRetryCounts.current[ requestKey ] ?? 0) + 1;
+                    lastAutomaticTenantSearchRequest.current = undefined;
+                }
+
                 dispatch(
                     addAlert({
                         description:
@@ -488,13 +500,14 @@ const TenantDropdown: FunctionComponent<TenantDropdownInterface> = (props: Tenan
     }, [ associatedTenants, associatedTenantsOffset, currentTenant, defaultTenant, hasMoreAssociatedTenants,
         isPrivilegedUser, saasFeatureStatus, tenantDomain ]);
 
-    useEffect(() => {
+    useEffect((): void => {
+        const requestKey: string = `${ tenantSearchQuery }:${ associatedTenantsOffset }`;
+        const retryCount: number = automaticTenantSearchRetryCounts.current[ requestKey ] ?? 0;
+
         if (!shouldLoadMoreForTenantSearch(tenantSearchQuery, tempTenantAssociationsList ?? [],
-            hasMoreAssociatedTenants, isAssociatedTenantsLoading)) {
+            hasMoreAssociatedTenants, isAssociatedTenantsLoading, retryCount)) {
             return;
         }
-
-        const requestKey: string = `${ tenantSearchQuery }:${ associatedTenantsOffset }`;
 
         if (lastAutomaticTenantSearchRequest.current === requestKey) {
             return;

--- a/features/admin.tenants.v1/components/dropdown/tenant-dropdown.tsx
+++ b/features/admin.tenants.v1/components/dropdown/tenant-dropdown.tsx
@@ -58,7 +58,16 @@ import {
 } from "@wso2is/react-components";
 import { AxiosResponse } from "axios";
 import isEmpty from "lodash-es/isEmpty";
-import React, { FunctionComponent, ReactElement, ReactNode, SyntheticEvent, useEffect, useState } from "react";
+import React, {
+    FunctionComponent,
+    ReactElement,
+    ReactNode,
+    SyntheticEvent,
+    useCallback,
+    useEffect,
+    useRef,
+    useState
+} from "react";
 import { useTranslation } from "react-i18next";
 import InfiniteScroll from "react-infinite-scroll-component";
 import { useDispatch, useSelector } from "react-redux";
@@ -85,6 +94,11 @@ import {
 } from "../../models";
 import { TenantAssociationsInterface } from "../../models/saas/tenants";
 import { handleTenantSwitch } from "../../utils";
+import {
+    filterAssociatedTenants,
+    hasMoreAssociatedTenants as hasMoreAssociatedTenantsInResponse,
+    shouldLoadMoreForTenantSearch
+} from "../../utils/tenant-search";
 import { AddTenantWizard } from "../add-modal";
 import "./tenant-dropdown.scss";
 
@@ -200,6 +214,11 @@ const TenantDropdown: FunctionComponent<TenantDropdownInterface> = (props: Tenan
     const [ organizationName, setOrganizationName ] = useState<string>("");
     const [ organizationHandle, setOrganizationHandle ] = useState<string>("");
     const [ isCopying, setIsCopying ] = useState<boolean>(false);
+    const [ tenantSearchQuery, setTenantSearchQuery ] = useState<string>("");
+    const [ isAssociatedTenantsLoading, setIsAssociatedTenantsLoading ] = useState<boolean>(false);
+
+    const isAssociatedTenantsRequestInFlight: React.MutableRefObject<boolean> = useRef<boolean>(false);
+    const lastAutomaticTenantSearchRequest: React.MutableRefObject<string> = useRef<string>(undefined);
 
     const { organizationType } = useGetCurrentOrganizationType();
 
@@ -212,7 +231,9 @@ const TenantDropdown: FunctionComponent<TenantDropdownInterface> = (props: Tenan
     useEffect(() => {
         setAssociatedTenantsOffset(0);
         if (!isPrivilegedUser && saasFeatureStatus !== FeatureStatus.DISABLED) {
-            getAssociatedTenants(null, associatedTenantsLimit, associatedTenantsOffset)
+            isAssociatedTenantsRequestInFlight.current = true;
+            setIsAssociatedTenantsLoading(true);
+            getAssociatedTenants(null, associatedTenantsLimit, 0)
                 .then((response: TenantRequestResponse) => {
                     let defaultTenant: TenantInfo;
                     let currentTenant: TenantInfo;
@@ -232,7 +253,10 @@ const TenantDropdown: FunctionComponent<TenantDropdownInterface> = (props: Tenan
                     setAssociatedTenants(tenants);
                     setDefaultTenant(defaultTenant);
                     setCurrentTenant(currentTenant);
-                    setHasMoreAssociatedTenants(response.totalResults > response.associatedTenants.length);
+                    setHasMoreAssociatedTenants(
+                        hasMoreAssociatedTenantsInResponse(response.totalResults, 0,
+                            response.associatedTenants.length)
+                    );
                 })
                 .catch((error: any) => {
                     dispatch(
@@ -246,6 +270,10 @@ const TenantDropdown: FunctionComponent<TenantDropdownInterface> = (props: Tenan
                                 t("extensions:manage.features.tenant.notifications." + "getTenants.message")
                         })
                     );
+                })
+                .finally((): void => {
+                    isAssociatedTenantsRequestInFlight.current = false;
+                    setIsAssociatedTenantsLoading(false);
                 });
         }
         getOrganizationData();
@@ -281,24 +309,29 @@ const TenantDropdown: FunctionComponent<TenantDropdownInterface> = (props: Tenan
             setCurrentTenant(_currentTenant);
         }
 
+        const visibleAssociatedTenants: TenantInfo[] = [ ...associatedTenants ];
+        const currentTenantIndex: number = visibleAssociatedTenants.findIndex(
+            (tenant: TenantInfo): boolean => tenant.domain === currentTenant?.domain
+        );
+
+        if (currentTenantIndex !== -1) {
+            visibleAssociatedTenants.splice(currentTenantIndex, 1);
+        }
+
         const association: TenantAssociationsInterface = {
-            associatedTenants: associatedTenants,
+            associatedTenants: visibleAssociatedTenants,
             currentTenant: currentTenant,
             defaultTenant: defaultTenant,
             username: email ?? username
         };
 
-        if (Array.isArray(association.associatedTenants)) {
-            // Remove the current tenant from the associated tenants list.
-            const currentTenantIndex: number = association.associatedTenants.indexOf(association.currentTenant);
-
-            if (currentTenantIndex !== -1) {
-                association.associatedTenants.splice(currentTenantIndex, 1);
-            }
-            setTempTenantAssociationsList(association.associatedTenants);
-        }
+        setTempTenantAssociationsList(filterAssociatedTenants(visibleAssociatedTenants, tenantSearchQuery));
         setTenantAssociations(association);
-    }, [ associatedTenants, defaultTenant, currentTenant ]);
+    }, [ associatedTenants, currentTenant, defaultTenant, tenantSearchQuery ]);
+
+    useEffect(() => {
+        lastAutomaticTenantSearchRequest.current = undefined;
+    }, [ tenantSearchQuery ]);
 
     const {
         data: deploymentUnitResponse,
@@ -393,47 +426,84 @@ const TenantDropdown: FunctionComponent<TenantDropdownInterface> = (props: Tenan
     /**
      * Load more tenants in the list using infinite scroll.
      */
-    const loadMoreItems = () => {
+    const loadMoreItems: () => void = useCallback((): void => {
         // Fetch more tenants.
-        if (!isPrivilegedUser && saasFeatureStatus !== FeatureStatus.DISABLED) {
-            getAssociatedTenants(null, associatedTenantsLimit, associatedTenantsOffset + associatedTenantsLimit)
-                .then((response: TenantRequestResponse) => {
-                    let updatedDefaultTenant: TenantInfo = defaultTenant;
-                    let updatedCurrentTenant: TenantInfo = currentTenant;
-                    const tenants: TenantInfo[] = [];
-
-                    response.associatedTenants.forEach((tenant: TenantInfo) => {
-                        if (isEmpty(defaultTenant) && tenant.default) {
-                            updatedDefaultTenant = tenant;
-                        }
-                        if (isEmpty(currentTenant) && tenant.domain === tenantDomain) {
-                            updatedCurrentTenant = tenant;
-                        }
-
-                        tenants.push(tenant);
-                    });
-                    // Add tenants to the associatedTenants state
-                    setAssociatedTenants([ ...associatedTenants, ...tenants ]);
-                    setAssociatedTenantsOffset(associatedTenantsOffset + associatedTenantsLimit);
-                    setDefaultTenant(updatedDefaultTenant);
-                    setCurrentTenant(updatedCurrentTenant);
-                    setHasMoreAssociatedTenants(associatedTenantsLimit === response.associatedTenants.length);
-                })
-                .catch((error: any) => {
-                    dispatch(
-                        addAlert({
-                            description:
-                                error?.description &&
-                                t("extensions:manage.features.tenant.notifications." + "getTenants.description"),
-                            level: AlertLevels.ERROR,
-                            message:
-                                error?.description &&
-                                t("extensions:manage.features.tenant.notifications." + "getTenants.message")
-                        })
-                    );
-                });
+        if (
+            isPrivilegedUser ||
+            saasFeatureStatus === FeatureStatus.DISABLED ||
+            !hasMoreAssociatedTenants ||
+            isAssociatedTenantsRequestInFlight.current
+        ) {
+            return;
         }
-    };
+
+        const nextOffset: number = associatedTenantsOffset + associatedTenantsLimit;
+
+        isAssociatedTenantsRequestInFlight.current = true;
+        setIsAssociatedTenantsLoading(true);
+
+        getAssociatedTenants(null, associatedTenantsLimit, nextOffset)
+            .then((response: TenantRequestResponse) => {
+                let updatedDefaultTenant: TenantInfo = defaultTenant;
+                let updatedCurrentTenant: TenantInfo = currentTenant;
+                const tenants: TenantInfo[] = [];
+
+                response.associatedTenants.forEach((tenant: TenantInfo) => {
+                    if (isEmpty(defaultTenant) && tenant.default) {
+                        updatedDefaultTenant = tenant;
+                    }
+                    if (isEmpty(currentTenant) && tenant.domain === tenantDomain) {
+                        updatedCurrentTenant = tenant;
+                    }
+
+                    tenants.push(tenant);
+                });
+                // Add tenants to the associatedTenants state
+                setAssociatedTenants([ ...associatedTenants, ...tenants ]);
+                setAssociatedTenantsOffset(nextOffset);
+                setDefaultTenant(updatedDefaultTenant);
+                setCurrentTenant(updatedCurrentTenant);
+                setHasMoreAssociatedTenants(
+                    hasMoreAssociatedTenantsInResponse(response.totalResults, nextOffset,
+                        response.associatedTenants.length)
+                );
+            })
+            .catch((error: any) => {
+                dispatch(
+                    addAlert({
+                        description:
+                            error?.description &&
+                            t("extensions:manage.features.tenant.notifications." + "getTenants.description"),
+                        level: AlertLevels.ERROR,
+                        message:
+                            error?.description &&
+                            t("extensions:manage.features.tenant.notifications." + "getTenants.message")
+                    })
+                );
+            })
+            .finally((): void => {
+                isAssociatedTenantsRequestInFlight.current = false;
+                setIsAssociatedTenantsLoading(false);
+            });
+    }, [ associatedTenants, associatedTenantsOffset, currentTenant, defaultTenant, hasMoreAssociatedTenants,
+        isPrivilegedUser, saasFeatureStatus, tenantDomain ]);
+
+    useEffect(() => {
+        if (!shouldLoadMoreForTenantSearch(tenantSearchQuery, tempTenantAssociationsList ?? [],
+            hasMoreAssociatedTenants, isAssociatedTenantsLoading)) {
+            return;
+        }
+
+        const requestKey: string = `${ tenantSearchQuery }:${ associatedTenantsOffset }`;
+
+        if (lastAutomaticTenantSearchRequest.current === requestKey) {
+            return;
+        }
+
+        lastAutomaticTenantSearchRequest.current = requestKey;
+        loadMoreItems();
+    }, [ associatedTenantsOffset, hasMoreAssociatedTenants, isAssociatedTenantsLoading, loadMoreItems,
+        tempTenantAssociationsList, tenantSearchQuery ]);
 
     /**
      * Resolve associated tenant record.
@@ -514,6 +584,8 @@ const TenantDropdown: FunctionComponent<TenantDropdownInterface> = (props: Tenan
                                         resolveAssociatedTenantRecord(tenant, index))
                                 }
                             </InfiniteScroll>
+                        ) : tenantSearchQuery && isAssociatedTenantsLoading ? (
+                            loadingComponent()
                         ) : (
                             <Item
                                 className="empty-list"
@@ -582,17 +654,7 @@ const TenantDropdown: FunctionComponent<TenantDropdownInterface> = (props: Tenan
     const searchTenantList = (event: React.ChangeEvent<HTMLInputElement>): void => {
         const changeValue: string = event.target.value;
 
-        if (tenantAssociations && Array.isArray(tenantAssociations.associatedTenants)) {
-            let result: TenantInfo[];
-
-            if (changeValue.length > 0) {
-                result = tenantAssociations.associatedTenants.filter((tenantInfo: TenantInfo) =>
-                    tenantInfo.domain?.toLowerCase()?.indexOf(changeValue.toLowerCase()) !== -1);
-            } else {
-                result = tenantAssociations.associatedTenants;
-            }
-            setTempTenantAssociationsList(result);
-        }
+        setTenantSearchQuery(changeValue);
     };
 
     /**
@@ -600,9 +662,7 @@ const TenantDropdown: FunctionComponent<TenantDropdownInterface> = (props: Tenan
      */
     const resetTenantDropdown = (): void => {
         setIsSwitchTenantsSelected(false);
-        if (tenantAssociations && Array.isArray(tenantAssociations.associatedTenants)) {
-            setTempTenantAssociationsList(tenantAssociations.associatedTenants);
-        }
+        setTenantSearchQuery("");
     };
 
     const handleTenantDropdown = (): void => {

--- a/features/admin.tenants.v1/utils/__tests__/tenant-search.test.ts
+++ b/features/admin.tenants.v1/utils/__tests__/tenant-search.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { TenantInfo } from "../../models";
+import {
+    filterAssociatedTenants,
+    hasMoreAssociatedTenants,
+    shouldLoadMoreForTenantSearch
+} from "../tenant-search";
+
+const createTenant = (domain: string): TenantInfo => ({ domain } as TenantInfo);
+
+describe("tenant search utilities", (): void => {
+    const firstPageTenants: TenantInfo[] = Array.from(
+        { length: 15 },
+        (_value: unknown, index: number): TenantInfo => createTenant(`tenant-${index + 1}`)
+    );
+
+    it("does not load another page when a matching tenant is in the first page", (): void => {
+        const matchingTenants: TenantInfo[] = filterAssociatedTenants(firstPageTenants, "tenant-1");
+
+        expect(matchingTenants).toHaveLength(7);
+        expect(shouldLoadMoreForTenantSearch("tenant-1", matchingTenants, true, false)).toBe(false);
+    });
+
+    it("loads the next page when a matching tenant is outside the first page", (): void => {
+        const nextPageTenants: TenantInfo[] = [ createTenant("target-tenant") ];
+        const matchingFirstPageTenants: TenantInfo[] = filterAssociatedTenants(firstPageTenants, "target");
+
+        expect(shouldLoadMoreForTenantSearch("target", matchingFirstPageTenants, true, false)).toBe(true);
+        expect(filterAssociatedTenants([ ...firstPageTenants, ...nextPageTenants ], "target"))
+            .toEqual(nextPageTenants);
+    });
+
+    it("continues loading unmatched searches until the final page", (): void => {
+        expect(shouldLoadMoreForTenantSearch("missing", [], true, false)).toBe(true);
+        expect(shouldLoadMoreForTenantSearch("missing", [], false, false)).toBe(false);
+    });
+
+    it("restores the loaded paginated list when the search query is cleared", (): void => {
+        const loadedTenants: TenantInfo[] = [ ...firstPageTenants, createTenant("target-tenant") ];
+
+        expect(filterAssociatedTenants(loadedTenants, "target")).toEqual([ createTenant("target-tenant") ]);
+        expect(filterAssociatedTenants(loadedTenants, "")).toEqual(loadedTenants);
+    });
+
+    it("does not initiate another request while a tenant page is loading", (): void => {
+        expect(shouldLoadMoreForTenantSearch("target", [], true, true)).toBe(false);
+    });
+
+    it("identifies whether an associated tenant response has another page", (): void => {
+        expect(hasMoreAssociatedTenants(16, 0, 15)).toBe(true);
+        expect(hasMoreAssociatedTenants(16, 15, 1)).toBe(false);
+    });
+});

--- a/features/admin.tenants.v1/utils/__tests__/tenant-search.test.ts
+++ b/features/admin.tenants.v1/utils/__tests__/tenant-search.test.ts
@@ -24,7 +24,7 @@ import {
     shouldLoadMoreForTenantSearch
 } from "../tenant-search";
 
-const createTenant = (domain: string): TenantInfo => ({ domain } as TenantInfo);
+const createTenant: (_domain: string) => TenantInfo = (domain: string): TenantInfo => ({ domain } as TenantInfo);
 
 describe("tenant search utilities", (): void => {
     const firstPageTenants: TenantInfo[] = Array.from(
@@ -36,21 +36,21 @@ describe("tenant search utilities", (): void => {
         const matchingTenants: TenantInfo[] = filterAssociatedTenants(firstPageTenants, "tenant-1");
 
         expect(matchingTenants).toHaveLength(7);
-        expect(shouldLoadMoreForTenantSearch("tenant-1", matchingTenants, true, false)).toBe(false);
+        expect(shouldLoadMoreForTenantSearch("tenant-1", matchingTenants, true, false, 0)).toBe(false);
     });
 
     it("loads the next page when a matching tenant is outside the first page", (): void => {
         const nextPageTenants: TenantInfo[] = [ createTenant("target-tenant") ];
         const matchingFirstPageTenants: TenantInfo[] = filterAssociatedTenants(firstPageTenants, "target");
 
-        expect(shouldLoadMoreForTenantSearch("target", matchingFirstPageTenants, true, false)).toBe(true);
+        expect(shouldLoadMoreForTenantSearch("target", matchingFirstPageTenants, true, false, 0)).toBe(true);
         expect(filterAssociatedTenants([ ...firstPageTenants, ...nextPageTenants ], "target"))
             .toEqual(nextPageTenants);
     });
 
     it("continues loading unmatched searches until the final page", (): void => {
-        expect(shouldLoadMoreForTenantSearch("missing", [], true, false)).toBe(true);
-        expect(shouldLoadMoreForTenantSearch("missing", [], false, false)).toBe(false);
+        expect(shouldLoadMoreForTenantSearch("missing", [], true, false, 0)).toBe(true);
+        expect(shouldLoadMoreForTenantSearch("missing", [], false, false, 0)).toBe(false);
     });
 
     it("restores the loaded paginated list when the search query is cleared", (): void => {
@@ -61,7 +61,12 @@ describe("tenant search utilities", (): void => {
     });
 
     it("does not initiate another request while a tenant page is loading", (): void => {
-        expect(shouldLoadMoreForTenantSearch("target", [], true, true)).toBe(false);
+        expect(shouldLoadMoreForTenantSearch("target", [], true, true, 0)).toBe(false);
+    });
+
+    it("stops automatic retries after a second failed request", (): void => {
+        expect(shouldLoadMoreForTenantSearch("target", [], true, false, 1)).toBe(true);
+        expect(shouldLoadMoreForTenantSearch("target", [], true, false, 2)).toBe(false);
     });
 
     it("identifies whether an associated tenant response has another page", (): void => {

--- a/features/admin.tenants.v1/utils/tenant-search.ts
+++ b/features/admin.tenants.v1/utils/tenant-search.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TenantInfo } from "../models";
+
+/**
+ * Filters associated tenants by their domain.
+ *
+ * @param tenants - Associated tenants available to the switcher.
+ * @param query - Search query entered by the user.
+ * @returns Matching tenants, or all tenants when the query is empty.
+ */
+export const filterAssociatedTenants = (tenants: TenantInfo[], query: string): TenantInfo[] => {
+    const normalizedQuery: string = query.trim().toLowerCase();
+
+    if (!normalizedQuery) {
+        return tenants;
+    }
+
+    return tenants.filter((tenant: TenantInfo): boolean =>
+        tenant.domain?.toLowerCase().includes(normalizedQuery));
+};
+
+/**
+ * Determines whether a search must retrieve another associated tenant page.
+ *
+ * @param query - Search query entered by the user.
+ * @param matchingTenants - Matching tenants in the loaded pages.
+ * @param hasMoreTenants - Whether the API has more pages.
+ * @param isLoading - Whether an associated tenant request is in progress.
+ * @returns Whether the next page should be requested.
+ */
+export const shouldLoadMoreForTenantSearch = (
+    query: string,
+    matchingTenants: TenantInfo[],
+    hasMoreTenants: boolean,
+    isLoading: boolean
+): boolean => Boolean(query.trim()) && matchingTenants.length === 0 && hasMoreTenants && !isLoading;
+
+/**
+ * Determines whether a paginated associated tenant response has a next page.
+ *
+ * @param totalResults - Total tenant associations reported by the API.
+ * @param offset - Offset used for the current request.
+ * @param resultCount - Number of tenants returned by the current request.
+ * @returns Whether the API has more associated tenant pages.
+ */
+export const hasMoreAssociatedTenants = (totalResults: number, offset: number, resultCount: number): boolean =>
+    totalResults > offset + resultCount;

--- a/features/admin.tenants.v1/utils/tenant-search.ts
+++ b/features/admin.tenants.v1/utils/tenant-search.ts
@@ -18,13 +18,6 @@
 
 import { TenantInfo } from "../models";
 
-/**
- * Filters associated tenants by their domain.
- *
- * @param tenants - Associated tenants available to the switcher.
- * @param query - Search query entered by the user.
- * @returns Matching tenants, or all tenants when the query is empty.
- */
 export const filterAssociatedTenants: (_tenants: TenantInfo[], _query: string) => TenantInfo[] = (
     tenants: TenantInfo[],
     query: string
@@ -39,16 +32,6 @@ export const filterAssociatedTenants: (_tenants: TenantInfo[], _query: string) =
         tenant.domain?.toLowerCase().includes(normalizedQuery));
 };
 
-/**
- * Determines whether a search must retrieve another associated tenant page.
- *
- * @param query - Search query entered by the user.
- * @param matchingTenants - Matching tenants in the loaded pages.
- * @param hasMoreTenants - Whether the API has more pages.
- * @param isLoading - Whether an associated tenant request is in progress.
- * @param retryCount - Number of retries attempted for the current search page.
- * @returns Whether the next page should be requested.
- */
 export const shouldLoadMoreForTenantSearch: (
     _query: string,
     _matchingTenants: TenantInfo[],
@@ -63,14 +46,6 @@ export const shouldLoadMoreForTenantSearch: (
     retryCount: number
 ): boolean => Boolean(query.trim()) && matchingTenants.length === 0 && hasMoreTenants && !isLoading && retryCount < 2;
 
-/**
- * Determines whether a paginated associated tenant response has a next page.
- *
- * @param totalResults - Total tenant associations reported by the API.
- * @param offset - Offset used for the current request.
- * @param resultCount - Number of tenants returned by the current request.
- * @returns Whether the API has more associated tenant pages.
- */
 export const hasMoreAssociatedTenants: (_totalResults: number, _offset: number, _resultCount: number) => boolean = (
     totalResults: number,
     offset: number,

--- a/features/admin.tenants.v1/utils/tenant-search.ts
+++ b/features/admin.tenants.v1/utils/tenant-search.ts
@@ -25,7 +25,10 @@ import { TenantInfo } from "../models";
  * @param query - Search query entered by the user.
  * @returns Matching tenants, or all tenants when the query is empty.
  */
-export const filterAssociatedTenants = (tenants: TenantInfo[], query: string): TenantInfo[] => {
+export const filterAssociatedTenants: (_tenants: TenantInfo[], _query: string) => TenantInfo[] = (
+    tenants: TenantInfo[],
+    query: string
+): TenantInfo[] => {
     const normalizedQuery: string = query.trim().toLowerCase();
 
     if (!normalizedQuery) {
@@ -43,14 +46,22 @@ export const filterAssociatedTenants = (tenants: TenantInfo[], query: string): T
  * @param matchingTenants - Matching tenants in the loaded pages.
  * @param hasMoreTenants - Whether the API has more pages.
  * @param isLoading - Whether an associated tenant request is in progress.
+ * @param retryCount - Number of retries attempted for the current search page.
  * @returns Whether the next page should be requested.
  */
-export const shouldLoadMoreForTenantSearch = (
+export const shouldLoadMoreForTenantSearch: (
+    _query: string,
+    _matchingTenants: TenantInfo[],
+    _hasMoreTenants: boolean,
+    _isLoading: boolean,
+    _retryCount: number
+) => boolean = (
     query: string,
     matchingTenants: TenantInfo[],
     hasMoreTenants: boolean,
-    isLoading: boolean
-): boolean => Boolean(query.trim()) && matchingTenants.length === 0 && hasMoreTenants && !isLoading;
+    isLoading: boolean,
+    retryCount: number
+): boolean => Boolean(query.trim()) && matchingTenants.length === 0 && hasMoreTenants && !isLoading && retryCount < 2;
 
 /**
  * Determines whether a paginated associated tenant response has a next page.
@@ -60,5 +71,8 @@ export const shouldLoadMoreForTenantSearch = (
  * @param resultCount - Number of tenants returned by the current request.
  * @returns Whether the API has more associated tenant pages.
  */
-export const hasMoreAssociatedTenants = (totalResults: number, offset: number, resultCount: number): boolean =>
-    totalResults > offset + resultCount;
+export const hasMoreAssociatedTenants: (_totalResults: number, _offset: number, _resultCount: number) => boolean = (
+    totalResults: number,
+    offset: number,
+    resultCount: number
+): boolean => totalResults > offset + resultCount;


### PR DESCRIPTION
### Purpose

Fixes wso2/product-is#27727.

The tenant switcher loaded 15 associated tenants and searched only the loaded list. The association API exposes pagination but no text-search parameter, so a tenant beyond the first page could not be found until scrolling loaded it.

This change fetches the next associated-tenant page when an active query has no loaded match. It preserves the existing paginated list and infinite scrolling, keeps a single request in flight, retries a failed automatic page load once, and delays the empty state until the relevant request completes.

### Related Issues

- Fixes wso2/product-is#27727

### Related PRs

- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [x] [Unit tests](/docs/testing/UNIT_TESTING.md) provided.
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided.

### Security checks

- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)

- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.

### Verification

- Focused ESLint passed for the changed component, utility, and test.
- Focused tenant-search regression tests: 7 passed.
- `git diff --check` passed.
- The normal Vitest setup is blocked by the pre-existing undeclared `msw` dependency; reproduced on clean `origin/master`.
- Repository-wide lint, type-check, and the `admin.tenants.v1` Rollup build have unrelated baseline failures, also reproduced on clean `origin/master`.