### PR TITLE
Resolve the "Me" label user id from the ID token subject

### DIFF
--- a/.changeset/olive-pugs-invite.md
+++ b/.changeset/olive-pugs-invite.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/admin.console-settings.v1": patch
+"@wso2is/admin.users.v1": patch
+"@wso2is/console": patch
+---
+
+Resolve the signed-in user id for the "Me" label from the ID token subject instead of the `scim2/Me` profile

--- a/features/admin.console-settings.v1/components/console-administrators/administrators-list/__tests__/administrators-table.test.tsx
+++ b/features/admin.console-settings.v1/components/console-administrators/administrators-list/__tests__/administrators-table.test.tsx
@@ -77,7 +77,7 @@ const administrators: UserListInterface = {
     totalResults: 2
 } as UserListInterface;
 
-const renderTable = (signedInUserId: string, showListItemActions: boolean = false): RenderResult =>
+const renderTable = (signedInUserSubject: string, showListItemActions: boolean = false): RenderResult =>
     render(
         <AdministratorsTable
             administrators={ administrators }
@@ -93,7 +93,9 @@ const renderTable = (signedInUserId: string, showListItemActions: boolean = fals
                     ...ReduxStoreStateMock.auth,
                     isPrivilegedUser: false,
                     // Both accounts share this username, so a username based comparison matches both rows.
-                    providedUsername: "alex@example.com"
+                    providedUsername: "alex@example.com",
+                    // `sub` of the ID token. The Console resolves the subject to the user id.
+                    username: signedInUserSubject
                 },
                 config: {
                     ...ReduxStoreStateMock.config,
@@ -112,14 +114,6 @@ const renderTable = (signedInUserId: string, showListItemActions: boolean = fals
                                 }
                             }
                         }
-                    }
-                },
-                profile: {
-                    ...ReduxStoreStateMock.profile,
-                    profileInfo: {
-                        ...ReduxStoreStateMock.profile.profileInfo,
-                        id: signedInUserId,
-                        userName: SHARED_USERNAME
                     }
                 }
             }
