### PR TITLE
Add a Console changeset to trigger a Console release

### DIFF
--- a/.changeset/console-release-dob-datepicker-fix.md
+++ b/.changeset/console-release-dob-datepicker-fix.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Release the Console so the date field fix from #10631 ships in a Console distribution. That PR's changeset only covered `@wso2is/identity-apps-core`, so the release workflow did not cut a Console release.


### PR DESCRIPTION
Follow-up to #10631.

### Problem

#10631 fixed the registration form crash caused by the date field passing `maxDate` to the picker. Its changeset listed only `@wso2is/identity-apps-core`.

The release script (`.github/workflows/scripts/release.sh`) decides which Maven releases to run by matching package names in the changesets `publishedPackages` output:

- `@wso2is/console` -> `apps/console/java` release
- `@wso2is/myaccount` -> `apps/myaccount/java` release
- `@wso2is/identity-apps-core` -> `identity-apps-core` release

Because `@wso2is/console` was not in that output, the run published `identity-apps-core-5.4.5` and did not cut a Console release.

### Change

Adds a changeset with `"@wso2is/console": patch` so the next release run cuts a Console release.

No source changes. The fix in #10631 is contained in `identity-apps-core/react-ui-core`, which the Console does not consume.