### PR TITLE
Let a date of birth validation error be corrected on the missing claims page

### DIFF
--- a/.changeset/fix-claim-validation-error-deadend.md
+++ b/.changeset/fix-claim-validation-error-deadend.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Allow a date of birth validation error to be corrected on the missing claims page during federated login, instead of forwarding the user to a generic error page.

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/requested-claims.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/requested-claims.jsp
@@ -46,6 +46,17 @@
 
 <%!
     private Log log = LogFactory.getLog(this.getClass());
+
+    /*
+     * Claim value validation failures that the user can correct by editing the form. For these the page is
+     * re-rendered with the message shown inline, instead of forwarding to the generic error page.
+     *
+     * SUO-10001 - claim value does not match the configured regex.
+     * SUO-10003 - date of birth is not an existing calendar date, or is a future date.
+     *
+     * SUO-10000 (user attribute update is not allowed) is deliberately absent: retrying cannot fix it.
+     */
+    private static final List<String> CORRECTABLE_CLAIM_ERROR_CODES = Arrays.asList("SUO-10001", "SUO-10003");
 %>
 
 <%
@@ -55,8 +66,7 @@
     Boolean isFederated = false;
     String errorCode = request.getParameter("errorCode");
     String errorMsg = request.getParameter("errorMessage");
-    // "SUO-10001" error code is thrown when claim value doesn't match with regex pattern.
-    if (!"SUO-10001".equals(errorCode) && StringUtils.isNotBlank(errorMsg)) {
+    if (!CORRECTABLE_CLAIM_ERROR_CODES.contains(errorCode) && StringUtils.isNotBlank(errorMsg)) {
         request.setAttribute(STATUS_MSG, errorMsg);
         if (!StringUtils.equals(errorMsg, "User attribute update is not allowed")) {
             request.setAttribute(STATUS, AuthenticationEndpointUtil.i18n(resourceBundle, CONFIGURATION_ERROR));


### PR DESCRIPTION
## Purpose

On the missing-claims page shown during federated login, a date of birth validation error sends the user to a generic error page instead of letting them correct the field.

`requested-claims.jsp` forwards every error code except `SUO-10001` to `error.do`:

```jsp
// "SUO-10001" error code is thrown when claim value doesn't match with regex pattern.
if (!"SUO-10001".equals(errorCode) && StringUtils.isNotBlank(errorMsg)) {
    …
    request.getRequestDispatcher("error.do").forward(request, response);
```

That was correct when `SUO-10001` was the only claim value validation code. `SUO-10003` was added later, for a date of birth that is not an existing calendar date or is in the future. It is not in the allowlist, so the user lands on "Configuration Error!" with no way to fix the value, and cannot complete the login.

## How the code reaches this page

1. The claim update fails in `SCIMUserOperationListener`, which throws `UserStoreClientException(message, SUO-10003)`.
2. `PostAuthnMissingClaimHandler` catches it and stores the message and `e.getErrorCode()` on the context.
3. The same handler puts both on the redirect back to this page as `errorMessage` and `errorCode`.
4. This JSP reads them and decides whether to re-render or forward.

Confirmed against a dev deployment by calling the page directly, since the branch is driven purely by request parameters:

```bash
curl -s ".../authenticationendpoint/claims.do?errorCode=SUO-10003&errorMessage=Date+of+Birth+cannot+be+a+future+date"
```

| Slot | `SUO-10001` (control) | `SUO-10003` |
|---|---|---|
| `STATUS` | `null` | `Configuration Error!` |
| `STATUS_MSG` | `null` | `Date of Birth cannot be a future date` |

Both null means the branch was not taken; both populated means it was and the request was forwarded.

## Approach

Replace the single comparison with a named list of the codes the user can act on, and add `SUO-10003`.

Deliberately **not** a prefix match on `SUO-100`. `SUO-10000` is "user attribute update is not allowed", which is in the same numeric range but is not correctable by retyping — a prefix match would have started rendering a form for an error the user cannot resolve.

Deliberately **not** including `SUO-10002` (length violation). It has the same defect, but it predates the `SUO-10003` work and is a pre-existing issue rather than something this change introduced. Worth fixing separately; not bundled here so this stays a targeted fix.

## Behaviour delta

Exactly one code changes. Verified by evaluating the old and new conditions side by side:

| errorCode | forwards to error page, before | after |
|---|---|---|
| `null` | true | true |
| `""` | true | true |
| `SUO-10000` | true | true |
| `SUO-10001` | false | false |
| `SUO-10002` | true | true |
| **`SUO-10003`** | **true** | **false** |
| unrelated, e.g. `FE-60018` | true | true |

`Arrays.asList(...).contains(null)` is null-safe, so a missing `errorCode` behaves as before.

## Testing

JSPs in this module are not compile-validated at build time (no jspc plugin), so:

- The declaration block was extracted and compiled standalone to catch syntax or typing errors.
- `java.util.Arrays` and `java.util.List` were already imported by this JSP; no new imports needed.
- The condition change was verified by the behaviour table above.

End-to-end verification needs a federated IdP with date of birth as a missing claim, which is why the mechanism was confirmed by driving the page's parameters directly rather than by provisioning one.

## Related

- The code originates in wso2-extensions/identity-inbound-provisioning-scim2#800.
- Sibling fixes from the same review: wso2-extensions/identity-inbound-provisioning-scim2#803, wso2/carbon-identity-framework#8260, wso2/identity-apps#10631.



## Related issue

wso2/product-is#28342
