### PR TITLE
Fix unhandled exceptions in authentication portal pages reachable without request context

### DIFF
--- a/.changeset/fix-dynamic-prompt-classcastexception.md
+++ b/.changeset/fix-dynamic-prompt-classcastexception.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix unhandled ClassCastException in authentication portal pages when accessed without prompt context

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/dynamic_prompt.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/dynamic_prompt.jsp
@@ -42,6 +42,14 @@
     String templateId = request.getParameter("templateId");
     String promptId = request.getParameter("promptId");
 
+    // The auth params are populated by AuthParameterFilter, which wraps the request only when it
+    // carries a session data key. A request reaching this page without that context is not a valid
+    // prompt request, so fail it cleanly instead of letting the cast below throw.
+    if (!(request instanceof AuthenticationRequestWrapper)) {
+        request.getRequestDispatcher("error.do").forward(request, response);
+        return;
+    }
+
     Map data = ((AuthenticationRequestWrapper) request).getAuthParams();
     String templatePath = templateMap.get(templateId);
 %>
@@ -50,8 +58,10 @@
 
 <%-- Data for the layout from the page --%>
 <%
-    String templateIdCapitalized = templateId.substring(0, 1).toUpperCase() + templateId.substring(1);
-    layoutData.put("is" + templateIdCapitalized + "DynamicPrompt", true);
+    if (StringUtils.isNotBlank(templateId)) {
+        String templateIdCapitalized = templateId.substring(0, 1).toUpperCase() + templateId.substring(1);
+        layoutData.put("is" + templateIdCapitalized + "DynamicPrompt", true);
+    }
     layoutData.put("isDynamicPrompt", true);
 %>
 
@@ -83,7 +93,7 @@
         </layout:component>
         <layout:component componentName="MainSection">
             <%
