### PR TITLE
fix(applications): fix missing error banner and scroll on empty SAML …

### DIFF
--- a/.changeset/happy-pillows-attend.md
+++ b/.changeset/happy-pillows-attend.md
@@ -1,5 +1,6 @@
 ---
 "@wso2is/admin.applications.v1": patch
+"@wso2is/console": patch
 ---
 
 Fix missing validation feedback for empty required SAML fields in the application creation wizard

--- a/.changeset/happy-pillows-attend.md
+++ b/.changeset/happy-pillows-attend.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.applications.v1": patch
+---
+
+Fix missing validation feedback for empty required SAML fields in the application creation wizard

--- a/features/admin.applications.v1/components/wizard/minimal-application-create-wizard.tsx
+++ b/features/admin.applications.v1/components/wizard/minimal-application-create-wizard.tsx
@@ -268,6 +268,7 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
     const issuerRef: MutableRefObject<HTMLDivElement> = useRef<HTMLDivElement>();
     const metaUrlRef: MutableRefObject<HTMLDivElement>  = useRef<HTMLDivElement>();
     const assertionConsumerUrlsRef: MutableRefObject<HTMLDivElement> = useRef<HTMLDivElement>();
+    const metaFileRef: MutableRefObject<HTMLDivElement> = useRef<HTMLDivElement>();
 
     // Maintain SAML configuration mode
     const [ samlConfigureMode, setSAMLConfigureMode ] = useState<string>(undefined);
@@ -783,6 +784,11 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
             {
                 assertionConsumerUrlsRef.current?.scrollIntoView(options);
                 break;
+            }
+            case "metadataFile":
+            {
+                metaFileRef.current?.scrollIntoView(options);
+                break;
             }           
         }
     };
@@ -875,6 +881,7 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
                     metaUrlRef={ metaUrlRef }
                     metaUrlError={ metaUrlError }
                     assertionConsumerUrlsRef={ assertionConsumerUrlsRef }
+                    metaFileRef={ metaFileRef }
                     onRequiredFieldMissing={ handleSAMLRequiredFieldMissing }
                     handleProtocolValueChange={ handleProtocolValueChange }
                     fields={ [ "issuer", "assertionConsumerURLs" ] }
@@ -974,13 +981,16 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
         }
     };
 