@@ -155,6 +149,13 @@ describe("AdministratorsTable - \"Me\" label", () => {
 
     it("labels the other account when it is the one signed in", () => {
         renderTable(ORGANIZATION_USER_ID);
+
+        expect(screen.queryAllByText("Me")).toHaveLength(1);
+        expect(resolveLabelledRowName()).toContain("Organization User");
+    });
+
+    it("labels the signed-in user's row when the subject is qualified with the domains", () => {
+        renderTable(`PRIMARY/${ORGANIZATION_USER_ID}@carbon.super`);
 
         expect(screen.queryAllByText("Me")).toHaveLength(1);
         expect(resolveLabelledRowName()).toContain("Organization User");

--- a/features/admin.console-settings.v1/components/console-administrators/administrators-list/__tests__/administrators-table.test.tsx
+++ b/features/admin.console-settings.v1/components/console-administrators/administrators-list/__tests__/administrators-table.test.tsx
@@ -120,13 +120,22 @@ const renderTable = (signedInUserSubject: string, showListItemActions: boolean =
         }
     );
 
+const MYSELF_LABEL_COMPONENT_ID: string = "administrators-table-item-myself-label";
+
+/**
+ * Resolves the rows that carry the "Me" label.
+ *
+ * @returns The labels rendered on the table.
+ */
+const queryMyselfLabels = (): HTMLElement[] => screen.queryAllByTestId(MYSELF_LABEL_COMPONENT_ID);
+
 /**
  * Resolves the display name of the row that carries the "Me" label.
  *
  * @returns Display name of the labelled row, or null when no row is labelled.
  */
 const resolveLabelledRowName = (): string | null => {
-    const labels: HTMLElement[] = screen.queryAllByText("Me");
+    const labels: HTMLElement[] = queryMyselfLabels();
 
     if (labels.length !== 1) {
         return null;
@@ -143,35 +152,43 @@ describe("AdministratorsTable - \"Me\" label", () => {
     it("labels only the row whose user id matches the signed-in user", () => {
         renderTable(CONSOLE_ADMINISTRATOR_ID);
 
-        expect(screen.queryAllByText("Me")).toHaveLength(1);
+        expect(queryMyselfLabels()).toHaveLength(1);
+        expect(queryMyselfLabels()[0]).toHaveTextContent("Me");
         expect(resolveLabelledRowName()).toContain("Console Administrator");
     });
 
     it("labels the other account when it is the one signed in", () => {
         renderTable(ORGANIZATION_USER_ID);
 
-        expect(screen.queryAllByText("Me")).toHaveLength(1);
+        expect(queryMyselfLabels()).toHaveLength(1);
         expect(resolveLabelledRowName()).toContain("Organization User");
     });
 
     it("labels the signed-in user's row when the subject is qualified with the domains", () => {
         renderTable(`PRIMARY/${ORGANIZATION_USER_ID}@carbon.super`);
 
-        expect(screen.queryAllByText("Me")).toHaveLength(1);
+        expect(queryMyselfLabels()).toHaveLength(1);
         expect(resolveLabelledRowName()).toContain("Organization User");
+    });
+
+    it("labels no row when the subject is not a user id", () => {
+        // A deployment that leaves `useUserIdForDefaultSubject` off puts the username in the subject.
+        renderTable("PRIMARY/alex@example.com@carbon.super");
+
+        expect(queryMyselfLabels()).toHaveLength(0);
     });
 
     it("labels no row when the signed-in user is not listed", () => {
         renderTable(UNLISTED_USER_ID);
 
-        expect(screen.queryByText("Me")).not.toBeInTheDocument();
+        expect(queryMyselfLabels()).toHaveLength(0);
     });
 
     it("hides the delete action only on the signed-in user's row", () => {
         renderTable(CONSOLE_ADMINISTRATOR_ID, true);
 
         const deleteButtons: HTMLElement[] = screen.getAllByTestId("administrators-list-item-delete-button");
-        const labelledRow: HTMLElement = screen.getByText("Me").closest("tr");
+        const labelledRow: HTMLElement = queryMyselfLabels()[0].closest("tr");
 
         expect(deleteButtons).toHaveLength(1);
         expect(labelledRow).not.toContainElement(deleteButtons[0]);

--- a/features/admin.console-settings.v1/components/console-administrators/administrators-list/administrators-table.tsx
+++ b/features/admin.console-settings.v1/components/console-administrators/administrators-list/administrators-table.tsx
@@ -182,7 +182,7 @@ const AdministratorsTable: React.FunctionComponent<AdministratorsTablePropsInter
         return state?.config?.ui?.features?.users;
     });
     const isPrivilegedUser: boolean = useSelector((state: AppState) => state.auth.isPrivilegedUser);
-    const authenticatedUserSubject: string = useSelector((state: AppState) => state?.auth?.username);
+    const authenticatedUserSubject: string = useSelector((state: AppState): string => state?.auth?.username);
     const primaryUserStoreDomainName: string = useSelector((state: AppState) =>
         state?.config?.ui?.primaryUserStoreDomainName);
 
@@ -193,7 +193,7 @@ const AdministratorsTable: React.FunctionComponent<AdministratorsTablePropsInter
      * User id of the current session, resolved from the `sub` claim of the ID token.
      */
     const authenticatedUserId: string = useMemo(
-        () => UserManagementUtils.resolveUserIdFromSubject(authenticatedUserSubject),
+        (): string => UserManagementUtils.resolveUserIdFromSubject(authenticatedUserSubject),
         [ authenticatedUserSubject ]
     );
 
@@ -497,7 +497,7 @@ const AdministratorsTable: React.FunctionComponent<AdministratorsTablePropsInter
     const resolveMyselfLabel = (user: UserBasicInterface): ReactNode => {
         if (isAuthenticatedUser(user)) {
             return (
-                <Label size="small">
+                <Label data-componentid={ `${ componentId }-item-myself-label` } size="small">
                     Me
                 </Label>
             );

--- a/features/admin.console-settings.v1/components/console-administrators/administrators-list/administrators-table.tsx
+++ b/features/admin.console-settings.v1/components/console-administrators/administrators-list/administrators-table.tsx
@@ -34,7 +34,6 @@ import { getUserNameWithoutDomain, isFeatureEnabled } from "@wso2is/core/helpers
 import {
     FeatureAccessConfigInterface,
     IdentifiableComponentInterface,
-    ProfileInfoInterface,
     RolesInterface,
     SBACInterface
 } from "@wso2is/core/models";
@@ -53,7 +52,7 @@ import dayjs, { Dayjs } from "dayjs";
 import duration from "dayjs/plugin/duration";
 import relativeTime from "dayjs/plugin/relativeTime";
 import isEmpty from "lodash-es/isEmpty";
-import React, { ReactElement, ReactNode, SyntheticEvent, useState } from "react";
+import React, { ReactElement, ReactNode, SyntheticEvent, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { Header, Icon, Label, ListItemProps, SemanticICONS } from "semantic-ui-react";
@@ -183,12 +182,20 @@ const AdministratorsTable: React.FunctionComponent<AdministratorsTablePropsInter
         return state?.config?.ui?.features?.users;
     });
     const isPrivilegedUser: boolean = useSelector((state: AppState) => state.auth.isPrivilegedUser);
-    const profileInfo: ProfileInfoInterface = useSelector((state: AppState) => state?.profile?.profileInfo);
+    const authenticatedUserSubject: string = useSelector((state: AppState) => state?.auth?.username);
     const primaryUserStoreDomainName: string = useSelector((state: AppState) =>
         state?.config?.ui?.primaryUserStoreDomainName);
 
     const hasUserUpdatePermission: boolean = useRequiredScopes(featureConfig?.scopes?.update);
     const hasUserDeletePermission: boolean = useRequiredScopes(featureConfig?.scopes?.delete);
+
+    /**
+     * User id of the current session, resolved from the `sub` claim of the ID token.
+     */
+    const authenticatedUserId: string = useMemo(
+        () => UserManagementUtils.resolveUserIdFromSubject(authenticatedUserSubject),
+        [ authenticatedUserSubject ]
+    );
 
     /**
      * Checks whether the given administrator is the user of the current session.
@@ -201,7 +208,7 @@ const AdministratorsTable: React.FunctionComponent<AdministratorsTablePropsInter
      * @returns Whether the given administrator is the user of the current session.
      */
     const isAuthenticatedUser = (user: UserBasicInterface): boolean =>
-        !!user?.id && !!profileInfo?.id && user.id === profileInfo.id;
+        !!user?.id && !!authenticatedUserId && user.id === authenticatedUserId;
 
     /**
      * Returns a locked icon if the account is locked.

--- a/features/admin.users.v1/utils/user-management-utils.ts
+++ b/features/admin.users.v1/utils/user-management-utils.ts
@@ -70,20 +70,19 @@ export class UserManagementUtils {
     /**
      * Resolves the user id of the current session from the `sub` claim of the ID token.
      *
-     * The Console application is created with `useUserIdForDefaultSubject` enabled, so its `sub`
-     * claim carries the user id rather than the username. Depending on the application's subject
-     * identifier settings, that id can be qualified with the userstore domain and the tenant
-     * domain — `PRIMARY/<user-id>@carbon.super`. A user id contains neither `/` nor `@`, so
-     * dropping both qualifiers leaves the bare id. The tenant domain is taken off the last `@` so
-     * that a subject that is not a user id — an email form username, say — is left with its own
-     * `@` intact and simply fails to match any id.
+     * The Console application resolves its subject from the `http://wso2.org/claims/userid`
+     * claim, so `sub` carries the user id rather than the username. The application also includes
+     * the userstore and the tenant domains in the subject, so the id arrives qualified —
+     * `<userstore>/<user-id>@<tenant>`. The userstore prefix is omitted for `PRIMARY`. A user id
+     * contains neither `/` nor `@`, so dropping both qualifiers leaves the bare id.
      *
-     * Deriving the id from the ID token keeps the caller independent of the `scim2/Me` response,
-     * which is not fetched in organizations or in deployments that read the profile from the
-     * ID token.
+     * The tenant domain is taken off the last `@` so that a subject that is not a user id — a
+     * username, in a deployment that resolves the subject from the username claim — keeps its own
+     * `@` intact and simply fails to match any id, rather than being truncated into a value that
+     * could match the wrong row.
      *
-     * @param subject - `sub` claim of the ID token, i.e. `state.auth.username`.
-     * @returns The user id of the current session, or an empty string when it cannot be resolved.
+     * @param subject - The `sub` claim of the ID token.
+     * @returns The user id, or an empty string when it cannot be resolved.
      */
     public static resolveUserIdFromSubject = (subject: string): string => {
         if (!subject) {

--- a/features/admin.users.v1/utils/user-management-utils.ts
+++ b/features/admin.users.v1/utils/user-management-utils.ts
@@ -70,16 +70,6 @@ export class UserManagementUtils {
     /**
      * Resolves the user id of the current session from the `sub` claim of the ID token.
      *
-     * The Console application resolves its subject from the `http://wso2.org/claims/userid`
-     * claim, so `sub` carries the user id rather than the username. The application also includes
-     * the userstore and the tenant domains in the subject, so the id arrives qualified —
-     * `<userstore>/<user-id>@<tenant>`. The userstore prefix is omitted for `PRIMARY`. A user id
-     * contains neither `/` nor `@`, so dropping both qualifiers leaves the bare id.
-     *
-     * The tenant domain is taken off the last `@` so that a subject that is not a user id — a
-     * username, in a deployment that resolves the subject from the username claim — keeps its own
-     * `@` intact and simply fails to match any id, rather than being truncated into a value that
-     * could match the wrong row.
      *
      * @param subject - The `sub` claim of the ID token.
      * @returns The user id, or an empty string when it cannot be resolved.

--- a/features/admin.users.v1/utils/user-management-utils.ts
+++ b/features/admin.users.v1/utils/user-management-utils.ts
@@ -68,6 +68,35 @@ export class UserManagementUtils {
     };
 
     /**
+     * Resolves the user id of the current session from the `sub` claim of the ID token.
+     *
+     * The Console application is created with `useUserIdForDefaultSubject` enabled, so its `sub`
+     * claim carries the user id rather than the username. Depending on the application's subject
+     * identifier settings, that id can be qualified with the userstore domain and the tenant
+     * domain — `PRIMARY/<user-id>@carbon.super`. A user id contains neither `/` nor `@`, so
+     * dropping both qualifiers leaves the bare id.
+     *
+     * Deriving the id from the ID token keeps the caller independent of the `scim2/Me` response,
+     * which is not fetched in organizations or in deployments that read the profile from the
+     * ID token.
+     *
+     * @param subject - `sub` claim of the ID token, i.e. `state.auth.username`.
+     * @returns The user id of the current session, or an empty string when it cannot be resolved.
+     */
+    public static resolveUserIdFromSubject = (subject: string): string => {
+        if (!subject) {
+            return "";
+        }
+
+        const withoutUserStoreDomain: string = subject.substring(subject.lastIndexOf("/") + 1);
+        const tenantDomainSeparatorIndex: number = withoutUserStoreDomain.indexOf("@");
+
+        return tenantDomainSeparatorIndex === -1
+            ? withoutUserStoreDomain
+            : withoutUserStoreDomain.substring(0, tenantDomainSeparatorIndex);
+    };
+
+    /**
      * Checks whether administrator role is present in the user roles.
      */
     public static isAdminUser = (roles: UserRoleInterface[]): boolean => {

--- a/features/admin.users.v1/utils/user-management-utils.ts
+++ b/features/admin.users.v1/utils/user-management-utils.ts
@@ -74,7 +74,9 @@ export class UserManagementUtils {
      * claim carries the user id rather than the username. Depending on the application's subject
      * identifier settings, that id can be qualified with the userstore domain and the tenant
      * domain — `PRIMARY/<user-id>@carbon.super`. A user id contains neither `/` nor `@`, so
-     * dropping both qualifiers leaves the bare id.
+     * dropping both qualifiers leaves the bare id. The tenant domain is taken off the last `@` so
+     * that a subject that is not a user id — an email form username, say — is left with its own
+     * `@` intact and simply fails to match any id.
      *
      * Deriving the id from the ID token keeps the caller independent of the `scim2/Me` response,
      * which is not fetched in organizations or in deployments that read the profile from the
@@ -89,7 +91,7 @@ export class UserManagementUtils {
         }
 
         const withoutUserStoreDomain: string = subject.substring(subject.lastIndexOf("/") + 1);
-        const tenantDomainSeparatorIndex: number = withoutUserStoreDomain.indexOf("@");
+        const tenantDomainSeparatorIndex: number = withoutUserStoreDomain.lastIndexOf("@");
 
         return tenantDomainSeparatorIndex === -1
             ? withoutUserStoreDomain


### PR DESCRIPTION
This pull request updates how the "Me" label is resolved and displayed in the Console administrators list. Instead of relying on the user profile from the `scim2/Me` endpoint, the signed-in user's ID is now determined from the ID token's `sub` (subject) claim. This approach improves accuracy and compatibility, especially in environments where the subject may be qualified with domains or formatted differently. The pull request also updates related tests and utilities to match this new logic.

**User identification and label resolution:**
* The "Me" label is now shown for the administrator row whose user ID matches the value resolved from the ID token's `sub` claim, using the new `UserManagementUtils.resolveUserIdFromSubject` utility. (F0b62f6bL182R182, F0b62f6bL208R208, [features/admin.users.v1/utils/user-management-utils.tsR70-R89](diffhunk://#diff-e21b1aaeadfbeb423658d49ae12cd67376bdc042b4965ea365cb36d20dfe3705R70-R89))
* The Redux selector for the authenticated user now uses the `auth.username` (subject) instead of the profile info, and the user ID is derived via a `useMemo` hook. (F0b62f6bL182R182)

**Test updates and enhancements:**
* The test suite has been refactored to use the subject-based identification, including new test cases for domain-qualified subjects and cases where the subject is not a user ID. The tests now use a component ID to query the "Me" label for more robust assertions. [[1]](diffhunk://#diff-35b9420931c0030e291206671d71b8ca67050fad476baffa52e04f0264c76674L80-R80) [[2]](diffhunk://#diff-35b9420931c0030e291206671d71b8ca67050fad476baffa52e04f0264c76674L96-R98) [[3]](diffhunk://#diff-35b9420931c0030e291206671d71b8ca67050fad476baffa52e04f0264c76674L116-R138) [[4]](diffhunk://#diff-35b9420931c0030e291206671d71b8ca67050fad476baffa52e04f0264c76674L152-R191)

**Utility improvements:**
* Added `UserManagementUtils.resolveUserIdFromSubject`, which extracts the user ID from the ID token's `sub` claim, handling domain-qualified subjects and tenant suffixes.

**UI improvements:**
* The "Me" label now includes a `data-componentid` attribute for easier test selection and automation.

**Changelog:**
* A patch changelog entry has been added for the affected packages, documenting the new method for resolving the signed-in user ID.