### PR TITLE
Keep the resolved default subject identifier when no claim is configured

### DIFF
--- a/.changeset/tidy-pugs-jam.md
+++ b/.changeset/tidy-pugs-jam.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.applications.v1": patch
+"@wso2is/console": patch
+---
+
+Keep the resolved default subject identifier when no subject claim is configured

--- a/features/admin.applications.v1/components/settings/attribute-management/advance-attribute-settings.tsx
+++ b/features/admin.applications.v1/components/settings/attribute-management/advance-attribute-settings.tsx
@@ -156,7 +156,7 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
                     setSelectedSubjectValue(selectedSubjectValue);
                 }
             } else {
-                setSelectedSubjectValue(initialSubject?.claim?.uri || dropDownOptions[ 0 ]?.value);
+                setSelectedSubjectValue(initialSubject?.claim?.uri || defaultSubjectAttribute);
             }
         } else if (selectedSubjectValue) {
             if (dropDownOptions && dropDownOptions.length > 0 &&
@@ -166,7 +166,7 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
                 setSelectedSubjectValue(defaultSubjectAttribute);
             }
         } else {
-            setSelectedSubjectValue(initialSubject?.claim?.uri || dropDownOptions[ 0 ]?.value);
+            setSelectedSubjectValue(initialSubject?.claim?.uri || defaultSubjectAttribute);
         }
     }, [ dropDownOptions ]);
 