-    const handleSAMLRequiredFieldMissing = (field: string, message: string): void => {
-    setAlert({
-        description: message,
-        level: AlertLevels.ERROR,
-        message: t("applications:notifications.addApplication.error.message")
-    });
-    scrollToInValidField(field);
+    const handleSAMLRequiredFieldMissing: (field: string, message: string) => void = (
+        field: string, 
+        message: string
+    ): void => {
+        setAlert({
+            description: message,
+            level: AlertLevels.ERROR,
+            message: t("applications:notifications.addApplication.error.message")
+        });
+        scrollToInValidField(field);
     };
 
     /**

--- a/features/admin.applications.v1/components/wizard/minimal-application-create-wizard.tsx
+++ b/features/admin.applications.v1/components/wizard/minimal-application-create-wizard.tsx
@@ -267,6 +267,7 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
     const nameRef: MutableRefObject<HTMLDivElement> = useRef<HTMLDivElement>();
     const issuerRef: MutableRefObject<HTMLDivElement> = useRef<HTMLDivElement>();
     const metaUrlRef: MutableRefObject<HTMLDivElement>  = useRef<HTMLDivElement>();
+    const assertionConsumerUrlsRef: MutableRefObject<HTMLDivElement> = useRef<HTMLDivElement>();
 
     // Maintain SAML configuration mode
     const [ samlConfigureMode, setSAMLConfigureMode ] = useState<string>(undefined);
@@ -778,6 +779,11 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
 
                 break;
             }
+            case "assertionConsumerUrls":
+            {
+                assertionConsumerUrlsRef.current?.scrollIntoView(options);
+                break;
+            }           
         }
     };
 
@@ -868,6 +874,8 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
                     issuerError={ issuerError }
                     metaUrlRef={ metaUrlRef }
                     metaUrlError={ metaUrlError }
+                    assertionConsumerUrlsRef={ assertionConsumerUrlsRef }
+                    onRequiredFieldMissing={ handleSAMLRequiredFieldMissing }
                     handleProtocolValueChange={ handleProtocolValueChange }
                     fields={ [ "issuer", "assertionConsumerURLs" ] }
                     hideFieldHints={ true }
@@ -964,6 +972,15 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
                     "fetchApplications.genericError.message")
             }));
         }
+    };
+
+    const handleSAMLRequiredFieldMissing = (field: string, message: string): void => {
+    setAlert({
+        description: message,
+        level: AlertLevels.ERROR,
+        message: t("applications:notifications.addApplication.error.message")
+    });
+    scrollToInValidField(field);
     };
 
     /**

--- a/features/admin.applications.v1/components/wizard/saml-protocol-settings-all-option-wizard-form.tsx
+++ b/features/admin.applications.v1/components/wizard/saml-protocol-settings-all-option-wizard-form.tsx
@@ -78,8 +78,10 @@ interface SAMLProtocolAllSettingsWizardFormPropsInterface extends TestableCompon
     setSAMLConfigureMode?: (mode: string) => void;
     issuerRef?: any;
     metaUrlRef?: any;
+    assertionConsumerUrlsRef?: any;
     issuerError?: boolean;
     metaUrlError?: boolean;
+    onRequiredFieldMissing?: (field: string, message: string) => void;
     /**
      * Check whether the protocol form changed.
      * @param state - Protocol changed state
@@ -108,8 +110,10 @@ export const SAMLProtocolAllSettingsWizardForm: FunctionComponent<SAMLProtocolAl
         setSAMLConfigureMode,
         issuerRef,
         metaUrlRef,
+        assertionConsumerUrlsRef,
         issuerError,
         metaUrlError,
+        onRequiredFieldMissing,
         handleProtocolValueChange,
         ["data-testid"]: testId
     } = props;
@@ -408,7 +412,7 @@ export const SAMLProtocolAllSettingsWizardForm: FunctionComponent<SAMLProtocolAl
                     ) }
                     { (!fields || fields.includes("assertionConsumerURLs")) && (
                         <Grid.Row columns={ 1 }>
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 } className="field">
+                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 } className="field" ref={ assertionConsumerUrlsRef}>
                                 <URLInput
                                     urlState={ assertionConsumerUrls }
                                     setURLState={ updateAssertionConsumerUrls }
@@ -636,6 +640,10 @@ export const SAMLProtocolAllSettingsWizardForm: FunctionComponent<SAMLProtocolAl
                                 // Check whether assertionConsumer url is empty or not.
                                 if (isEmpty(assertionConsumerUrls) && isEmpty(url)) {
                                     setAssertionConsumerUrlError(true);
+                                    onRequiredFieldMissing?.(
+                                        "assertionConsumerUrls",
+                                        t("applications:forms.inboundSAML.fields.assertionURLs.validations.empty")
+                                    );
                                 } else {
                                     onSubmit(getFormValues(values, url));
                                 }
@@ -643,6 +651,10 @@ export const SAMLProtocolAllSettingsWizardForm: FunctionComponent<SAMLProtocolAl
                         } else {
                             if (configureMode === SAMLConfigModes.META_FILE && isEmpty(xmlBase64String)) {
                                 setEmptyFileError(true);
+                                onRequiredFieldMissing?.(
+                                    "metadataFile",
+                                    t("applications:forms.inboundSAML.fields.metadataFile.validations.empty")
+                                );
                             } else {
                                 onSubmit(getFormValues(values));
                             }

--- a/features/admin.applications.v1/components/wizard/saml-protocol-settings-all-option-wizard-form.tsx
+++ b/features/admin.applications.v1/components/wizard/saml-protocol-settings-all-option-wizard-form.tsx
@@ -414,122 +414,124 @@ export const SAMLProtocolAllSettingsWizardForm: FunctionComponent<SAMLProtocolAl
                     ) }
                     { (!fields || fields.includes("assertionConsumerURLs")) && (
                         <Grid.Row columns={ 1 }>
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 } className="field" ref={ assertionConsumerUrlsRef}>
-                                <URLInput
-                                    urlState={ assertionConsumerUrls }
-                                    setURLState={ updateAssertionConsumerUrls }
-                                    labelName={
-                                        t("applications:forms.inboundSAML" +
-                                            ".fields.assertionURLs.label")
-                                    }
-                                    placeholder={
-                                        t("applications:forms.inboundSAML" +
-                                            ".fields.assertionURLs.placeholder")
-                                    }
-                                    validationErrorMsg={
-                                        t("applications:forms." +
-                                            "spaProtocolSettingsWizard.fields.callBackUrls.validations.invalid")
-                                    }
-                                    emptyErrorMessage={
-                                        t("applications:forms.inboundSAML" +
-                                            ".fields.assertionURLs.validations.empty")
-                                    }
-                                    validation={ (value: string) => {
-                                        if (!(URLUtils.isURLValid(value, true) && (URLUtils.isHttpUrl(value) ||
-                                            URLUtils.isHttpsUrl(value)))) {
-
-                                            return false;
+                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 } className="field">
+                                <div ref={ assertionConsumerUrlsRef }>
+                                    <URLInput
+                                        urlState={ assertionConsumerUrls }
+                                        setURLState={ updateAssertionConsumerUrls }
+                                        labelName={
+                                            t("applications:forms.inboundSAML" +
+                                                ".fields.assertionURLs.label")
                                         }
-
-                                        if (!URLUtils.isMobileDeepLink(value)) {
-                                            return false;
+                                        placeholder={
+                                            t("applications:forms.inboundSAML" +
+                                                ".fields.assertionURLs.placeholder")
                                         }
+                                        validationErrorMsg={
+                                            t("applications:forms." +
+                                                "spaProtocolSettingsWizard.fields.callBackUrls.validations.invalid")
+                                        }
+                                        emptyErrorMessage={
+                                            t("applications:forms.inboundSAML" +
+                                                ".fields.assertionURLs.validations.empty")
+                                        }
+                                        validation={ (value: string) => {
+                                            if (!(URLUtils.isURLValid(value, true) && (URLUtils.isHttpUrl(value) ||
+                                                URLUtils.isHttpsUrl(value)))) {
 
-                                        setAssertionConsumerURLsErrorLabel(null);
-
-                                        return true;
-                                    } }
-                                    computerWidth={ 10 }
-                                    required={ true }
-                                    showError={ showAssertionConsumerUrlError }
-                                    setShowError={ setAssertionConsumerUrlError }
-                                    hint={
-                                        !hideFieldHints && t("applications:" +
-                                            "forms.inboundSAML.fields.assertionURLs.hint")
-                                    }
-                                    addURLTooltip={ t("common:addURL") }
-                                    duplicateURLErrorMessage={ t("common:duplicateURLError") }
-                                    data-testid={ `${testId}-assertion-consumer-url-input` }
-                                    getSubmit={ (submitFunction: (callback: (url?: string) => void) => void) => {
-                                        submitUrl = submitFunction;
-                                    } }
-                                    showPredictions={ false }
-                                    customLabel={ assertionConsumerURLsErrorLabel }
-                                    popupHeaderPositive={ t("applications:URLInput.withLabel."
-                                        + "positive.header") }
-                                    popupHeaderNegative={ t("applications:URLInput.withLabel."
-                                        + "negative.header") }
-                                    popupContentPositive={ t("applications:URLInput.withLabel."
-                                        + "positive.content", { productName: config.ui.productName }) }
-                                    popupContentNegative={ t("applications:URLInput.withLabel."
-                                        + "negative.content", { productName: config.ui.productName }) }
-                                    popupDetailedContentPositive={ t("applications:URLInput."
-                                        + "withLabel.positive.detailedContent.0") }
-                                    popupDetailedContentNegative={ t("applications:URLInput."
-                                        + "withLabel.negative.detailedContent.0") }
-                                    insecureURLDescription={ t("console:common.validations.inSecureURL.description") }
-                                    showLessContent={ t("common:showLess") }
-                                    showMoreContent={ t("common:showMore") }
-                                />
-                                {
-                                    (assertionConsumerURLFromTemplate) && isSAASDeployment && (
-                                        <Message
-                                            visible
-                                            type="info"
-                                            content={
-                                                (<>
-                                                    {
-                                                        <Trans
-                                                            i18nKey={ "applications:forms." +
-                                                            "inboundSAML.fields.assertionURLs.info" }
-                                                            tOptions={ {
-                                                                assertionURLFromTemplate:
-                                                                assertionConsumerURLFromTemplate
-                                                            } }
-                                                        >
-                                                            Don’t have an app? Try out a sample app
-                                                            using <strong>{ assertionConsumerURLFromTemplate }</strong>
-                                                            as the assertion Response URL.
-                                                            (You can download and run a sample
-                                                            at a later step.)
-                                                        </Trans>
-                                                    }
-                                                    {
-                                                        (assertionConsumerUrls === undefined ||
-                                                            assertionConsumerUrls === "") && (
-                                                            <LinkButton
-                                                                className={ "m-1 p-1 with-no-border orange" }
-                                                                onClick={
-                                                                    (e: React.MouseEvent<HTMLButtonElement, MouseEvent>
-                                                                    ) => {
-                                                                        e.preventDefault();
-                                                                        setAssertionConsumerUrls(
-                                                                            assertionConsumerURLFromTemplate);
-                                                                        setIssuer(issuerFromTemplate);
-                                                                        setHasAssertionConsumerUrls(true);
-                                                                    }
-                                                                }
-                                                                data-testid={ `${testId}-add-now-button` }
-                                                            >
-                                                                <span style={ { fontWeight: "bold" } }>Add Now</span>
-                                                            </LinkButton>
-                                                        )
-                                                    }
-                                                </>)
+                                                return false;
                                             }
-                                        />
-                                    )
-                                }
+
+                                            if (!URLUtils.isMobileDeepLink(value)) {
+                                                return false;
+                                            }
+
+                                            setAssertionConsumerURLsErrorLabel(null);
+
+                                            return true;
+                                        } }
+                                        computerWidth={ 10 }
+                                        required={ true }
+                                        showError={ showAssertionConsumerUrlError }
+                                        setShowError={ setAssertionConsumerUrlError }
+                                        hint={
+                                            !hideFieldHints && t("applications:" +
+                                                "forms.inboundSAML.fields.assertionURLs.hint")
+                                        }
+                                        addURLTooltip={ t("common:addURL") }
+                                        duplicateURLErrorMessage={ t("common:duplicateURLError") }
+                                        data-testid={ `${testId}-assertion-consumer-url-input` }
+                                        getSubmit={ (submitFunction: (callback: (url?: string) => void) => void) => {
+                                            submitUrl = submitFunction;
+                                        } }
+                                        showPredictions={ false }
+                                        customLabel={ assertionConsumerURLsErrorLabel }
+                                        popupHeaderPositive={ t("applications:URLInput.withLabel."
+                                            + "positive.header") }
+                                        popupHeaderNegative={ t("applications:URLInput.withLabel."
+                                            + "negative.header") }
+                                        popupContentPositive={ t("applications:URLInput.withLabel."
+                                            + "positive.content", { productName: config.ui.productName }) }
+                                        popupContentNegative={ t("applications:URLInput.withLabel."
+                                            + "negative.content", { productName: config.ui.productName }) }
+                                        popupDetailedContentPositive={ t("applications:URLInput."
+                                            + "withLabel.positive.detailedContent.0") }
+                                        popupDetailedContentNegative={ t("applications:URLInput."
+                                            + "withLabel.negative.detailedContent.0") }
+                                        insecureURLDescription={ t("console:common.validations.inSecureURL.description") }
+                                        showLessContent={ t("common:showLess") }
+                                        showMoreContent={ t("common:showMore") }
+                                    />
+                                    {
+                                        (assertionConsumerURLFromTemplate) && isSAASDeployment && (
+                                            <Message
+                                                visible
+                                                type="info"
+                                                content={
+                                                    (<>
+                                                        {
+                                                            <Trans
+                                                                i18nKey={ "applications:forms." +
+                                                                "inboundSAML.fields.assertionURLs.info" }
+                                                                tOptions={ {
+                                                                    assertionURLFromTemplate:
+                                                                    assertionConsumerURLFromTemplate
+                                                                } }
+                                                            >
+                                                                Don’t have an app? Try out a sample app
+                                                                using <strong>{ assertionConsumerURLFromTemplate }</strong>
+                                                                as the assertion Response URL.
+                                                                (You can download and run a sample
+                                                                at a later step.)
+                                                            </Trans>
+                                                        }
+                                                        {
+                                                            (assertionConsumerUrls === undefined ||
+                                                                assertionConsumerUrls === "") && (
+                                                                <LinkButton
+                                                                    className={ "m-1 p-1 with-no-border orange" }
+                                                                    onClick={
+                                                                        (e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+                                                                        ) => {
+                                                                            e.preventDefault();
+                                                                            setAssertionConsumerUrls(
+                                                                                assertionConsumerURLFromTemplate);
+                                                                            setIssuer(issuerFromTemplate);
+                                                                            setHasAssertionConsumerUrls(true);
+                                                                        }
+                                                                    }
+                                                                    data-testid={ `${testId}-add-now-button` }
+                                                                >
+                                                                    <span style={ { fontWeight: "bold" } }>Add Now</span>
+                                                                </LinkButton>
+                                                            )
+                                                        }
+                                                    </>)
+                                                }
+                                            />
+                                        )
+                                    }
+                                </div>
                             </Grid.Column>
                         </Grid.Row>
 
@@ -600,26 +602,28 @@ export const SAMLProtocolAllSettingsWizardForm: FunctionComponent<SAMLProtocolAl
         } else if (configureMode === SAMLConfigModes.META_FILE) {
             return (
                 <Grid.Row columns={ 1 }>
-                    <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 } ref={ metaFileRef }>
-                        <FilePicker
-                            key={ 1 }
-                            fileStrategy={ XML_FILE_PROCESSING_STRATEGY }
-                            file={ selectedMetadataFile }
-                            pastedContent={ pastedMetadataContent }
-                            onChange={ (result: PickerResult<any>) => {
-                                setSelectedMetadataFile(result.file);
-                                setPastedMetadataContent(result.pastedContent);
-                                setXmlBase64String(result.serialized as string);
-                            } }
-                            uploadButtonText="Upload Metadata File"
-                            dropzoneText="Drag and drop a XML file here."
-                            data-testid={ `${testId}-form-wizard-saml-xml-config-file-picker` }
-                            icon={ getCertificateIllustrations().uploadPlaceholder }
-                            placeholderIcon={ <Icon name="file code" size="huge"/> }
-                            normalizeStateOnRemoveOperations={ true }
-                            emptyFileError={ emptyFileError }
-                            hidePasteOption={ true }
-                        />
+                    <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
+                        <div ref={ metaFileRef }>
+                            <FilePicker
+                                key={ 1 }
+                                fileStrategy={ XML_FILE_PROCESSING_STRATEGY }
+                                file={ selectedMetadataFile }
+                                pastedContent={ pastedMetadataContent }
+                                onChange={ (result: PickerResult<any>) => {
+                                    setSelectedMetadataFile(result.file);
+                                    setPastedMetadataContent(result.pastedContent);
+                                    setXmlBase64String(result.serialized as string);
+                                } }
+                                uploadButtonText="Upload Metadata File"
+                                dropzoneText="Drag and drop a XML file here."
+                                data-testid={ `${testId}-form-wizard-saml-xml-config-file-picker` }
+                                icon={ getCertificateIllustrations().uploadPlaceholder }
+                                placeholderIcon={ <Icon name="file code" size="huge"/> }
+                                normalizeStateOnRemoveOperations={ true }
+                                emptyFileError={ emptyFileError }
+                                hidePasteOption={ true }
+                            />
+                        </div>
                     </Grid.Column>
                 </Grid.Row>
             );

--- a/features/admin.applications.v1/components/wizard/saml-protocol-settings-all-option-wizard-form.tsx
+++ b/features/admin.applications.v1/components/wizard/saml-protocol-settings-all-option-wizard-form.tsx
@@ -35,7 +35,7 @@ import {
 } from "@wso2is/react-components";
 import { FormValidation } from "@wso2is/validation";
 import isEmpty from "lodash-es/isEmpty";
-import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
+import React, { FunctionComponent, ReactElement, useEffect, useState, MutableRefObject } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { Button, Grid, Icon } from "semantic-ui-react";
@@ -76,9 +76,10 @@ interface SAMLProtocolAllSettingsWizardFormPropsInterface extends TestableCompon
      * @param mode - configuration mode
      */
     setSAMLConfigureMode?: (mode: string) => void;
-    issuerRef?: any;
-    metaUrlRef?: any;
-    assertionConsumerUrlsRef?: any;
+    issuerRef?: MutableRefObject<HTMLDivElement>;
+    metaUrlRef?: MutableRefObject<HTMLDivElement>;
+    assertionConsumerUrlsRef?: MutableRefObject<HTMLDivElement>;
+    metaFileRef?: MutableRefObject<HTMLDivElement>;
     issuerError?: boolean;
     metaUrlError?: boolean;
     onRequiredFieldMissing?: (field: string, message: string) => void;
@@ -111,6 +112,7 @@ export const SAMLProtocolAllSettingsWizardForm: FunctionComponent<SAMLProtocolAl
         issuerRef,
         metaUrlRef,
         assertionConsumerUrlsRef,
+        metaFileRef,
         issuerError,
         metaUrlError,
         onRequiredFieldMissing,
@@ -598,7 +600,7 @@ export const SAMLProtocolAllSettingsWizardForm: FunctionComponent<SAMLProtocolAl
         } else if (configureMode === SAMLConfigModes.META_FILE) {
             return (
                 <Grid.Row columns={ 1 }>
-                    <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
+                    <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 } ref={ metaFileRef }>
                         <FilePicker
                             key={ 1 }
                             fileStrategy={ XML_FILE_PROCESSING_STRATEGY }


### PR DESCRIPTION
### Purpose
* Fixed a validation bug in the SAML application creation wizard where leaving the Assertion Consumer URLs (ACS URLs) or the metadata file empty resulted in a silent submission failure instead of triggering validation feedback.
* Integrated `onRequiredFieldMissing` callbacks and DOM refs from `SAMLProtocolAllSettingsWizardForm` up to `MinimalAppCreateWizard`.
* Enabled the top-level wizard error banner (`useWizardAlert`) and smooth window scrolling directly to the missing field when custom SAML validations fail.

### Demo
https://github.com/user-attachments/assets/246d60c4-c49a-4d60-a6d7-eb19d3e75793

### Related Issues
- wso2/product-is#28355

### Related PRs
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [x] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [x] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.