### PR TITLE
Fix attribute list not refreshing after adding custom SCIM attributes

### DIFF
--- a/.changeset/fix-scim2-attribute-list-refresh.md
+++ b/.changeset/fix-scim2-attribute-list-refresh.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.claims.v1": patch
+---
+
+Fix attribute list not refreshing after adding custom SCIM attributes

--- a/.changeset/fix-scim2-attribute-list-refresh.md
+++ b/.changeset/fix-scim2-attribute-list-refresh.md
@@ -1,5 +1,6 @@
 ---
 "@wso2is/admin.claims.v1": patch
+"@wso2is/console": patch
 ---
 
 Fix attribute list not refreshing after adding custom SCIM attributes

--- a/features/admin.claims.v1/components/edit/external-dialect/edit-external-claims.tsx
+++ b/features/admin.claims.v1/components/edit/external-dialect/edit-external-claims.tsx
@@ -297,11 +297,12 @@ export const EditExternalClaims: FunctionComponent<EditExternalClaimsPropsInterf
     const handleAttributesSubmit = (claims: AddExternalClaim[]): void => {
 
         setIsSubmitting(true);
+        let isDialectCreated: boolean = false;
         const resolvedDialectIDPromise: Promise<string> = dialectID
             ? Promise.resolve(dialectID)
             : addDialect(attributeUri)
                 .then(() => {
-                    updateDialects(true);
+                    isDialectCreated = true;
 
                     return getDialects({});
                 })
@@ -325,7 +326,7 @@ export const EditExternalClaims: FunctionComponent<EditExternalClaimsPropsInterf
                 });
             });
 
-            Promise.all(addAttributesRequests);
+            return Promise.all(addAttributesRequests);
         }).then(() => {
             dispatch(addAlert(
                 {
@@ -353,6 +354,9 @@ export const EditExternalClaims: FunctionComponent<EditExternalClaimsPropsInterf
                 }
             ));
         }).finally(() => {
+            if (isDialectCreated) {
+                updateDialects?.(true);
+            }
             setIsSubmitting(false);
             setShowAddExternalClaim(false);
         });

--- a/features/admin.claims.v1/pages/attribute-mappings.tsx
+++ b/features/admin.claims.v1/pages/attribute-mappings.tsx
@@ -87,7 +87,7 @@ const AttributeMappings: FunctionComponent<RouteChildrenProps<AttributeMappingsP
         const [ dialects, setDialects ] = useState<ClaimDialect[]>(null);
         const [ mappedLocalclaims, setMappedLocalClaims ] = useState<string[]>([]);
         const [ triggerFetchMappedClaims, setTriggerFetchMappedClaims ] = useState<boolean>(true);
-        const [ triigerFetchDialects, setTriggerFetchDialects ] = useState<boolean>(true);
+        const [ triggerFetchDialects, setTriggerFetchDialects ] = useState<boolean>(true);
 
         const {
             userStoresList
@@ -100,9 +100,11 @@ const AttributeMappings: FunctionComponent<RouteChildrenProps<AttributeMappingsP
         }, [ userStoresList ]);
 
         useEffect(() => {
-            getDialect();
-            setTriggerFetchDialects(false);
-        }, [ triigerFetchDialects ]);
+            if (triggerFetchDialects) {
+                getDialect();
+                setTriggerFetchDialects(false);
+            }
+        }, [ triggerFetchDialects ]);
 
         useEffect(() => {
             if ( dialects && dialects.length > 0 && triggerFetchMappedClaims ) {


### PR DESCRIPTION
### Purpose

When the SCIM2 custom dialect (`urn:scim:schemas:extension:custom:User`) does not exist yet, it is created on demand when the first custom SCIM attribute is added (introduced with #7746). However, `handleAttributesSubmit` triggers the attribute list refresh before the add-attribute requests complete (the `Promise.all` of the add requests is not returned from the chain), so a newly added attribute only appears after switching tabs.

This PR:
- Awaits the add-attribute requests and triggers the dialect list refresh only after they complete (and also on failure when the dialect was created, so a retry does not attempt to create the dialect again).
- Guards the dialect fetch `useEffect` so resetting the trigger flag does not fire a duplicate fetch, and fixes the `triigerFetchDialects` typo.

### Related Issues

- https://github.com/wso2/product-is/issues/28240

### Related PRs
- https://github.com/wso2/identity-apps/pull/7746
