### PR TITLE
Reuse an existing deployment unit session when handing off from the central region

### DIFF
--- a/.changeset/console-reuse-deployment-unit-session.md
+++ b/.changeset/console-reuse-deployment-unit-session.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Reuse an existing deployment unit session when handing off from the central region in central deployments, instead of forcing a re-authentication on every Console load.

--- a/apps/console/src/auth.html
+++ b/apps/console/src/auth.html
@@ -534,7 +534,10 @@
 
                                             authSecondary.initialize(regionalAuthConfig);
                                             if (loginTenant !== superTenantGlobal) {
-                                                authSecondary.signIn({prompt: "login",fidp: "PlatformIDP"})
+                                                // `prompt` is intentionally omitted so that an existing session at the
+                                                // deployment unit is reused. Forcing `prompt=login` here re-authenticated
+                                                // the user against the platform IdP on every console load.
+                                                authSecondary.signIn({ fidp: "PlatformIDP" });
                                             } else {
                                                 authSecondary.signIn(getAuthParams({}));
                                             }


### PR DESCRIPTION
## Issue

In a central deployment the Console signs in at the central region, then hands the user off to their deployment unit. That hand-off always requested `prompt=login`, so any existing session at the deployment unit was discarded and the user was re-authenticated against the platform IdP on every Console load.

## Fix

Drop `prompt` from the deployment unit sign-in in `apps/console/src/auth.html`, so an existing session is reused when one is present. `fidp` is kept, so a user without a session is still routed to the platform IdP exactly as before.