### PR TITLE
Resolve the "Me" label by user id in the console administrators table

### DIFF
--- a/.changeset/funky-swans-dance.md
+++ b/.changeset/funky-swans-dance.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Resolve the "Me" label in Console Settings > Administrators by user id instead of username

--- a/.changeset/tricky-donkeys-attack.md
+++ b/.changeset/tricky-donkeys-attack.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.console-settings.v1": patch
+---
+
+Resolve the "Me" label in Console Settings > Administrators by user id instead of username

--- a/features/admin.console-settings.v1/components/console-administrators/administrators-list/__tests__/administrators-table.test.tsx
+++ b/features/admin.console-settings.v1/components/console-administrators/administrators-list/__tests__/administrators-table.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { UserListInterface } from "@wso2is/admin.users.v1/models/user";
+import ReduxStoreStateMock from "@wso2is/unit-testing/__mocks__/redux/redux-store-state";
+import { RenderResult, render, screen } from "@wso2is/unit-testing/utils";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import AdministratorsTable from "../administrators-table";
+import type {} from "@testing-library/jest-dom/vitest";
+
+vi.mock("@wso2is/admin.server-configurations.v1/api/server-config", () => ({
+    useServerConfigs: () => ({ data: { realmConfig: { adminUser: "root-admin" } } })
+}));
+
+vi.mock("@wso2is/admin.organizations.v1/hooks/use-get-organization-type", () => ({
+    useGetCurrentOrganizationType: () => ({
+        isFirstLevelOrganization: () => true,
+        isSubOrganization: () => false,
+        isSuperOrganization: () => false
+    })
+}));
+
+vi.mock("../../../../hooks/use-console-roles", () => ({
+    default: () => ({ consoleRoles: { Resources: [] } })
+}));
+
+/**
+ * The console administrator and the organization user share an email address but are distinct
+ * accounts, so they carry distinct user ids. This is the reported scenario.
+ */
+const CONSOLE_ADMINISTRATOR_ID: string = "3f2a1b7c-0000-4000-8000-aaaaaaaaaaaa";
+const ORGANIZATION_USER_ID: string = "9d8c7b6a-0000-4000-8000-bbbbbbbbbbbb";
+const UNLISTED_USER_ID: string = "00000000-0000-4000-8000-cccccccccccc";
+const SHARED_USERNAME: string = "PRIMARY/alex@example.com";
+
+const administrators: UserListInterface = {
+    Resources: [
+        {
+            emails: [ "alex@example.com" ],
+            id: CONSOLE_ADMINISTRATOR_ID,
+            name: {
+                familyName: "Administrator",
+                givenName: "Console"
+            },
+            roles: [],
+            userName: SHARED_USERNAME
+        },
+        {
+            emails: [ "alex@example.com" ],
+            id: ORGANIZATION_USER_ID,
+            name: {
+                familyName: "User",
+                givenName: "Organization"
+            },
+            roles: [],
+            userName: SHARED_USERNAME
+        }
+    ],
+    itemsPerPage: 10,
+    startIndex: 1,
+    totalResults: 2
+} as UserListInterface;
+
+const renderTable = (signedInUserId: string): RenderResult =>
+    render(
+        <AdministratorsTable
+            administrators={ administrators }
+            data-componentid="administrators-table"
+            isLoading={ false }
+        />,
+        {
+            initialState: {
+                ...ReduxStoreStateMock,
+                auth: {
+                    ...ReduxStoreStateMock.auth,
+                    // Both accounts share this username, so a username based comparison matches both rows.
+                    providedUsername: "alex@example.com"
+                },
+                profile: {
+                    ...ReduxStoreStateMock.profile,
+                    profileInfo: {
+                        ...ReduxStoreStateMock.profile.profileInfo,
+                        id: signedInUserId,
+                        userName: SHARED_USERNAME
+                    }
+                }
+            }
+        }
+    );
+
+/**
+ * Resolves the display name of the row that carries the "Me" label.
+ *
+ * @returns Display name of the labelled row, or null when no row is labelled.
+ */
+const resolveLabelledRowName = (): string => {
+    const labels: HTMLElement[] = screen.queryAllByText("Me");
+
+    if (labels.length !== 1) {
+        return null;
+    }
+
+    return labels[0].closest("tr")?.textContent ?? null;
+};
+
+describe("AdministratorsTable - \"Me\" label", () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("labels only the row whose user id matches the signed-in user", () => {
+        renderTable(CONSOLE_ADMINISTRATOR_ID);
+
+        expect(screen.queryAllByText("Me")).toHaveLength(1);
+        expect(resolveLabelledRowName()).toContain("Console Administrator");
+    });
+
+    it("labels the other account when it is the one signed in", () => {
+        renderTable(ORGANIZATION_USER_ID);
+
+        expect(screen.queryAllByText("Me")).toHaveLength(1);
+        expect(resolveLabelledRowName()).toContain("Organization User");
+    });
+
+    it("labels no row when the signed-in user is not listed", () => {
+        renderTable(UNLISTED_USER_ID);
+
+        expect(screen.queryByText("Me")).not.toBeInTheDocument();
+    });
+});

