### PR TITLE
Fix registration form crash when the date field holds a future date

### DIFF
--- a/.changeset/fix-dob-datepicker-crash.md
+++ b/.changeset/fix-dob-datepicker-crash.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix the registration form being unmounted when the date field holds a future date. The date input no longer caps the calendar at today, which was making a crash in the underlying picker reachable.

--- a/identity-apps-core/react-ui-core/src/components/adapters/date-field-adapter.js
+++ b/identity-apps-core/react-ui-core/src/components/adapters/date-field-adapter.js
@@ -29,16 +29,6 @@ import ValidationError from "../validation-error";
 const DATE_VALIDATOR = "DateValidator";
 const ISO_DATE_FORMAT = "YYYY-MM-DD";
 
-/**
- * Format today's date as a YYYY-MM-DD string.
- */
-const formatToday = () => {
-    const date = new Date();
-    const pad = (num) => String(num).padStart(2, "0");
-
-    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
-};
-
 const DateFieldAdapter = ({ component, formState, formStateHandler, fieldErrorHandler }) => {
 
     const { identifier, required, label, placeholder, validations, hint } = component.config;
@@ -48,13 +38,18 @@ const DateFieldAdapter = ({ component, formState, formStateHandler, fieldErrorHa
 
     const [ value, setValue ] = useState("");
 
-    // Derive calendar constraints from the configured DateValidator rule, so the picker
-    // matches the validation rule the field was given (no field-specific logic here).
+    // Note: do not pass `maxDate` to DateInput. semantic-ui-calendar-react 0.15.3 crashes when the
+    // picker mounts on a month in which every day is disabled: getInitialDatePosition falls through
+    // to `selectable[0].position` without guarding the empty case, and the throw happens inside
+    // componentDidMount, which unmounts the whole form. Capping at today made that state reachable
+    // whenever the field already held a later date. Future dates are rejected by the DateValidator
+    // rule below and by the user store operation listener on submit.
+
+    // Derive the date format from the configured DateValidator rule, so the input parses the
+    // same format the validation rule expects (no field-specific logic here).
     const dateValidatorRule = Array.isArray(validations)
         ? validations.find((rule) => rule?.name === DATE_VALIDATOR)
         : undefined;
-    const disallowFuture = Boolean(dateValidatorRule?.conditions?.some(
-        (condition) => condition.key === "disallow.future" && condition.value === "true"));
 
     useEffect(() => {
         formStateHandler(component.config.identifier, value);
@@ -80,7 +75,6 @@ const DateFieldAdapter = ({ component, formState, formStateHandler, fieldErrorHa
                 value={ value }
                 required={ required }
                 dateFormat={ dateValidatorRule ? ISO_DATE_FORMAT : undefined }
-                maxDate={ disallowFuture ? formatToday() : undefined }
                 clearable
                 closeOnMouseLeave
                 closable


### PR DESCRIPTION
## Purpose

Fixes a crash that blanks the dynamic registration form when the date field holds a future date.

Typing a future date into the Date of Birth field, closing the calendar popup, then selecting the field text unmounts the entire sign-up form. The user is left on a blank page and has to reload. Reproduced 3/3 from a fresh form on a dev tenant.

```
TypeError: Cannot read properties of undefined (reading 'position')
```

## Root cause

Not a bug in this repo's logic — an unguarded empty-array access in `semantic-ui-calendar-react@0.15.3`, `src/pickers/dayPicker/sharedFunctions.ts`:

```ts
export function getInitialDatePosition(initDate, values, selectablePositions) {
  const selectable = selectablePositions.reduce(...);
  const res = find(selectable, (item) => item.value === initDate);
  if (res) { return res.position; }
  return selectable[0].position;   // <-- selectable is [] -> undefined.position
}
```

`SingleSelectionPicker.componentDidMount` runs on every popup mount and falls back to `getInitialDatePosition()`. `DayPicker` passes it all day positions minus the disabled ones. With `maxDate` set to today and the displayed month entirely after today, **every** position is disabled, so the array is empty. Because the throw happens during mount and there is no error boundary, React tears down the subtree — hence the blank form.

Isolated against the library's own functions, with controls:

| picker page | selectable positions | result |
|---|---|---|
| Apr 2027 | 0 | `TypeError: ... reading 'position'` |
| Sep 2026 | 0 | same |
| Aug 2026 (current month, maxDate = 19th) | 19 | ok |
| May 1990 | 31 | ok, returns 16 |

With `maxDate` omitted the same three pages give 30, 30, 31 — never empty. So `maxDate` is what makes the latent library bug reachable.

The trigger is narrow. `state.date` has to initialise on an all-disabled month, which requires the field's value to already be beyond `maxDate` at mount. Clicking cannot get you there: `isNextPageAvailable(date, maxDate)` correctly returns false at the current month, so you cannot page into a fully disabled month. `initialDate` is not a workaround either — `buildValue` returns the parsed value first and only falls back to `initialDate` when the value does not parse.

## Approach

Drop `maxDate`, and remove the now-unused `formatToday` helper and `disallowFuture` derivation. `dateFormat` still comes from the `DateValidator` rule, so ISO parsing and the format error are unchanged.

Validation behaviour is not affected:

- The client still rejects a future date inline with `Cannot be a future date.` via the `DateValidator` rule in `use-field-validations.js`.
- The server still rejects it in `SCIMUserOperationListener` at user creation.

The only thing lost is the greying out of future days in the picker. Given the alternative is a form that unrecoverably blanks, that seemed the right trade for now.

A comment is added at the call site recording why `maxDate` must not be reintroduced.

## Follow-up (not in this PR)

The proper fix is upstream: `return selectable.length ? selectable[0].position : 0;`. The library is at 0.15.3 and this repo has no pnpm `patchedDependencies` set up, so that is a separate decision. Longer term, replacing `semantic-ui-calendar-react` here with the MUI X `DatePicker` already used by the Console via `@wso2is/forms` would fix it properly and drop an unmaintained dependency.

## Related

Follows up on #10558, which introduced the `maxDate` cap.

## Testing

- Reproduced the crash 3/3 on a dev tenant before the change.
- Verified in node against the library's own functions that no page is fully disabled without `maxDate` (table above).
- Confirmed the file still parses as JSX.



## Related issue

wso2/product-is#28342
