### PR TITLE
Add proxy_context_path support for console and myaccount apps

### DIFF
--- a/.changeset/proxy-context-path-support.md
+++ b/.changeset/proxy-context-path-support.md
@@ -1,0 +1,12 @@
+---
+"@wso2is/admin.branding.v1": patch
+"@wso2is/admin.connections.v1": patch
+"@wso2is/admin.core.v1": patch
+"@wso2is/admin.extensions.v1": patch
+"@wso2is/admin.onboarding.v1": patch
+"@wso2is/admin.server-configurations.v1": patch
+"@wso2is/console": patch
+"@wso2is/myaccount": patch
+---
+
+Add proxy_context_path support for console and myaccount apps

--- a/apps/console/scripts/build/assemble-vite-build.js
+++ b/apps/console/scripts/build/assemble-vite-build.js
@@ -35,6 +35,34 @@ const deploymentConfig = fs.readJsonSync(deploymentConfigPath);
 const themeName = deploymentConfig?.ui?.theme?.name || "default";
 const buildMode = resolveBuildMode(process.env);
 
+/**
+ * JSP scriptlet that resolves the externally visible proxy context path at request time.
+ */
+const PROXY_CONTEXT_PATH_SCRIPTLET = [
+    "<%",
+    "    String resolvedProxyContextPath = ServerConfiguration.getInstance().getFirstProperty(PROXY_CONTEXT_PATH);",
+    "    String proxyContextPathPrefix = StringUtils.isNotBlank(resolvedProxyContextPath) ? \"/\" + resolvedProxyContextPath : \"\";",
+    "%>"
+].join("\n");
+
+/**
+ * JSP expression that renders the resolved proxy context path prefix (empty when unset).
+ */
+const PROXY_CONTEXT_PATH_EXPRESSION = "<%=proxyContextPathPrefix%>";
+
+/**
+ * Resolve the public base path used by the deployed shells.
+ *
+ * @returns {string} Public base path, optionally prefixed with a JSP expression.
+ */
+function resolveRuntimePublicBase() {
+    if (buildMode.isExternalTomcat || (buildMode.isStatic && buildMode.isPreAuthCheckEnabled)) {
+        return buildMode.publicBase;
+    }
+
+    return `${PROXY_CONTEXT_PATH_EXPRESSION}${buildMode.publicBase}`;
+}
+
 const buildRoot = path.resolve(appRoot, "build", "console");
 const appBuildRoot = path.resolve(buildRoot, buildMode.isStatic && buildMode.isPreAuthCheckEnabled
     ? buildMode.appBasePath
@@ -636,7 +664,7 @@ function buildTemplateOptions() {
     const basename = buildMode.isStatic && buildMode.isPreAuthCheckEnabled
         ? buildMode.appBasePath
         : "console";
-    const publicPath = buildMode.publicBase;
+    const publicPath = resolveRuntimePublicBase();
     const themeHash = resolveThemeHash(themeName);
     const isExternalTomcat = buildMode.isExternalTomcat;
 
@@ -694,6 +722,9 @@ function buildTemplateOptions() {
             : "",
         proxyContextPathConstant: !isExternalTomcat
             ? "<%@ page import=\"static org.wso2.carbon.identity.core.util.IdentityCoreConstants.PROXY_CONTEXT_PATH\" %>"
+            : "",
+        proxyContextPathScriptlet: !isExternalTomcat
+            ? PROXY_CONTEXT_PATH_SCRIPTLET
             : "",
         publicPath,
         requestForwardSnippet: "if(request.getParameter(\"code\") != null && !request.getParameter(\"code\").trim().isEmpty()) {request.getRequestDispatcher(\"/authenticate?code=\"+request.getParameter(\"code\")+\"&AuthenticatedIdPs=\"+request.getParameter(\"AuthenticatedIdPs\")+\"&session_state=\"+request.getParameter(\"session_state\")).forward(request, response);}",
@@ -784,7 +815,7 @@ function renderShellFiles() {
     }
 
     const manifest = fs.readJsonSync(manifestPath);
-    const entryTags = buildEntryTags(manifest, "src/init/vite-entry.ts", buildMode.publicBase);
+    const entryTags = buildEntryTags(manifest, "src/init/vite-entry.ts", resolveRuntimePublicBase());
 
     if (buildMode.isStatic && buildMode.isPreAuthCheckEnabled) {
         renderTemplateToFile("auth.html", path.resolve(buildRoot, "index.html"), templateOptions);

--- a/apps/console/src/app.tsx
+++ b/apps/console/src/app.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -220,7 +220,8 @@ const App = ({
         // mirroring how the branding subsystem builds its theme asset prefix. Avoids depending on
         // window.publicPath, which is not set in the Console runtime.
         const clientOrigin: string = (window[ "AppUtils" ]?.getConfig()?.clientOrigin ?? "").replace(/\/+$/, "");
-        const appBase: string = (window[ "AppUtils" ]?.getConfig()?.appBase ?? "").replace(/^\/+|\/+$/g, "");
+        const appBase: string = (window[ "AppUtils" ]?.getConfig()?.appBaseWithProxy ?? "")
+            .replace(/^\/+|\/+$/g, "");
         const themePrefix: string = `${ clientOrigin }${ appBase ? "/" + appBase : "" }/libs/themes/${ theme }`;
 
         return resolveAppLogoFilePath(appFaviconPath, themePrefix);

--- a/apps/console/src/home.jsp
+++ b/apps/console/src/home.jsp
@@ -1,11 +1,20 @@
-<!--
-~    Copyright (c) 2022-2025, WSO2 Inc. (http://www.wso2.com). All Rights Reserved.
-~
-~    This software is the property of WSO2 Inc. and its suppliers, if any.
-~    Dissemination of any information or reproduction of any material contained
-~    herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
-~    You may not alter or remove any copyright or other notice from copies of this content."
--->
+<%--
+  ~ Copyright (c) 2022-2026, WSO2 LLC. (https://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+--%>
 
 <%= buildOptions.serverConfiguration %>
 <%= buildOptions.proxyContextPathConstant %>
@@ -19,6 +28,8 @@
 <%= buildOptions.cookieproEnabledFlag %>
 <%= buildOptions.cookieproInitialScriptTypeCheck %>
 <%= buildOptions.cookieproDomainScriptId %>
+
+<%= buildOptions.proxyContextPathScriptlet %>
 
 <jsp:scriptlet>
     session.setAttribute("authCode",request.getParameter("code"));

--- a/apps/console/src/index.jsp
+++ b/apps/console/src/index.jsp
@@ -1,11 +1,20 @@
-<!--
-~    Copyright (c) 2022-2025, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
-~
-~    This software is the property of WSO2 LLC. and its suppliers, if any.
-~    Dissemination of any information or reproduction of any material contained
-~    herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
-~    You may not alter or remove any copyright or other notice from copies of this content."
--->
+<%--
+  ~ Copyright (c) 2022-2026, WSO2 LLC. (https://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+--%>
 
 <%= buildOptions.contentType %>
 <%= buildOptions.serverConfiguration %>
@@ -14,6 +23,9 @@
 <%= buildOptions.importIdentityTenantUtil %>
 <%= buildOptions.importOwaspEncode %>
 <%= buildOptions.importIsSuperTenantRequiredInUrl %>
+<%= buildOptions.importStringUtils %>
+
+<%= buildOptions.proxyContextPathScriptlet %>
 
 <script>
     var userAccessedPath = window.location.href;
@@ -140,7 +152,7 @@
             }
         </style>
         <script
-            src="/<%= buildOptions.basename + '/' %>startup-config.js"
+            src="<%= buildOptions.publicPath %>startup-config.js"
         ></script>
 
         <!-- Start of custom stylesheets -->
@@ -425,7 +437,7 @@
     <script>
         if(!authorizationCode) {
             var authSPAJS = document.createElement("script");
-            var authScriptSrc = "<%= '/' + buildOptions.basename + '/auth-spa-3.1.2.min.js' %>";
+            var authScriptSrc = "<%= buildOptions.publicPath %>auth-spa-3.1.2.min.js";
 
             authSPAJS.setAttribute("src", authScriptSrc);
             authSPAJS.setAttribute("async", "false");

--- a/apps/console/src/init/app-utils.ts
+++ b/apps/console/src/init/app-utils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2020-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -148,6 +148,23 @@ export const AppUtils: any = (function() {
         },
 
         /**
+         * Get the app base prefixed with the proxy context path, without any tenant or
+         * organization segment.
+         *
+         * @returns App base with the proxy context path applied.
+         */
+        getAppBaseWithProxyContextPath: function() {
+            const proxyContextPath: string = this.getProxyContextPath();
+            const appBaseName: string = _config.appBaseName || "";
+
+            if (!proxyContextPath) {
+                return appBaseName;
+            }
+
+            return appBaseName ? `${proxyContextPath}/${appBaseName}` : proxyContextPath;
+        },
+
+        /**
          * Get app base with the tenant domain.
          *
          * @returns App base with tenant.
@@ -242,6 +259,7 @@ export const AppUtils: any = (function() {
                 },
                 allowMultipleAppProtocols: allowMultipleAppProtocol,
                 appBase: _config.appBaseName,
+                appBaseWithProxy: this.getAppBaseWithProxyContextPath(),
                 appBaseNameForHistoryAPI: this.constructAppBaseNameForHistoryAPI(),
                 appBaseWithTenant: this.getAppBaseWithTenantAndOrganization(),
                 centralDeploymentEnabled: _config.centralDeploymentEnabled,

--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -551,7 +551,10 @@ export default defineConfig(({ mode }: { mode: string }) => {
     const environment: Record<string, string> = loadEnv(mode, __dirname, "");
     const buildMode: ReturnType<typeof resolveBuildMode> = resolveBuildMode(environment);
     const isDevelopment: boolean = mode !== "production";
-    const publicBasePath: string = isDevelopment ? "/" : buildMode.publicBase;
+    // Relative base keeps built asset/chunk URLs anchored to the importing module
+    // (`import.meta.url`), so the app works under any externally visible prefix
+    // (e.g. a `proxy_context_path`) without the base being baked in at build time.
+    const publicBasePath: string = isDevelopment ? "/" : "./";
     const metaHash: string = resolveMetaHash();
     const devServerPort: number = Number(environment.DEV_SERVER_PORT || 9001);
     const devServerHost: string = environment.DEV_SERVER_HOST || "localhost";

--- a/apps/myaccount/scripts/build/assemble-vite-build.js
+++ b/apps/myaccount/scripts/build/assemble-vite-build.js
@@ -35,6 +35,34 @@ const deploymentConfig = fs.readJsonSync(deploymentConfigPath);
 const themeName = deploymentConfig?.ui?.theme?.name || "default";
 const buildMode = resolveBuildMode(process.env);
 
+/**
+ * JSP scriptlet that resolves the externally visible proxy context path at request time.
+ */
+const PROXY_CONTEXT_PATH_SCRIPTLET = [
+    "<%",
+    "    String resolvedProxyContextPath = ServerConfiguration.getInstance().getFirstProperty(PROXY_CONTEXT_PATH);",
+    "    String proxyContextPathPrefix = StringUtils.isNotBlank(resolvedProxyContextPath) ? \"/\" + resolvedProxyContextPath : \"\";",
+    "%>"
+].join("\n");
+
+/**
+ * JSP expression that renders the resolved proxy context path prefix (empty when unset).
+ */
+const PROXY_CONTEXT_PATH_EXPRESSION = "<%=proxyContextPathPrefix%>";
+
+/**
+ * Resolve the public base path used by the deployed shells.
+ *
+ * @returns {string} Public base path, optionally prefixed with a JSP expression.
+ */
+function resolveRuntimePublicBase() {
+    if (buildMode.isExternalTomcat || (buildMode.isStatic && buildMode.isPreAuthCheckEnabled)) {
+        return buildMode.publicBase;
+    }
+
+    return `${PROXY_CONTEXT_PATH_EXPRESSION}${buildMode.publicBase}`;
+}
+
 const buildRoot = path.resolve(appRoot, "build", "myaccount");
 const appBuildRoot = path.resolve(buildRoot, buildMode.isStatic && buildMode.isPreAuthCheckEnabled
     ? buildMode.appBasePath
@@ -551,7 +579,7 @@ function buildTemplateOptions() {
     const basename = buildMode.isStatic && buildMode.isPreAuthCheckEnabled
         ? buildMode.appBasePath
         : "myaccount";
-    const publicPath = buildMode.publicBase;
+    const publicPath = resolveRuntimePublicBase();
     const themeHash = resolveThemeHash(themeName);
     const rtlThemeHash = resolveRtlThemeHash(themeName);
     const isExternalTomcat = buildMode.isExternalTomcat;
@@ -609,6 +637,9 @@ function buildTemplateOptions() {
             : "",
         proxyContextPathConstant: !isExternalTomcat
             ? "<%@ page import=\"static org.wso2.carbon.identity.core.util.IdentityCoreConstants.PROXY_CONTEXT_PATH\" %>"
+            : "",
+        proxyContextPathScriptlet: !isExternalTomcat
+            ? PROXY_CONTEXT_PATH_SCRIPTLET
             : "",
         publicPath,
         requestForwardSnippet: "if(request.getParameter(\"code\") != null && !request.getParameter(\"code\").trim().isEmpty()) {request.getRequestDispatcher(\"/authenticate?code=\"+request.getParameter(\"code\")+\"&AuthenticatedIdPs=\"+request.getParameter(\"AuthenticatedIdPs\")+\"&session_state=\"+request.getParameter(\"session_state\")).forward(request, response);}",
@@ -684,7 +715,7 @@ function renderShellFiles() {
     }
 
     const manifest = fs.readJsonSync(manifestPath);
-    const entryTags = buildEntryTags(manifest, "src/init/vite-entry.ts", buildMode.publicBase);
+    const entryTags = buildEntryTags(manifest, "src/init/vite-entry.ts", resolveRuntimePublicBase());
 
     if (buildMode.isStatic && buildMode.isPreAuthCheckEnabled) {
         renderTemplateToFile("auth.html", path.resolve(buildRoot, "index.html"), templateOptions);

--- a/apps/myaccount/src/components/shared/header.tsx
+++ b/apps/myaccount/src/components/shared/header.tsx
@@ -442,11 +442,11 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
                                         }/` +
                                         `${ StringUtils.removeSlashesFromPath(
                                             window[ "AppUtils" ].getConfig()
-                                                .appBase
+                                                .appBaseWithProxy
                                         ) !== ""
                                             ? StringUtils.removeSlashesFromPath(
                                                 window[ "AppUtils" ].getConfig()
-                                                    .appBase
+                                                    .appBaseWithProxy
                                             ) + "/"
                                             : ""
                                         }libs/themes/` +
@@ -466,11 +466,11 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
                                         }/` +
                                         `${ StringUtils.removeSlashesFromPath(
                                             window[ "AppUtils" ].getConfig()
-                                                .appBase
+                                                .appBaseWithProxy
                                         ) !== ""
                                             ? StringUtils.removeSlashesFromPath(
                                                 window[ "AppUtils" ].getConfig()
-                                                    .appBase
+                                                    .appBaseWithProxy
                                             ) + "/"
                                             : ""
                                         }libs/themes/` +

--- a/apps/myaccount/src/components/shared/pre-loader/pre-loader.tsx
+++ b/apps/myaccount/src/components/shared/pre-loader/pre-loader.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -81,11 +81,11 @@ export const PreLoader: FunctionComponent<PreLoaderPropsInterface> = (
             }/` +
             `${ StringUtils.removeSlashesFromPath(
                 window[ "AppUtils" ].getConfig()
-                    .appBase
+                    .appBaseWithProxy
             ) !== ""
                 ? StringUtils.removeSlashesFromPath(
                     window[ "AppUtils" ].getConfig()
-                        .appBase
+                        .appBaseWithProxy
                 ) + "/"
                 : ""
             }libs/themes/wso2is`

--- a/apps/myaccount/src/configs/app.ts
+++ b/apps/myaccount/src/configs/app.ts
@@ -51,7 +51,7 @@ export class Config {
         return {
             __experimental__platformIdP: window[ "AppUtils" ]?.getConfig()?.__experimental__platformIdP,
             appBaseName: window["AppUtils"]?.getConfig()?.appBaseWithTenant,
-            appBaseNameWithoutTenant: window["AppUtils"]?.getConfig()?.appBase,
+            appBaseNameWithoutTenant: window["AppUtils"]?.getConfig()?.appBaseWithProxy,
             appHomePath: window["AppUtils"]?.getConfig()?.routes?.home,
             appLoginPath: window["AppUtils"]?.getConfig()?.routes?.login,
             appLogoutPath: window["AppUtils"]?.getConfig()?.routes?.logout,
@@ -209,7 +209,7 @@ export class Config {
                     generateBackendPaths(
                         language,
                         namespace,
-                        window["AppUtils"]?.getConfig()?.appBase,
+                        window["AppUtils"]?.getConfig()?.appBaseWithProxy,
                         store?.getState()?.config?.i18n ?? {
                             langAutoDetectEnabled: I18nConstants.LANG_AUTO_DETECT_ENABLED,
                             namespaceDirectories: I18nConstants.BUNDLE_NAMESPACE_DIRECTORIES,

--- a/apps/myaccount/src/constants/app-constants.ts
+++ b/apps/myaccount/src/constants/app-constants.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2019-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -77,7 +77,7 @@ export class AppConstants {
      * @returns The app base name.
      */
     public static getAppBasename(): string {
-        return window["AppUtils"].getConfig().appBase;
+        return window["AppUtils"].getConfig().appBaseWithProxy;
     }
 
     /**

--- a/apps/myaccount/src/home.jsp
+++ b/apps/myaccount/src/home.jsp
@@ -1,11 +1,20 @@
-<!--
-~    Copyright (c) 2022-2025, WSO2 Inc. (http://www.wso2.com). All Rights Reserved.
-~
-~    This software is the property of WSO2 Inc. and its suppliers, if any.
-~    Dissemination of any information or reproduction of any material contained
-~    herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
-~    You may not alter or remove any copyright or other notice from copies of this content."
--->
+<%--
+  ~ Copyright (c) 2022-2026, WSO2 LLC. (https://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+--%>
 
 <%= buildOptions.serverConfiguration %>
 <%= buildOptions.proxyContextPathConstant %>
@@ -19,6 +28,8 @@
 <%= buildOptions.cookieproEnabledFlag %>
 <%= buildOptions.cookieproInitialScriptTypeCheck %>
 <%= buildOptions.cookieproDomainScriptId %>
+
+<%= buildOptions.proxyContextPathScriptlet %>
 
 <jsp:scriptlet>
     session.setAttribute("authCode",request.getParameter("code"));

--- a/apps/myaccount/src/index.jsp
+++ b/apps/myaccount/src/index.jsp
@@ -1,11 +1,20 @@
-<!--
-~    Copyright (c) 2022-2025, WSO2 Inc. (http://www.wso2.com). All Rights Reserved.
-~
-~    This software is the property of WSO2 Inc. and its suppliers, if any.
-~    Dissemination of any information or reproduction of any material contained
-~    herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
-~    You may not alter or remove any copyright or other notice from copies of this content."
--->
+<%--
+  ~ Copyright (c) 2022-2026, WSO2 LLC. (https://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+--%>
 
 <%= buildOptions.contentType %>
 <%= buildOptions.serverConfiguration %>
@@ -14,6 +23,9 @@
 <%= buildOptions.importIdentityTenantUtil %>
 <%= buildOptions.importOwaspEncode %>
 <%= buildOptions.importIsSuperTenantRequiredInUrl %>
+<%= buildOptions.importStringUtils %>
+
+<%= buildOptions.proxyContextPathScriptlet %>
 
 <script>
     var userAccessedPath = window.location.href;
@@ -148,7 +160,7 @@
                 animation-iteration-count: infinite;
             }
         </style>
-        <script src="/<%= buildOptions.basename ? buildOptions.basename + '/' : '' %>startup-config.js"></script>
+        <script src="<%= buildOptions.publicPath %>startup-config.js"></script>
         <script>
             var userAccessedPath = window.location.href;
             var userTenant = userAccessedPath.split("/" + startupConfig.tenantPrefix + "/")[1] ?  userAccessedPath.split("/" + startupConfig.tenantPrefix + "/")[1].split("/")[0] : null;
@@ -419,7 +431,7 @@
     <script>
         if (!authorizationCode) {
             var authSPAJS = document.createElement("script");
-            var authScriptSrc = "<%= buildOptions.basename ? '/' + buildOptions.basename + '/auth-spa-3.1.2.min.js' : '/auth-spa-3.1.2.min.js'%>";
+            var authScriptSrc = "<%= buildOptions.publicPath %>auth-spa-3.1.2.min.js";
 
             authSPAJS.setAttribute("src", authScriptSrc);
             authSPAJS.setAttribute("async", "false");

--- a/apps/myaccount/src/init/app-utils.ts
+++ b/apps/myaccount/src/init/app-utils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2020-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -143,6 +143,23 @@ export const AppUtils: AppUtilsInterface = (function() {
         },
 
         /**
+         * Get the app base prefixed with the proxy context path, without any tenant or
+         * organization segment.
+         *
+         * @returns App base with the proxy context path applied.
+         */
+        getAppBaseWithProxyContextPath: function() {
+            const proxyContextPath: string = this.getProxyContextPath();
+            const appBaseName: string = _config.appBaseName || "";
+
+            if (!proxyContextPath) {
+                return appBaseName;
+            }
+
+            return appBaseName ? `${proxyContextPath}/${appBaseName}` : proxyContextPath;
+        },
+
+        /**
          * Get app base with the tenant domain.
          *
          * @returns App base with tenant.
@@ -213,6 +230,7 @@ export const AppUtils: AppUtilsInterface = (function() {
             return {
                 __experimental__platformIdP: _config.__experimental__platformIdP,
                 appBase: _config.appBaseName,
+                appBaseWithProxy: this.getAppBaseWithProxyContextPath(),
                 appBaseNameForHistoryAPI: this.constructAppBaseNameForHistoryAPI(),
                 appBaseWithTenant: this.getAppBaseWithTenantAndOrganization(),
                 clientID: this.getClientId(),

--- a/apps/myaccount/vite.config.ts
+++ b/apps/myaccount/vite.config.ts
@@ -484,7 +484,10 @@ export default defineConfig(({ mode }: { mode: string }) => {
     const environment: Record<string, string> = loadEnv(mode, __dirname, "");
     const buildMode: ReturnType<typeof resolveBuildMode> = resolveBuildMode(environment);
     const isDevelopment: boolean = mode !== "production";
-    const publicBasePath: string = isDevelopment ? "/" : buildMode.publicBase;
+    // Relative base keeps built asset/chunk URLs anchored to the importing module
+    // (`import.meta.url`), so the app works under any externally visible prefix
+    // (e.g. a `proxy_context_path`) without the base being baked in at build time.
+    const publicBasePath: string = isDevelopment ? "/" : "./";
     const devServerPort: number = Number(environment.DEV_SERVER_PORT || 9000);
     const devServerHost: string = environment.DEV_SERVER_HOST || "localhost";
     const devServerWebSocketHost: string = environment.WDS_SOCKET_HOST || devServerHost;

--- a/features/admin.branding.v1/meta/branding-preference-meta.ts
+++ b/features/admin.branding.v1/meta/branding-preference-meta.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2021-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -73,10 +73,10 @@ export class BrandingPreferenceMeta {
         const getAbsoluteLogoPath = (logo: string) => {
             return resolveAppLogoFilePath(logo, `${ window[ "AppUtils" ].getConfig().clientOrigin }/${
                 StringUtils.removeSlashesFromPath(
-                    window[ "AppUtils" ].getConfig().appBase
+                    window[ "AppUtils" ].getConfig().appBaseWithProxy
                 ) !== ""
                     ? StringUtils.removeSlashesFromPath(
-                        window[ "AppUtils" ].getConfig().appBase
+                        window[ "AppUtils" ].getConfig().appBaseWithProxy
                     ) + "/"
                     : ""
             }libs/themes/${systemTheme}`);

--- a/features/admin.connections.v1/api/authenticators.ts
+++ b/features/admin.connections.v1/api/authenticators.ts
@@ -431,7 +431,7 @@ export const updateFederatedAuthenticators = (
             "Content-Type": "application/json"
         },
         method: HttpMethods.PUT,
-        url: store.getState().config.endpoints.identityProviders + "/" + idpId + "/federated-authenticators/"
+        url: store.getState().config.endpoints.identityProviders + "/" + idpId + "/federated-authenticators"
     };
 
     return httpClient(requestConfig)

--- a/features/admin.connections.v1/api/connections.ts
+++ b/features/admin.connections.v1/api/connections.ts
@@ -340,7 +340,7 @@ const useGetConnectionConnectedApps = <Data = ConnectedAppsInterface, Error = Re
             "Content-Type": "application/json"
         },
         method: HttpMethods.GET,
-        url: resourceEndpoints.identityProviders + "/" + idpId + "/connected-apps/"
+        url: resourceEndpoints.identityProviders + "/" + idpId + "/connected-apps"
     };
 
     const { data, error, isValidating, mutate } = useRequest<Data, Error>(requestConfig);
@@ -857,7 +857,7 @@ export const getConnectedApps = (
             limit,
             offset
         },
-        url: store.getState().config.endpoints.identityProviders + "/" + idpId + "/connected-apps/"
+        url: store.getState().config.endpoints.identityProviders + "/" + idpId + "/connected-apps"
     };
 
     return httpClient(requestConfig)
@@ -890,7 +890,7 @@ export const getConnectedAppsOfAuthenticator = (authenticatorId: string): Promis
             "Content-Type": "application/json"
         },
         method: HttpMethods.GET,
-        url: store.getState().config.endpoints.authenticators + "/" + authenticatorId + "/connected-apps/"
+        url: store.getState().config.endpoints.authenticators + "/" + authenticatorId + "/connected-apps"
     };
 
     return httpClient(requestConfig)
@@ -1034,7 +1034,7 @@ const updateFederatedAuthenticators = (
             "Content-Type": "application/json"
         },
         method: HttpMethods.PUT,
-        url: store.getState().config.endpoints.identityProviders + "/" + idpId + "/federated-authenticators/"
+        url: store.getState().config.endpoints.identityProviders + "/" + idpId + "/federated-authenticators"
     };
 
     return httpClient(requestConfig)
@@ -1281,7 +1281,7 @@ export const useConnectionGroups = <Data = ConnectionGroupInterface[], Error = R
             "Content-Type": "application/json"
         },
         method: HttpMethods.GET,
-        url: store.getState().config.endpoints.identityProviders + "/" + idpId + "/groups/"
+        url: store.getState().config.endpoints.identityProviders + "/" + idpId + "/groups"
     };
 
     const { data, error, isValidating, mutate } = useRequest<Data, Error>(requestConfig);
@@ -1310,7 +1310,7 @@ export const updateConnectionGroup = (idpId: string, idpGroups: ConnectionGroupI
             "Content-Type": "application/json"
         },
         method: HttpMethods.PUT,
-        url: store.getState().config.endpoints.identityProviders + "/" + idpId + "/groups/"
+        url: store.getState().config.endpoints.identityProviders + "/" + idpId + "/groups"
     };
 
     return httpClient(requestConfig)

--- a/features/admin.connections.v1/api/use-get-authenticator-connected-apps.ts
+++ b/features/admin.connections.v1/api/use-get-authenticator-connected-apps.ts
@@ -42,7 +42,7 @@ export const useGetAuthenticatorConnectedApps = <Data = ConnectedAppsInterface, 
             "Content-Type": "application/json"
         },
         method: HttpMethods.GET,
-        url: store.getState().config.endpoints.authenticators + "/" + authenticatorId + "/connected-apps/"
+        url: store.getState().config.endpoints.authenticators + "/" + authenticatorId + "/connected-apps"
     };
 
     const { data, error, isValidating, mutate } = useRequest<Data, Error>(shouldFetch ? requestConfig : null);

--- a/features/admin.core.v1/components/header.tsx
+++ b/features/admin.core.v1/components/header.tsx
@@ -556,8 +556,8 @@ const Header: FunctionComponent<HeaderPropsInterface> = ({
                         window["AppUtils"].getConfig().ui.appLogoPath,
                     `${window["AppUtils"].getConfig().clientOrigin}/` +
                         `${
-                            StringUtils.removeSlashesFromPath(window["AppUtils"].getConfig().appBase) !== ""
-                                ? StringUtils.removeSlashesFromPath(window["AppUtils"].getConfig().appBase) + "/"
+                            StringUtils.removeSlashesFromPath(window["AppUtils"].getConfig().appBaseWithProxy) !== ""
+                                ? StringUtils.removeSlashesFromPath(window["AppUtils"].getConfig().appBaseWithProxy) + "/"
                                 : ""
                         }libs/themes/` +
                         config.ui.theme.name

--- a/features/admin.core.v1/configs/app.ts
+++ b/features/admin.core.v1/configs/app.ts
@@ -211,7 +211,7 @@ export class Config {
             adminApp: window[ "AppUtils" ]?.getConfig()?.adminApp,
             allowMultipleAppProtocols: window[ "AppUtils" ]?.getConfig()?.allowMultipleAppProtocols,
             appBaseName: window[ "AppUtils" ]?.getConfig()?.appBaseWithTenant,
-            appBaseNameWithoutTenant: window[ "AppUtils" ]?.getConfig()?.appBase,
+            appBaseNameWithoutTenant: window[ "AppUtils" ]?.getConfig()?.appBaseWithProxy,
             appHomePath: window[ "AppUtils" ]?.getConfig()?.routes?.home,
             appLoginPath: window[ "AppUtils" ]?.getConfig()?.routes?.login,
             appLogoutPath: window[ "AppUtils" ]?.getConfig()?.routes?.logout,
@@ -256,7 +256,7 @@ export class Config {
                 loadPath: (language: string[], namespace: string[]) => generateBackendPaths(
                     language,
                     namespace,
-                    window[ "AppUtils" ]?.getConfig()?.appBase,
+                    window[ "AppUtils" ]?.getConfig()?.appBaseWithProxy,
                     Config.getI18nConfig() ?? {
                         langAutoDetectEnabled: I18nConstants.LANG_AUTO_DETECT_ENABLED,
                         namespaceDirectories: I18nConstants.BUNDLE_NAMESPACE_DIRECTORIES,

--- a/features/admin.core.v1/constants/app-constants.ts
+++ b/features/admin.core.v1/constants/app-constants.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022-2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2022-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -128,7 +128,7 @@ export class AppConstants {
      * @returns The app base name.
      */
     public static getAppBasename(): string {
-        return window["AppUtils"]?.getConfig()?.appBase;
+        return window["AppUtils"]?.getConfig()?.appBaseWithProxy;
     }
 
     /**

--- a/features/admin.extensions.v1/components/claims/api/claims.ts
+++ b/features/admin.extensions.v1/components/claims/api/claims.ts
@@ -34,7 +34,7 @@ export const getDialects = (): Promise<any> => {
             "Content-Type": "application/json"
         },
         method: HttpMethods.GET,
-        url: `${store.getState().config.endpoints.claims}/`
+        url: `${store.getState().config.endpoints.claims}`
     };
 
     return httpClient(requestConfig)
@@ -58,7 +58,7 @@ export const getClaimsForDialect = (dialectID: string): Promise<any> => {
             "Content-Type": "application/json"
         },
         method: HttpMethods.GET,
-        url: `${store.getState().config.endpoints.externalClaims.replace("{}", dialectID)}/`
+        url: `${store.getState().config.endpoints.externalClaims.replace("{}", dialectID)}`
     };
 
     return httpClient(requestConfig)

--- a/features/admin.onboarding.v1/components/shared/header.tsx
+++ b/features/admin.onboarding.v1/components/shared/header.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -42,9 +42,9 @@ const Header = () => {
                                     window["AppUtils"].getConfig().ui.appLogoPath,
                                 `${window["AppUtils"].getConfig().clientOrigin}/` +
                                     `${
-                                        StringUtils.removeSlashesFromPath(window["AppUtils"].getConfig().appBase) !== ""
+                                        StringUtils.removeSlashesFromPath(window["AppUtils"].getConfig().appBaseWithProxy) !== ""
                                             ? StringUtils.removeSlashesFromPath(
-                                                window["AppUtils"].getConfig().appBase
+                                                window["AppUtils"].getConfig().appBaseWithProxy
                                             ) + "/"
                                             : ""
                                     }libs/themes/` +

--- a/features/admin.server-configurations.v1/api/governance-connectors.ts
+++ b/features/admin.server-configurations.v1/api/governance-connectors.ts
@@ -97,7 +97,7 @@ export const useGovernanceConnectors = <
         },
         method: HttpMethods.GET,
         url: store.getState().config.endpoints.governanceConnectorCategories + "/"
-            + categoryId + "/connectors/"
+            + categoryId + "/connectors"
     };
 
     const { data, error, isValidating, mutate } = useRequest<Data, Error>(shouldFetch ? requestConfig: null);
@@ -314,7 +314,7 @@ export const revertGovernanceConnectorProperties = (
  */
 export const getGovernanceConnectors = (categoryId: string): Promise<GovernanceConnectorInterface[]> => {
     const url: string = store.getState().config.endpoints.governanceConnectorCategories +
-        "/" + categoryId + "/connectors/";
+        "/" + categoryId + "/connectors";
 
     return getData(url);
 };


### PR DESCRIPTION
## Summary

Adds `proxy_context_path` support to the console and myaccount apps so the app shells and their static assets resolve correctly when the server sits behind a reverse-proxy prefix, and stops the API layer from issuing requests that provoke a prefix-losing redirect.

### Proxy context path support

- **Request-time asset base** — a JSP scriptlet resolves the prefix per request; JSP `publicPath` and the Vite entry tag now emit `<prefix>/console/…`, so `startup-config.js`, `auth-spa-*.min.js` and the entry chunk load from the correct URL.
- **Runtime-agnostic chunks** — Vite `base` switched to `./` in production so lazy chunks resolve via `import.meta.url` and follow the entry under any prefix without being rebuilt.
- **`appBaseWithProxy` in AppUtils** — new config value used everywhere static resources are fetched (i18n bundles, themes, logos, favicons). Routing is untouched and continues to use `appBaseWithTenant` and `appBaseNameForHistoryAPI`.

Static and external-Tomcat builds skip the JSP-driven path — behavior unchanged.

### Trailing slashes on API URLs

A trailing slash makes the container issue a 302 to the canonical path, and that redirect's `Location` is built without the proxy context path. The browser then follows it to an un-prefixed URL, which a proxy exposing only the prefixed route rejects. Removed the trailing slash from 12 call sites across connections, authenticators, governance connectors and claims. This also saves a redirect round-trip in every deployment, with or without a proxy.

Fixes: https://github.com/wso2/product-is/issues/18904