-                if (templatePath != null) {
+                if (templatePath != null && StringUtils.isNotBlank(promptId)) {
             %>
                 <div class="ui segment">
                     <c:set var="data" value="<%=data%>" scope="request"/>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/dynamic_prompt.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/dynamic_prompt.jsp
@@ -58,8 +58,8 @@
 
 <%-- Data for the layout from the page --%>
 <%
-        String templateIdCapitalized = templateId.substring(0, 1).toUpperCase() + templateId.substring(1);
-        layoutData.put("is" + templateIdCapitalized + "DynamicPrompt", true);
+    String templateIdCapitalized = templateId.substring(0, 1).toUpperCase() + templateId.substring(1);
+    layoutData.put("is" + templateIdCapitalized + "DynamicPrompt", true);
     layoutData.put("isDynamicPrompt", true);
 %>
 

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/dynamic_prompt.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/dynamic_prompt.jsp
@@ -58,10 +58,8 @@
 
 <%-- Data for the layout from the page --%>
 <%
-    if (StringUtils.isNotBlank(templateId)) {
         String templateIdCapitalized = templateId.substring(0, 1).toUpperCase() + templateId.substring(1);
         layoutData.put("is" + templateIdCapitalized + "DynamicPrompt", true);
-    }
     layoutData.put("isDynamicPrompt", true);
 %>
 
@@ -93,7 +91,7 @@
         </layout:component>
         <layout:component componentName="MainSection">
             <%
-                if (templatePath != null && StringUtils.isNotBlank(promptId)) {
+                if (templatePath != null) {
             %>
                 <div class="ui segment">
                     <c:set var="data" value="<%=data%>" scope="request"/>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/fido2-auth.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/fido2-auth.jsp
@@ -36,6 +36,14 @@
 <%
     String authRequest = Encode.forJavaScriptBlock(request.getParameter("data"));
 
+    // The auth params are populated by AuthParameterFilter, which wraps the request only when it
+    // carries a session data key. A request reaching this page without that context is not a valid
+    // prompt request, so fail it cleanly instead of letting the cast below throw.
+    if (!(request instanceof AuthenticationRequestWrapper)) {
+        request.getRequestDispatcher("error.do").forward(request, response);
+        return;
+    }
+
     Map data = ((AuthenticationRequestWrapper) request).getAuthParams();
     boolean enablePasskeyProgressiveEnrollment = (boolean) data.get("FIDO.EnablePasskeyProgressiveEnrollment");
 %>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/fido2-identifierfirst.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/fido2-identifierfirst.jsp
@@ -34,6 +34,14 @@
 <%@include file="util/authenticator-utils.jsp" %>
 
 <%
+    // The auth params are populated by AuthParameterFilter, which wraps the request only when it
+    // carries a session data key. A request reaching this page without that context is not a valid
+    // prompt request, so fail it cleanly instead of letting the cast below throw.
+    if (!(request instanceof AuthenticationRequestWrapper)) {
+        request.getRequestDispatcher("error.do").forward(request, response);
+        return;
+    }
+
     Map data = ((AuthenticationRequestWrapper) request).getAuthParams();
     boolean enablePasskeyProgressiveEnrollment = (boolean) data.get("FIDO.EnablePasskeyProgressiveEnrollment");
 %>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/fido2-passkey-status.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/fido2-passkey-status.jsp
@@ -33,6 +33,14 @@
 <%
     String isKeyExist = request.getParameter("keyExist");
 
+    // The auth params are populated by AuthParameterFilter, which wraps the request only when it
+    // carries a session data key. A request reaching this page without that context is not a valid
+    // prompt request, so fail it cleanly instead of letting the cast below throw.
+    if (!(request instanceof AuthenticationRequestWrapper)) {
+        request.getRequestDispatcher("error.do").forward(request, response);
+        return;
+    }
+
     Map data = ((AuthenticationRequestWrapper) request).getAuthParams();
     boolean enablePasskeyProgressiveEnrollment = (boolean) data.get("FIDO.EnablePasskeyProgressiveEnrollment");
 %>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/handle-multiple-sessions.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/handle-multiple-sessions.jsp
@@ -39,6 +39,14 @@
 
 <%
     String promptId = request.getParameter("promptId");
+
+    // The prompt id identifies the authentication context this page acts on, and is encoded into the
+    // form below. Without it there is no context to render, so fail cleanly instead of throwing.
+    if (StringUtils.isBlank(promptId)) {
+        request.getRequestDispatcher("error.do").forward(request, response);
+        return;
+    }
+
     String authAPIURL = application.getInitParameter(Constants.AUTHENTICATION_REST_ENDPOINT_URL);
 
     if (StringUtils.isBlank(authAPIURL)) {

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/requested-claims.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/requested-claims.jsp
@@ -64,12 +64,16 @@
         request.getRequestDispatcher("error.do").forward(request, response);
         return;
     }
-    if (request.getParameter(Constants.MISSING_CLAIMS) != null) {
-        missingClaimList = request.getParameter(Constants.MISSING_CLAIMS).split(",");
-    }
     // The page exists to collect the missing claims listed in this parameter, and iterates the list
-    // unconditionally when rendering. Without it there is nothing to prompt for.
-    if (missingClaimList == null || missingClaimList.length == 0) {
+    // unconditionally when rendering, taking the first character of each entry. Without the
+    // parameter there is nothing to prompt for, and a blank entry would break that rendering.
+    String missingClaims = request.getParameter(Constants.MISSING_CLAIMS);
+    if (StringUtils.isBlank(missingClaims)) {
+        request.getRequestDispatcher("error.do").forward(request, response);
+        return;
+    }
+    missingClaimList = missingClaims.split(",", -1);
+    if (Arrays.stream(missingClaimList).anyMatch(StringUtils::isBlank)) {
         request.getRequestDispatcher("error.do").forward(request, response);
         return;
     }

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/requested-claims.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/requested-claims.jsp
@@ -67,6 +67,12 @@
     if (request.getParameter(Constants.MISSING_CLAIMS) != null) {
         missingClaimList = request.getParameter(Constants.MISSING_CLAIMS).split(",");
     }
+    // The page exists to collect the missing claims listed in this parameter, and iterates the list
+    // unconditionally when rendering. Without it there is nothing to prompt for.
+    if (missingClaimList == null || missingClaimList.length == 0) {
+        request.getRequestDispatcher("error.do").forward(request, response);
+        return;
+    }
     if (request.getParameter(Constants.DISPLAY_NAMES) != null) {
         String[] displayNamesParam = request.getParameter(Constants.DISPLAY_NAMES).split(",");
         for (String displayName: displayNamesParam) {

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/resend-confirmation-captcha.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/resend-confirmation-captcha.jsp
@@ -36,6 +36,14 @@
 
 <%
     String UTF_8 = "UTF-8";
+
+    // The username is encoded into the resend form action below. Without it there is no account to
+    // resend a confirmation for, so fail cleanly instead of throwing.
+    if (StringUtils.isBlank(request.getParameter("failedUsername"))) {
+        request.getRequestDispatcher("error.do").forward(request, response);
+        return;
+    }
+
     boolean reCaptchaResendEnabled = false;
     if (request.getParameter("reCaptchaResend") != null && Boolean.parseBoolean(request.getParameter("reCaptchaResend"))) {
         reCaptchaResendEnabled = true;


### PR DESCRIPTION
## Problem

`dynamic_prompt.jsp` casts the incoming request to `AuthenticationRequestWrapper` unconditionally:

```java
Map data = ((AuthenticationRequestWrapper) request).getAuthParams();
```

`AuthParameterFilter` only wraps a request carrying `sessionDataKey`, `sessionDataKeyConsent` or `errorKey`, and otherwise passes the raw request through (`AuthParameterFilter.java:98`). A request without one therefore reaches the cast unwrapped and throws `ClassCastException`.

The page is reachable unauthenticated, so any client can trigger it, and each request logs **2 ERROR lines**.

Sweeping every JSP in the webapp with an unauthenticated `GET` found the same symptom on six further pages, in three causes:

| Page | Cause |
|---|---|
| `dynamic_prompt.jsp` | unguarded `AuthenticationRequestWrapper` cast |
| `fido2-auth.jsp`, `fido2-identifierfirst.jsp`, `fido2-passkey-status.jsp` | same cast |
| `handle-multiple-sessions.jsp` | `promptId` → `URLEncoder.encode()` NPE |
| `requested-claims.jsp` | `missingClaims` iterated when rendering — NPE when absent, `StringIndexOutOfBoundsException` when blank |
| `resend-confirmation-captcha.jsp` | `failedUsername` → `URLEncoder.encode()` NPE |

## Fix

Guard the cast on the four pages that perform it and forward a request without prompt context to `error.do`, following the convention already used elsewhere in this webapp. Guard the three unchecked parameters the same way.

For `requested-claims.jsp`, validate the raw `missingClaims` parameter before splitting and reject blank entries — an empty value splits into a one-element array holding an empty string, which passes a length check and then breaks the render loop.

## Verification

On WSO2 IS 7.4.0, unauthenticated, default pack, no configuration change:

- every affected page logged 2 ERROR lines per request before the change and **0** after
- every request that previously rendered still renders the same page at the same byte count
- a sweep of all 67 pages in the webapp shows no remaining page failing this way, other than pages that fail to compile standalone for unrelated reasons

## Not included

`basicauth.jsp`, `tenantauth.jsp` and `identifierauth.jsp` also log 2 ERROR lines on a direct request, but they are `<%@ include %>` fragments of `login.jsp` and fail to compile only when requested standalone, because their imports live in the parent page. Nothing is wrong with the fragments themselves — the issue is that the webapp serves them directly, which needs a webapp-level fix rather than per-page guards. `add-security-questions.jsp` fails to compile for an unrelated missing class. Both are better handled separately.