### PR TITLE
Add console to the changeset for the SSO-session binding description fix

### DIFF
--- a/.changeset/release-console-sso-binding-description.md
+++ b/.changeset/release-console-sso-binding-description.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Release the Console with the clarified SSO-session token binding type description


### PR DESCRIPTION
### Purpose

Follow-up to #10616, which clarified the SSO-session token binding type description.

That PR's changeset listed `@wso2is/i18n` and `@wso2is/admin.applications.v1` but omitted `@wso2is/console`. Both were released as `@wso2is/i18n@2.44.2` and `@wso2is/admin.applications.v1@2.43.14`, but no new `@wso2is/console` tag was cut — the latest is still `@wso2is/console@4.14.9`, which predates the fix.

The internal dependency ranges are caret ranges that already accept the new patch versions, so changesets had no reason to pull the console into that release on its own.

This PR adds a `@wso2is/console` patch changeset so a console release is cut with the corrected text.

No code change.

### Related Issues
- https://github.com/wso2/product-is/issues/28335

### Related PRs
- #10616

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
