### PR TITLE
Fix duplicate user attributes being listed in user attribute dropdown in user filtering view

### DIFF
--- a/.changeset/fix-duplicate-user-search-attributes.md
+++ b/.changeset/fix-duplicate-user-search-attributes.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.users.v1": patch
+---
+
+Fix duplicate user attributes being listed in the user attribute dropdown in the user filtering view

--- a/.changeset/fix-duplicate-user-search-attributes.md
+++ b/.changeset/fix-duplicate-user-search-attributes.md
@@ -1,5 +1,6 @@
 ---
 "@wso2is/admin.users.v1": patch
+"@wso2is/console": patch
 ---
 
 Fix duplicate user attributes being listed in the user attribute dropdown in the user filtering view

--- a/features/admin.users.v1/utils/user-management-utils.ts
+++ b/features/admin.users.v1/utils/user-management-utils.ts
@@ -486,6 +486,12 @@ export const resolveUserSearchAttributes = (
 ): DropdownChild[] => {
     const sortedSchemas: ProfileSchemaInterface[] = ProfileUtils.flattenSchemas([ ...profileSchemas ])
         .filter((schema: ProfileSchemaInterface) => {
+            // `userName` is already added as a hardcoded option by the consumers of this function.
+            // Exclude it here to avoid rendering a duplicate entry.
+            if (schema?.name === ProfileConstants.SCIM2_SCHEMA_DICTIONARY.get("USERNAME")) {
+                return false;
+            }
+
             // The global supportedByDefault value is a string. Hence, it needs to be converted to a boolean.
             let resolveSupportedByDefaultValue: boolean = schema?.supportedByDefault?.toLowerCase() === "true";
 
@@ -504,20 +510,36 @@ export const resolveUserSearchAttributes = (
             return getDisplayOrder(a) - getDisplayOrder(b);
         });
 
-    let searchAttributes:DropdownChild[] = [];
+    // Migrated tenants can end up with the same attribute (e.g. `country`, `preferredMFAOption`) exposed under
+    // both the enterprise dialect and the system schema. Both map to the same local claim and carry the same
+    // display name but different schema-qualified values, so de-duplicating by option value would not work.
+    // De-duplicate by attribute name instead, preferring the system schema variant as it is the canonical
+    // location in 7.x.
+    const deduplicatedSchemasByName: Map<string, ProfileSchemaInterface> = new Map();
 
-    if (sortedSchemas) {
-        searchAttributes = sortedSchemas.map((schema: ProfileSchemaInterface, index: number) => {
-            const extendedSchemaSupportedName:string = schema?.schemaId
-                ? schema.schemaId + ":" + schema.name
-                : schema.name;
+    sortedSchemas?.forEach((schema: ProfileSchemaInterface) => {
+        const existingSchema: ProfileSchemaInterface = deduplicatedSchemasByName.get(schema.name);
 
-            return {
-                key: index,
-                text: schema.displayName,
-                value: extendedSchemaSupportedName
-            };
-        });
+        if (!existingSchema || schema.schemaId === ProfileConstants.SCIM2_SYSTEM_USER_SCHEMA) {
+            deduplicatedSchemasByName.set(schema.name, schema);
+        }
+    });
+
+    let searchAttributes: DropdownChild[] = [];
+
+    if (deduplicatedSchemasByName.size > 0) {
+        searchAttributes = Array.from(deduplicatedSchemasByName.values())
+            .map((schema: ProfileSchemaInterface, index: number) => {
+                const extendedSchemaSupportedName: string = schema?.schemaId
+                    ? schema.schemaId + ":" + schema.name
+                    : schema.name;
+
+                return {
+                    key: index,
+                    text: schema.displayName,
+                    value: extendedSchemaSupportedName
+                };
+            });
     }
 
     return searchAttributes;

--- a/features/admin.users.v1/utils/user-management-utils.ts
+++ b/features/admin.users.v1/utils/user-management-utils.ts
@@ -486,8 +486,10 @@ export const resolveUserSearchAttributes = (
 ): DropdownChild[] => {
     const sortedSchemas: ProfileSchemaInterface[] = ProfileUtils.flattenSchemas([ ...profileSchemas ])
         .filter((schema: ProfileSchemaInterface) => {
-            // `userName` is already added as a hardcoded option by the consumers of this function.
-            // Exclude it here to avoid rendering a duplicate entry.
+            /*
+             * `userName` is already added as a hardcoded option by the consumers of this function.
+             * Exclude it here to avoid rendering a duplicate entry.
+             */
             if (schema?.name === ProfileConstants.SCIM2_SCHEMA_DICTIONARY.get("USERNAME")) {
                 return false;
             }
@@ -510,11 +512,13 @@ export const resolveUserSearchAttributes = (
             return getDisplayOrder(a) - getDisplayOrder(b);
         });
 
-    // Migrated tenants can end up with the same attribute (e.g. `country`, `preferredMFAOption`) exposed under
-    // both the enterprise dialect and the system schema. Both map to the same local claim and carry the same
-    // display name but different schema-qualified values, so de-duplicating by option value would not work.
-    // De-duplicate by attribute name instead, preferring the system schema variant as it is the canonical
-    // location in 7.x.
+    /*
+     * Migrated tenants can end up with the same attribute (e.g. `country`, `preferredMFAOption`) exposed under
+     * both the enterprise dialect and the system schema. Both map to the same local claim and carry the same
+     * display name but different schema-qualified values, so de-duplicating by option value would not work.
+     * De-duplicate by attribute name instead, preferring the system schema variant as it is the canonical
+     * location in 7.x.
+     */
     const deduplicatedSchemasByName: Map<string, ProfileSchemaInterface> = new Map();
 
     sortedSchemas?.forEach((schema: ProfileSchemaInterface) => {


### PR DESCRIPTION
## Purpose

Resolves https://github.com/wso2/product-is/issues/28303

After migrating from WSO2 IS v6.1.0 to IS v7.3.0, attributes present in both the enterprise dialect (`urn:ietf:params:scim:schemas:extension:enterprise:2.0:User`) and the system schema (`urn:scim:wso2:schema`) — e.g. `Country`, `preferredMFAOption` — were listed twice in the *Console > User Management > Users > Advanced Search > Filter attribute* dropdown. The `Username` attribute could also be duplicated since it is already added as a hardcoded option by consumers of `resolveUserSearchAttributes`.

## Changes

- Exclude the `userName` schema attribute from the resolved list since it's already added separately by consumers of `resolveUserSearchAttributes`.
- De-duplicate schema attributes by name (rather than by the schema-qualified option value, since the same local claim is exposed with different schema-qualified values under each dialect), preferring the system schema variant as the canonical one in 7.x.

## Related PRs

- Original fix: https://github.com/wso2-support/identity-apps/pull/1422