--- a/features/admin.console-settings.v1/components/console-administrators/administrators-list/__tests__/administrators-table.test.tsx
+++ b/features/admin.console-settings.v1/components/console-administrators/administrators-list/__tests__/administrators-table.test.tsx
@@ -77,20 +77,42 @@ const administrators: UserListInterface = {
     totalResults: 2
 } as UserListInterface;
 
-const renderTable = (signedInUserId: string): RenderResult =>
+const renderTable = (signedInUserId: string, showListItemActions: boolean = false): RenderResult =>
     render(
         <AdministratorsTable
             administrators={ administrators }
             data-componentid="administrators-table"
             isLoading={ false }
+            showListItemActions={ showListItemActions }
         />,
         {
+            allowedScopes: "internal_login internal_user_mgt_delete",
             initialState: {
                 ...ReduxStoreStateMock,
                 auth: {
                     ...ReduxStoreStateMock.auth,
+                    isPrivilegedUser: false,
                     // Both accounts share this username, so a username based comparison matches both rows.
                     providedUsername: "alex@example.com"
+                },
+                config: {
+                    ...ReduxStoreStateMock.config,
+                    ui: {
+                        ...ReduxStoreStateMock.config.ui,
+                        features: {
+                            ...ReduxStoreStateMock.config.ui.features,
+                            users: {
+                                disabledFeatures: [],
+                                enabled: true,
+                                scopes: {
+                                    create: [ "internal_user_mgt_create" ],
+                                    delete: [ "internal_user_mgt_delete" ],
+                                    read: [ "internal_user_mgt_list" ],
+                                    update: [ "internal_user_mgt_update" ]
+                                }
+                            }
+                        }
+                    }
                 },
                 profile: {
                     ...ReduxStoreStateMock.profile,
@@ -109,7 +131,7 @@ const renderTable = (signedInUserId: string): RenderResult =>
  *
  * @returns Display name of the labelled row, or null when no row is labelled.
  */
-const resolveLabelledRowName = (): string => {
+const resolveLabelledRowName = (): string | null => {
     const labels: HTMLElement[] = screen.queryAllByText("Me");
 
     if (labels.length !== 1) {
@@ -142,5 +164,15 @@ describe("AdministratorsTable - \"Me\" label", () => {
         renderTable(UNLISTED_USER_ID);
 
         expect(screen.queryByText("Me")).not.toBeInTheDocument();
+    });
+
+    it("hides the delete action only on the signed-in user's row", () => {
+        renderTable(CONSOLE_ADMINISTRATOR_ID, true);
+
+        const deleteButtons: HTMLElement[] = screen.getAllByTestId("administrators-list-item-delete-button");
+        const labelledRow: HTMLElement = screen.getByText("Me").closest("tr");
+
+        expect(deleteButtons).toHaveLength(1);
+        expect(labelledRow).not.toContainElement(deleteButtons[0]);
     });
 });

--- a/features/admin.console-settings.v1/components/console-administrators/administrators-list/administrators-table.tsx
+++ b/features/admin.console-settings.v1/components/console-administrators/administrators-list/administrators-table.tsx
@@ -34,6 +34,7 @@ import { getUserNameWithoutDomain, isFeatureEnabled } from "@wso2is/core/helpers
 import {
     FeatureAccessConfigInterface,
     IdentifiableComponentInterface,
+    ProfileInfoInterface,
     RolesInterface,
     SBACInterface
 } from "@wso2is/core/models";
@@ -181,13 +182,26 @@ const AdministratorsTable: React.FunctionComponent<AdministratorsTablePropsInter
     const featureConfig: FeatureAccessConfigInterface = useSelector((state: AppState) => {
         return state?.config?.ui?.features?.users;
     });
-    const authenticatedUser: string = useSelector((state: AppState) => state?.auth?.providedUsername);
     const isPrivilegedUser: boolean = useSelector((state: AppState) => state.auth.isPrivilegedUser);
+    const profileInfo: ProfileInfoInterface = useSelector((state: AppState) => state?.profile?.profileInfo);
     const primaryUserStoreDomainName: string = useSelector((state: AppState) =>
         state?.config?.ui?.primaryUserStoreDomainName);
 
     const hasUserUpdatePermission: boolean = useRequiredScopes(featureConfig?.scopes?.update);
     const hasUserDeletePermission: boolean = useRequiredScopes(featureConfig?.scopes?.delete);
+
+    /**
+     * Checks whether the given administrator is the user of the current session.
+     *
+     * The same table renders both the console administrators list and the organization users list, so
+     * a single email address can appear in both as two distinct accounts. Comparing usernames marks
+     * both rows as the current user; the user id identifies the session's account unambiguously.
+     *
+     * @param user - The administrator listed in a row of the table.
+     * @returns Whether the given administrator is the user of the current session.
+     */
+    const isAuthenticatedUser = (user: UserBasicInterface): boolean =>
+        !!user?.id && !!profileInfo?.id && user.id === profileInfo.id;
 
     /**
      * Returns a locked icon if the account is locked.
@@ -453,7 +467,7 @@ const AdministratorsTable: React.FunctionComponent<AdministratorsTablePropsInter
                     || readOnlyUserStores?.includes(userStore.toString())
                     || (getUserNameWithoutDomain(user?.userName) === serverConfigs?.realmConfig?.adminUser &&
                             !isSubOrganization())
-                    || authenticatedUser?.includes(getUserNameWithoutDomain(user?.userName));
+                    || isAuthenticatedUser(user);
             },
             icon: (): SemanticICONS => "trash alternate",
             onClick: (e: SyntheticEvent, user: UserBasicInterface): void => {
@@ -474,7 +488,7 @@ const AdministratorsTable: React.FunctionComponent<AdministratorsTablePropsInter
      * @returns the label indication of your own account.
      */
     const resolveMyselfLabel = (user: UserBasicInterface): ReactNode => {
-        if (authenticatedUser?.includes(getUserNameWithoutDomain(user?.userName))) {
+        if (isAuthenticatedUser(user)) {
             return (
                 <Label size="small">
                     Me


### PR DESCRIPTION
## Issue

In **Console Settings > Administrators**, the **"Me"** label was applied to a row when the signed-in
username *contained* the listed username. The same table renders both the console administrators list
and the organization users list, so when one email address exists in both as two distinct accounts,
both rows were labelled "Me" — even though only one of them can be the current session. The label did
not change depending on which of the two accounts signed in.

The same comparison guarded the delete action, so it also hid the delete button on the wrong row.

## Fix

Compare the listed user's id against the signed-in user's id (`profile.profileInfo.id`) instead of
matching username strings. The id is unique to the account of the current session, so exactly one row
can match. The listed rows already carry the id, so no extra request is needed.

## Testing

Added `administrators-table.test.tsx`: two accounts sharing a username but with different user ids.
Without the change, both rows render the label; with it, only the signed-in account's row does, and it
follows whichever account is signed in.