@@ -247,9 +247,11 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
     const submitValues = (values: Record<string, any>) => {
         const settingValues: {
             role: RoleInterface;
-            subject: SubjectInterface
-            oidc: OIDCDataInterface
+            subject: SubjectInterface;
+            oidc: OIDCDataInterface;
+            isSubjectClaimExplicit: boolean;
         } = {
+            isSubjectClaimExplicit: showSubjectAttribute,
             oidc: {
                 ...oidcInitialValues,
                 subject: {
@@ -293,7 +295,7 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
         // as sending an empty value for subject results in issues.
         // Ref: https://github.com/wso2/product-is/issues/19054
         if (!settingValues?.subject?.claim || settingValues?.subject?.claim === "") {
-            settingValues.subject.claim = claimConfigurations.subject.claim.uri;
+            settingValues.subject.claim = claimConfigurations?.subject?.claim?.uri ?? defaultSubjectAttribute;
         }
 
         // Preserve the configured role claim URI when the resolved value is empty, as the User Attributes tab does
@@ -340,12 +342,23 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
     };
 
     /**
+     * This function resolves the hidden status of the include user domain and include tenant domain options.
+     * @returns The hidden status.
+     */
+    const resolveIncludeDomainOptionsHiddenStatus = (): boolean => {
+        return !applicationConfig.attributeSettings.advancedAttributeSettings.showSubjectAttribute ||
+                (onlyOIDCConfigured && !showSubjectAttribute) ||
+                isEmpty(dropDownOptions)
+        ;
+    };
+
+    /**
      * This function resolves the hidden status of the subject attribute section.
      * @returns The hidden status.
      */
     const resolveSubjectAttributeHiddenStatus = (): boolean => {
         return !applicationConfig.attributeSettings.advancedAttributeSettings.showSubjectAttribute ||
-                (onlyOIDCConfigured && !showSubjectAttribute)
+                ((onlyOIDCConfigured || !claimConfigurations?.subject?.claim?.uri) && !showSubjectAttribute)
         ;
     };
 
@@ -473,7 +486,7 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
                                     </Grid.Column>
                                 </Grid.Row>
                             ) }
-                            { (onlyOIDCConfigured &&
+                            { ((onlyOIDCConfigured || !claimConfigurations?.subject?.claim?.uri) &&
                                 !disabledFeatures?.includes(
                                     "applications.attributes.alternativeSubjectIdentifier")) && (
                                 <Grid.Row columns={ 1 }>
@@ -548,7 +561,8 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
                             }
                             {
                                 !(disabledFeatures?.includes("applications.attributes" +
-                                        ".alternativeSubjectIdentifier") || resolveDropDownHiddenStatus()) && (
+                                        ".alternativeSubjectIdentifier") ||
+                                    resolveIncludeDomainOptionsHiddenStatus()) && (
                                     <Grid.Row
                                         columns={ 1 }
                                         data-componentid="application-edit-user-attributes-include-user-domain"
@@ -576,7 +590,8 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
                             }
                             {
                                 !(disabledFeatures?.includes("applications.attributes" +
-                                    ".alternativeSubjectIdentifier") || resolveDropDownHiddenStatus()) && (
+                                    ".alternativeSubjectIdentifier") ||
+                                    resolveIncludeDomainOptionsHiddenStatus()) && (
                                     <Grid.Row
                                         columns={ 1 }
                                         data-componentid="application-edit-user-attributes-include-tenant-domain"

--- a/features/admin.applications.v1/components/settings/attribute-management/attribute-settings.tsx
+++ b/features/admin.applications.v1/components/settings/attribute-management/attribute-settings.tsx
@@ -92,7 +92,8 @@ export interface ExtendedExternalClaimInterface extends ExternalClaim {
 interface AdvanceSettingsSubmissionInterface {
     subject: SubjectConfigInterface;
     role: RoleConfigInterface;
-    oidc: OIDCDataInterface
+    oidc: OIDCDataInterface;
+    isSubjectClaimExplicit?: boolean;
 }
 
 interface AttributeSettingsPropsInterface extends SBACInterface<FeatureConfigInterface>,
@@ -1139,6 +1140,10 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
         const RequestedClaims: RequestedClaimConfigurationInterface[] = [];
         const subjectClaim: AppClaimInterface = advanceSettingValues?.subject?.claim;
 
+        const isSubjectClaimOmitted: boolean = !onlyOIDCConfigured
+            && !claimConfigurations?.subject?.claim?.uri
+            && !advanceSettingValues?.isSubjectClaimExplicit;
+
         if (selectedDialect.localDialect) {
             selectedClaims.map((claim: ExtendedClaimInterface) => {
                 // If claim mapping is there then check whether claim is requested or not.
@@ -1198,7 +1203,7 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
             isSubjectSelectedWithoutMapping = true;
         }
 
-        if (claimMappingFinal.length > 0 && isSubjectSelectedWithoutMapping) {
+        if (claimMappingFinal.length > 0 && isSubjectSelectedWithoutMapping && !isSubjectClaimOmitted) {
             const claimMappedObject: ExtendedClaimMappingInterface = {
                 applicationClaim: DefaultSubjectAttribute,
                 localClaim: {
@@ -1247,6 +1252,10 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
         // Stop sending subject claim for OIDC applications based on the excludeSubjectClaim configuration.
         if (applicationConfig.excludeSubjectClaim && onlyOIDCConfigured) {
             delete submitValue.claimConfiguration.subject;
+        }
+
+        if (isSubjectClaimOmitted) {
+            delete submitValue.claimConfiguration.subject.claim;
         }
 
         // Stop sending tokenEndpointAllowReusePvtKeyJwt if tokenEndpointAuthMethod is not PRIVATE_KEY_JWT.


### PR DESCRIPTION
## Purpose
Applications with no subject claim URI configured (including applications migrated from older versions) had no way to represent "no subject claim configured" in the User Attributes tab. The UI fell back to an arbitrary dropdown value, which then got persisted as a concrete claim on the next update, overriding the server-resolved default subject identifier and marking that claim as mandatory.

## Related Issue
- https://github.com/wso2/product-is/issues/28334

## Implementation
- `advance-attribute-settings.tsx`
  - Subject value initialization now falls back to `defaultSubjectAttribute` instead of the first dropdown option.
  - Reused the existing "Assign alternate subject identifier" checkbox for any application with no subject claim URI configured, so the dropdown stays hidden by default instead of pre-selecting a value.
  - Added `resolveIncludeDomainOptionsHiddenStatus()` so the include user store domain / include tenant domain options remain visible and editable independent of that checkbox.
  - `submitValues` now reports `isSubjectClaimExplicit` (the checkbox state) to the parent, and the empty-claim fallback uses `claimConfigurations?.subject?.claim?.uri ?? defaultSubjectAttribute`.
- `attribute-settings.tsx`
  - `AdvanceSettingsSubmissionInterface` accepts the optional `isSubjectClaimExplicit` flag.
  - When the checkbox is left unticked for an application with no configured subject claim, the subject claim is omitted from the update payload and the implicit `DefaultSubjectAttribute` claim mapping is no longer injected, so the server-resolved default subject stays in effect. Explicitly picking an attribute persists that choice as before.