### PR TITLE
Add missing "Learn More" documentation links to Login & Registration and Notification Channels tiles

### DIFF
--- a/.changeset/add-missing-learn-more-links.md
+++ b/.changeset/add-missing-learn-more-links.md
@@ -1,0 +1,23 @@
+---
+"@wso2is/admin.alternative-login-identifier.v1": patch
+"@wso2is/admin.consents.v1": patch
+"@wso2is/admin.core.v1": patch
+"@wso2is/admin.impersonation.v1": patch
+"@wso2is/admin.issuer-usage-scope.v1": patch
+"@wso2is/admin.organization-discovery.v1": patch
+"@wso2is/admin.provisioning.v1": patch
+"@wso2is/admin.push-providers.v1": patch
+"@wso2is/admin.saml2-configuration.v1": patch
+"@wso2is/admin.server-configurations.v1": patch
+"@wso2is/admin.session-management.v1": patch
+"@wso2is/admin.username-validation.v1": patch
+---
+
+Add the missing "Learn More" documentation links to the Login & Registration and Notification Channels
+pages that were shipping without one — Alternative Login Identifiers, Username Validation, Session Management,
+Policy Management, Preference Management, Admin Initiated Password Reset, SAML2 Web SSO Configuration,
+Organization Discovery, Impersonation, Issuer Usage Scope, Outbound Provisioning Configuration,
+Internal Notification Sending, Email Provider, SMS Provider and Push Provider. The Email Provider and SMS
+Provider pages already rendered a `DocumentationLink`, but the `develop.emailProviders.learnMore` and
+`develop.smsProviders.learnMore` keys they read were absent from the documentation link config, so the link
+resolved to `undefined` and never rendered.

--- a/.changeset/add-missing-learn-more-links.md
+++ b/.changeset/add-missing-learn-more-links.md
@@ -11,6 +11,8 @@
 "@wso2is/admin.server-configurations.v1": patch
 "@wso2is/admin.session-management.v1": patch
 "@wso2is/admin.username-validation.v1": patch
+"@wso2is/console": patch
+"@wso2is/i18n": patch
 ---
 
 Add the missing "Learn More" documentation links to the Login & Registration and Notification Channels
@@ -21,3 +23,6 @@ Internal Notification Sending, Email Provider, SMS Provider and Push Provider. T
 Provider pages already rendered a `DocumentationLink`, but the `develop.emailProviders.learnMore` and
 `develop.smsProviders.learnMore` keys they read were absent from the documentation link config, so the link
 resolved to `undefined` and never rendered.
+
+The two governance connector descriptions touched here (Alternative Login Identifiers and Admin Initiated
+Password Reset) also move from hardcoded English to `governanceConnectors` i18n keys.

--- a/features/admin.alternative-login-identifier.v1/pages/alternative-login-identifier-page.tsx
+++ b/features/admin.alternative-login-identifier.v1/pages/alternative-login-identifier-page.tsx
@@ -62,9 +62,11 @@ import {
     ContentLoader,
     DangerZone,
     DangerZoneGroup,
+    DocumentationLink,
     EmphasizedSegment,
     Message,
-    PageLayout } from "@wso2is/react-components";
+    PageLayout,
+    useDocumentation } from "@wso2is/react-components";
 import { AxiosError } from "axios";
 import isEmpty from "lodash-es/isEmpty";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
@@ -93,6 +95,7 @@ const AlternativeLoginIdentifierInterface: FunctionComponent<AlternativeLoginIde
 
     const { ["data-componentid"]: componentId } = props;
     const { t } = useTranslation();
+    const { getLink } = useDocumentation();
     const dispatch: Dispatch = useDispatch();
 
     const categoryId: string = ServerConfigurationsConstants.ACCOUNT_MANAGEMENT_CATEGORY_ID;
@@ -600,6 +603,11 @@ const AlternativeLoginIdentifierInterface: FunctionComponent<AlternativeLoginIde
                             description={ (
                                 <>
                                     { t("extensions:manage.accountLogin.alternativeLoginIdentifierPage.description") }
+                                    <DocumentationLink
+                                        link={ getLink("manage.accountLogin.alternativeLoginIdentifiers.learnMore") }
+                                    >
+                                        { t("common:learnMore") }
+                                    </DocumentationLink>
                                 </>
                             ) }
                             data-componentid={ `${componentId}-page-layout` }

--- a/features/admin.consents.v1/pages/policy-consents.tsx
+++ b/features/admin.consents.v1/pages/policy-consents.tsx
@@ -37,9 +37,11 @@ import { AlertLevels, FeatureAccessConfigInterface, IdentifiableComponentInterfa
 import { addAlert } from "@wso2is/core/store";
 import {
     ConfirmationModal,
+    DocumentationLink,
     ListLayout,
     PageLayout,
-    PrimaryButton
+    PrimaryButton,
+    useDocumentation
 } from "@wso2is/react-components";
 import React, { FunctionComponent, MouseEvent, ReactElement, useMemo, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
@@ -68,6 +70,7 @@ const PolicyConsentsPage: FunctionComponent<PolicyConsentsPageProps> = (props: P
     } = props;
 
     const { t } = useTranslation();
+    const { getLink } = useDocumentation();
     const dispatch: Dispatch = useDispatch();
 
     const consentsFeatureConfig: FeatureAccessConfigInterface = useSelector(
@@ -334,7 +337,14 @@ const PolicyConsentsPage: FunctionComponent<PolicyConsentsPageProps> = (props: P
         <PageLayout
             pageTitle={ t("consents:policyConsents.pages.list.title") }
             title={ t("consents:policyConsents.pages.list.heading") }
-            description={ t("consents:policyConsents.pages.list.description") }
+            description={ (
+                <>
+                    { t("consents:policyConsents.pages.list.description") }
+                    <DocumentationLink link={ getLink("manage.consentManagement.policyManagement.learnMore") }>
+                        { t("common:learnMore") }
+                    </DocumentationLink>
+                </>
+            ) }
             data-componentid={ `${componentId}-layout` }
             backButton={ {
                 onClick: () => {

--- a/features/admin.consents.v1/pages/preference-management.tsx
+++ b/features/admin.consents.v1/pages/preference-management.tsx
@@ -32,9 +32,11 @@ import { AlertLevels, FeatureAccessConfigInterface, IdentifiableComponentInterfa
 import { addAlert } from "@wso2is/core/store";
 import {
     ConfirmationModal,
+    DocumentationLink,
     ListLayout,
     PageLayout,
-    PrimaryButton
+    PrimaryButton,
+    useDocumentation
 } from "@wso2is/react-components";
 import React, { FunctionComponent, MouseEvent, ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -62,6 +64,7 @@ const PreferenceManagementPage: FunctionComponent<PreferenceManagementPageProps>
     } = props;
 
     const { t } = useTranslation();
+    const { getLink } = useDocumentation();
     const dispatch: Dispatch = useDispatch();
 
     const preferenceManagementFeatureConfig: FeatureAccessConfigInterface = useSelector(
@@ -259,7 +262,16 @@ const PreferenceManagementPage: FunctionComponent<PreferenceManagementPageProps>
         <PageLayout
             pageTitle={ t("consents:preferenceManagement.pages.list.title") }
             title={ t("consents:preferenceManagement.pages.list.heading") }
-            description={ t("consents:preferenceManagement.pages.list.description") }
+            description={ (
+                <>
+                    { t("consents:preferenceManagement.pages.list.description") }
+                    <DocumentationLink
+                        link={ getLink("manage.consentManagement.preferenceManagement.learnMore") }
+                    >
+                        { t("common:learnMore") }
+                    </DocumentationLink>
+                </>
+            ) }
             data-componentid={ `${componentId}-layout` }
             backButton={ {
                 onClick: () => {

--- a/features/admin.core.v1/configs/documentation.ts
+++ b/features/admin.core.v1/configs/documentation.ts
@@ -411,6 +411,9 @@ export const DocumentationLinks: DocumentationLinksInterface = {
             },
             learnMore: documentationBaseUrl + "/references/email-templates/"
         },
+        emailProviders: {
+            learnMore: documentationBaseUrl + "/guides/notification-channels/configure-email-provider/"
+        },
         eventPublishing: {
             learnMore: documentationBaseUrl + "/guides/asgardeo-events/"
         },
@@ -423,6 +426,9 @@ export const DocumentationLinks: DocumentationLinksInterface = {
                 learnMore: undefined
             }
         },
+        pushProviders: {
+            learnMore: documentationBaseUrl + "/guides/notification-channels/configure-push-provider/"
+        },
         smsCustomization: {
             form: {
                 smsBody: {
@@ -430,6 +436,9 @@ export const DocumentationLinks: DocumentationLinksInterface = {
                 }
             },
             learnMore: undefined
+        },
+        smsProviders: {
+            learnMore: documentationBaseUrl + "/guides/notification-channels/configure-sms-provider/"
         },
         webhooks: {
             learnMore: documentationBaseUrl + "/guides/webhooks/understanding-webhooks/"
@@ -439,7 +448,21 @@ export const DocumentationLinks: DocumentationLinksInterface = {
         accountDisable: {
             learnMore: documentationBaseUrl + "/guides/account-configurations/account-disabling/"
         },
+        accountLogin: {
+            alternativeLoginIdentifiers: {
+                learnMore: documentationBaseUrl
+                    + "/guides/user-accounts/account-login/configure-login-identifiers/"
+            },
+            usernameValidation: {
+                learnMore: documentationBaseUrl
+                    + "/guides/account-configurations/account-login/username-validation/"
+            }
+        },
         accountRecovery: {
+            adminInitiatedPasswordReset: {
+                learnMore: documentationBaseUrl
+                    + "/guides/account-configurations/account-recovery/admin-initiated-password-reset/"
+            },
             passwordRecovery: {
                 learnMore: documentationBaseUrl + "/guides/user-accounts/password-recovery/"
             }
@@ -458,14 +481,34 @@ export const DocumentationLinks: DocumentationLinksInterface = {
                 learnMore: documentationBaseUrl + "/guides/users/attributes/manage-scim2-attribute-mappings/"
             }
         },
+        consentManagement: {
+            policyManagement: {
+                learnMore: documentationBaseUrl + "/guides/consent-management/policy-consent/"
+            },
+            preferenceManagement: {
+                learnMore: documentationBaseUrl + "/guides/consent-management/preference-management-consent/"
+            }
+        },
         groups: {
             learnMore: documentationBaseUrl + "/guides/users/manage-groups/",
             roles: {
                 learnMore: documentationBaseUrl + "/guides/users/manage-groups/#assign-roles-to-groups"
             }
         },
+        impersonation: {
+            learnMore: documentationBaseUrl + "/guides/authorization/user-impersonation/"
+        },
         insights: {
             learnMore: documentationBaseUrl + "/guides/organization-insights/"
+        },
+        internalNotificationSending: {
+            // TODO: Update once the internal notification sending guide is published on the Asgardeo doc site.
+            learnMore: undefined
+        },
+        issuerUsageScope: {
+            learnMore: documentationBaseUrl + "/guides/organization-management/"
+                + "select-token-issuer-for-organization-apps/"
+                + "#control-root-token-issuer-access-for-child-organizations"
         },
         loginSecurity: {
             botDetection: {
@@ -475,6 +518,10 @@ export const DocumentationLinks: DocumentationLinksInterface = {
                 learnMore: documentationBaseUrl
                     + "/guides/user-accounts/account-security/login-attempts-security/"
             },
+            sessionManagement: {
+                learnMore: documentationBaseUrl
+                    + "/guides/account-configurations/login-security/session-management/"
+            },
             siftConnector: {
                 learnMore: documentationBaseUrl + "/guides/account-configurations/login-security/"
                     + "sift-fraud-detection/"
@@ -483,11 +530,21 @@ export const DocumentationLinks: DocumentationLinksInterface = {
         logs: {
             learnMore: documentationBaseUrl + "/guides/asgardeo-logs/"
         },
+        organizationDiscovery: {
+            learnMore: documentationBaseUrl + "/guides/organization-management/organization-discovery/"
+                + "email-domain-based-organization-discovery/"
+        },
         organizations: {
             learnMore: documentationBaseUrl + "/guides/organization-management/"
         },
+        outboundProvisioning: {
+            learnMore: documentationBaseUrl + "/guides/users/outbound-provisioning/setup-outbound-provisioning/"
+        },
         privateKeyJWT: {
             learnMore: documentationBaseUrl + "/guides/authentication/oidc/private-key-jwt-client-auth"
+        },
+        saml2WebSso: {
+            learnMore: documentationBaseUrl + "/guides/authentication/saml/"
         },
         selfRegistration: {
             learnMore: documentationBaseUrl + "/guides/user-self-service/self-register/"

--- a/features/admin.core.v1/models/documentation.ts
+++ b/features/admin.core.v1/models/documentation.ts
@@ -16,7 +16,19 @@
  * under the License.
  */
 
+interface AccountLoginDocumentationLinksInterface {
+    alternativeLoginIdentifiers: {
+        learnMore: string;
+    }
+    usernameValidation: {
+        learnMore: string;
+    }
+}
+
 interface AccountRecoveryDocumentationLinksInterface {
+    adminInitiatedPasswordReset: {
+        learnMore: string;
+    }
     passwordRecovery: {
         learnMore: string;
     }
@@ -31,6 +43,9 @@ interface LoginSecurityDocumentationLinksInterface {
         learnMore: string;
     },
     loginAttempts: {
+        learnMore: string;
+    },
+    sessionManagement: {
         learnMore: string;
     },
     siftConnector: {
@@ -402,7 +417,32 @@ interface ConnectionsDocumentationLinksInterface {
     }
 }
 
+interface ConsentManagementDocumentationLinksInterface {
+    policyManagement: {
+        learnMore: string;
+    }
+    preferenceManagement: {
+        learnMore: string;
+    }
+}
+
+interface EmailProvidersDocumentationLinksInterface {
+    learnMore: string;
+}
+
 interface EventPublishingDocumentationLinksInterface {
+    learnMore: string;
+}
+
+interface ImpersonationDocumentationLinksInterface {
+    learnMore: string;
+}
+
+interface InternalNotificationSendingDocumentationLinksInterface {
+    learnMore: string;
+}
+
+interface IssuerUsageScopeDocumentationLinksInterface {
     learnMore: string;
 }
 
@@ -422,6 +462,26 @@ interface SelfRegistrationDocumentationLinksInterface {
 }
 
 interface OrganizationDocumentationLinksInterface {
+    learnMore: string;
+}
+
+interface OrganizationDiscoveryDocumentationLinksInterface {
+    learnMore: string;
+}
+
+interface OutboundProvisioningDocumentationLinksInterface {
+    learnMore: string;
+}
+
+interface PushProvidersDocumentationLinksInterface {
+    learnMore: string;
+}
+
+interface Saml2WebSsoDocumentationLinksInterface {
+    learnMore: string;
+}
+
+interface SmsProvidersDocumentationLinksInterface {
     learnMore: string;
 }
 
@@ -531,21 +591,32 @@ export interface DocumentationLinksInterface {
         connections: ConnectionsDocumentationLinksInterface;
         eventPublishing: EventPublishingDocumentationLinksInterface;
         emailCustomization: EmailCustomizationLinksInterface;
+        emailProviders: EmailProvidersDocumentationLinksInterface;
         multiTenancy: MultiTenancyDocumentationLinksInterface;
+        pushProviders: PushProvidersDocumentationLinksInterface;
         smsCustomization: SmsCustomizationLinksInterface;
+        smsProviders: SmsProvidersDocumentationLinksInterface;
         webhooks: WebhooksDocumentationLinksInterface;
     }
     manage: {
         accountDisable: AccountDisableDocumentationLinksInterface;
+        accountLogin: AccountLoginDocumentationLinksInterface;
         accountRecovery: AccountRecoveryDocumentationLinksInterface;
         administrators: AdministratorsDocumentationLinksInterface;
+        consentManagement: ConsentManagementDocumentationLinksInterface;
+        impersonation: ImpersonationDocumentationLinksInterface;
+        internalNotificationSending: InternalNotificationSendingDocumentationLinksInterface;
+        issuerUsageScope: IssuerUsageScopeDocumentationLinksInterface;
         loginSecurity: LoginSecurityDocumentationLinksInterface;
         attributes: AttributesDocumentationLinksInterface;
         groups: GroupsDocumentationLinksInterface;
         insights: InsightsDocumentationLinksInterface;
         logs: LogsDocumentationLinksInterface;
+        organizationDiscovery: OrganizationDiscoveryDocumentationLinksInterface;
         organizations: OrganizationDocumentationLinksInterface;
+        outboundProvisioning: OutboundProvisioningDocumentationLinksInterface;
         privateKeyJWT: PrivateKeyJWTDocumentationLinksInterface;
+        saml2WebSso: Saml2WebSsoDocumentationLinksInterface;
         selfRegistration: SelfRegistrationDocumentationLinksInterface;
         users: UsersDocumentationLinksInterface;
         userStores: UserStoreDocumentationLinksInterface;

--- a/features/admin.impersonation.v1/pages/impersonation-configuration.tsx
+++ b/features/admin.impersonation.v1/pages/impersonation-configuration.tsx
@@ -25,7 +25,15 @@ import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { Field, Form, FormPropsInterface } from "@wso2is/forms";
-import { ContentLoader, DangerZone, DangerZoneGroup, EmphasizedSegment, PageLayout } from "@wso2is/react-components";
+import {
+    ContentLoader,
+    DangerZone,
+    DangerZoneGroup,
+    DocumentationLink,
+    EmphasizedSegment,
+    PageLayout,
+    useDocumentation
+} from "@wso2is/react-components";
 import React, { FunctionComponent, MutableRefObject, ReactElement, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
@@ -68,6 +76,7 @@ const ImpersonationConfigurationPage: FunctionComponent<ImpersonationConfigurati
     const dispatch: Dispatch<any> = useDispatch();
 
     const { t } = useTranslation();
+    const { getLink } = useDocumentation();
 
     const [ impersonationConfig, setImpersonationConfig ] =
         useState<ImpersonationConfigFormValuesInterface>(undefined);
@@ -185,7 +194,14 @@ const ImpersonationConfigurationPage: FunctionComponent<ImpersonationConfigurati
         <PageLayout
             title={ t("impersonation:title") }
             pageTitle={ t("impersonation:title") }
-            description={ t("impersonation:description") }
+            description={ (
+                <>
+                    { t("impersonation:description") }
+                    <DocumentationLink link={ getLink("manage.impersonation.learnMore") }>
+                        { t("common:learnMore") }
+                    </DocumentationLink>
+                </>
+            ) }
             backButton={ {
                 onClick: () => onBackButtonClick(),
                 text: t("governanceConnectors:goBackLoginAndRegistration")

--- a/features/admin.issuer-usage-scope.v1/pages/issuer-usage-scope-configuration.tsx
+++ b/features/admin.issuer-usage-scope.v1/pages/issuer-usage-scope-configuration.tsx
@@ -33,10 +33,12 @@ import { AlertInterface, AlertLevels, IdentifiableComponentInterface } from "@ws
 import { addAlert } from "@wso2is/core/store";
 import { FinalForm, FinalFormField, FormRenderProps, TextFieldAdapter } from "@wso2is/forms";
 import {
+    DocumentationLink,
     EmphasizedSegment,
     Hint,
     PageLayout,
-    PrimaryButton
+    PrimaryButton,
+    useDocumentation
 } from "@wso2is/react-components";
 import React, { ChangeEvent, FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -81,6 +83,7 @@ const IssuerUsageScopeConfigurationPage: FunctionComponent<IssuerUsageScopeConfi
     );
 
     const { t } = useTranslation([ "issuerUsageScope" ]);
+    const { getLink } = useDocumentation();
     const dispatch: Dispatch = useDispatch();
 
     const [ issuerUsageScopeConfig, setIssuerUsageScopeConfig ] = useState<IssuerUsageScopeOption>(
@@ -187,7 +190,14 @@ const IssuerUsageScopeConfigurationPage: FunctionComponent<IssuerUsageScopeConfi
         <PageLayout
             title={ t("issuerUsageScope:title") }
             pageTitle={ t("issuerUsageScope:title") }
-            description={ t("issuerUsageScope:description") }
+            description={ (
+                <>
+                    { t("issuerUsageScope:description") }
+                    <DocumentationLink link={ getLink("manage.issuerUsageScope.learnMore") }>
+                        { t("common:learnMore") }
+                    </DocumentationLink>
+                </>
+            ) }
             backButton={ {
                 onClick: () => onBackButtonClick(),
                 text: t("governanceConnectors:goBackLoginAndRegistration")

--- a/features/admin.organization-discovery.v1/pages/organization-discovery-domains-page.tsx
+++ b/features/admin.organization-discovery.v1/pages/organization-discovery-domains-page.tsx
@@ -36,7 +36,13 @@ import { isFeatureEnabled } from "@wso2is/core/helpers";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { Field, Form } from "@wso2is/forms";
-import { EmphasizedSegment, Link, PageLayout } from "@wso2is/react-components";
+import {
+    DocumentationLink,
+    EmphasizedSegment,
+    Link,
+    PageLayout,
+    useDocumentation
+} from "@wso2is/react-components";
 import React, {
     FunctionComponent,
     ReactElement,
@@ -81,6 +87,7 @@ const OrganizationDiscoveryDomainsPage: FunctionComponent<OrganizationDiscoveryD
     const { [ "data-componentid" ]: testId } = props;
 
     const { t } = useTranslation();
+    const { getLink } = useDocumentation();
 
     const dispatch: Dispatch = useDispatch();
 
@@ -439,7 +446,14 @@ const OrganizationDiscoveryDomainsPage: FunctionComponent<OrganizationDiscoveryD
         <PageLayout
             pageTitle={ t("pages:emailDomainDiscovery.title") }
             title={ t("pages:emailDomainDiscovery.title") }
-            description={ t("pages:emailDomainDiscovery.subTitle") }
+            description={ (
+                <>
+                    { t("pages:emailDomainDiscovery.subTitle") }
+                    <DocumentationLink link={ getLink("manage.organizationDiscovery.learnMore") }>
+                        { t("common:learnMore") }
+                    </DocumentationLink>
+                </>
+            ) }
             data-componentid={ `${ testId }-page-layout` }
             backButton={ {
                 "data-testid": `${ testId }-page-back-button`,

--- a/features/admin.provisioning.v1/pages/outbound-provisioning-settings.tsx
+++ b/features/admin.provisioning.v1/pages/outbound-provisioning-settings.tsx
@@ -33,7 +33,13 @@ import { useIdentityProviderList } from "@wso2is/admin.identity-providers.v1/api
 import { IdentityProviderInterface } from "@wso2is/admin.identity-providers.v1/models/identity-provider";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { EmptyPlaceholder, PageLayout, PrimaryButton } from "@wso2is/react-components";
+import {
+    DocumentationLink,
+    EmptyPlaceholder,
+    PageLayout,
+    PrimaryButton,
+    useDocumentation
+} from "@wso2is/react-components";
 import React, {
     FunctionComponent,
     MouseEvent,
@@ -81,6 +87,7 @@ const OutboundProvisioningSettingsPage: FunctionComponent<OutboundProvisioningSe
     const { [ "data-componentid" ]: componentId } = props;
 
     const { t } = useTranslation();
+    const { getLink } = useDocumentation();
     const dispatch: Dispatch = useDispatch();
 
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state?.config?.ui?.features);
@@ -333,7 +340,14 @@ const OutboundProvisioningSettingsPage: FunctionComponent<OutboundProvisioningSe
         <PageLayout
             pageTitle={ t("applications:resident.provisioning.outbound.heading") }
             title={ t("applications:resident.provisioning.outbound.heading") }
-            description={ t("applications:resident.provisioning.outbound.subHeading") }
+            description={ (
+                <>
+                    { t("applications:resident.provisioning.outbound.subHeading") }
+                    <DocumentationLink link={ getLink("manage.outboundProvisioning.learnMore") }>
+                        { t("common:learnMore") }
+                    </DocumentationLink>
+                </>
+            ) }
             data-componentid={ `${ componentId }-layout` }
             backButton={ {
                 "data-componentid": `${ componentId }-back-button`,

--- a/features/admin.push-providers.v1/pages/push-providers.tsx
+++ b/features/admin.push-providers.v1/pages/push-providers.tsx
@@ -26,7 +26,14 @@ import ExtensionTemplatesProvider from "@wso2is/admin.template-core.v1/provider/
 import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { ConfirmationModal, DangerZone, DangerZoneGroup, PageLayout } from "@wso2is/react-components";
+import {
+    ConfirmationModal,
+    DangerZone,
+    DangerZoneGroup,
+    DocumentationLink,
+    PageLayout,
+    useDocumentation
+} from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
@@ -61,6 +68,7 @@ const PushProvidersPage: FunctionComponent<PushProvidersPageInterface> = (
 
     const { ["data-componentid"]: componentId = "push-providers-page" } = props;
     const { t } = useTranslation();
+    const { getLink } = useDocumentation();
     const dispatch: Dispatch = useDispatch();
 
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
@@ -295,7 +303,14 @@ const PushProvidersPage: FunctionComponent<PushProvidersPageInterface> = (
         <PageLayout
             title={ t("pushProviders:heading") }
             pageTitle={ t("pushProviders:heading") }
-            description={ t("pushProviders:subHeading") }
+            description={ (
+                <>
+                    { t("pushProviders:subHeading") }
+                    <DocumentationLink link={ getLink("develop.pushProviders.learnMore") }>
+                        { t("common:learnMore") }
+                    </DocumentationLink>
+                </>
+            ) }
             bottomMargin={ false }
             contentTopMargin={ false }
             pageHeaderMaxWidth= { true }

--- a/features/admin.saml2-configuration.v1/pages/saml2-configuration.tsx
+++ b/features/admin.saml2-configuration.v1/pages/saml2-configuration.tsx
@@ -34,10 +34,12 @@ import { Field, Form, FormPropsInterface } from "@wso2is/forms";
 import {
     DangerZone,
     DangerZoneGroup,
+    DocumentationLink,
     EmphasizedSegment,
     PageLayout,
     PrimaryButton,
-    URLInput
+    URLInput,
+    useDocumentation
 } from "@wso2is/react-components";
 import { FormValidation } from "@wso2is/validation";
 import React, { FunctionComponent, MutableRefObject, ReactElement, useEffect, useRef, useState } from "react";
@@ -87,6 +89,7 @@ const Saml2ConfigurationPage: FunctionComponent<Saml2ConfigurationPageInterface>
     const dispatch: Dispatch<any> = useDispatch();
 
     const { t } = useTranslation();
+    const { getLink } = useDocumentation();
 
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
     const [ isReverting, setIsReverting ] = useState<boolean>(false);
@@ -311,7 +314,14 @@ const Saml2ConfigurationPage: FunctionComponent<Saml2ConfigurationPageInterface>
         <PageLayout
             title={ t("saml2Config:title") }
             pageTitle={ t("saml2Config:title") }
-            description={ t("saml2Config:description") }
+            description={ (
+                <>
+                    { t("saml2Config:description") }
+                    <DocumentationLink link={ getLink("manage.saml2WebSso.learnMore") }>
+                        { t("common:learnMore") }
+                    </DocumentationLink>
+                </>
+            ) }
             backButton={ {
                 onClick: () => onBackButtonClick(),
                 text: t("governanceConnectors:goBackLoginAndRegistration")

--- a/features/admin.server-configurations.v1/pages/connector-edit-page.tsx
+++ b/features/admin.server-configurations.v1/pages/connector-edit-page.tsx
@@ -576,8 +576,24 @@ const ConnectorEditPage: FunctionComponent<ConnectorEditPageInterface> = (
                 return "Enable self-service username recovery for users on the login page." +
                     "The user will receive a usernmae reset link via email upon request.";
             case ServerConfigurationsConstants.MULTI_ATTRIBUTE_LOGIN_CONNECTOR_ID:
-                return "Configure alternative login identifiers and allow users to use username or configured" +
-                    " login identifier in login and recovery flows.";
+                return (<>
+                    Configure alternative login identifiers and allow users to use username or configured
+                    login identifier in login and recovery flows.
+                    <DocumentationLink
+                        link={ getLink("manage.accountLogin.alternativeLoginIdentifiers.learnMore") }
+                    >
+                        { t("common:learnMore") }
+                    </DocumentationLink>
+                </>);
+            case ServerConfigurationsConstants.ADMIN_FORCE_PASSWORD_RESET_CONNECTOR_ID:
+                return (<>
+                    Enable administrators to initiate password reset process for users.
+                    <DocumentationLink
+                        link={ getLink("manage.accountRecovery.adminInitiatedPasswordReset.learnMore") }
+                    >
+                        { t("common:learnMore") }
+                    </DocumentationLink>
+                </>);
             case ServerConfigurationsConstants.ASK_PASSWORD_CONNECTOR_ID:
                 return "Allow users to set their own passwords during admin-initiated onboarding" +
                     " and configure related settings.";

--- a/features/admin.server-configurations.v1/pages/connector-edit-page.tsx
+++ b/features/admin.server-configurations.v1/pages/connector-edit-page.tsx
@@ -577,8 +577,8 @@ const ConnectorEditPage: FunctionComponent<ConnectorEditPageInterface> = (
                     "The user will receive a usernmae reset link via email upon request.";
             case ServerConfigurationsConstants.MULTI_ATTRIBUTE_LOGIN_CONNECTOR_ID:
                 return (<>
-                    Configure alternative login identifiers and allow users to use username or configured
-                    login identifier in login and recovery flows.
+                    { t("governanceConnectors:connectorCategories.accountManagement.connectors." +
+                        "multiattributeLoginHandler.description") }
                     <DocumentationLink
                         link={ getLink("manage.accountLogin.alternativeLoginIdentifiers.learnMore") }
                     >
@@ -587,7 +587,8 @@ const ConnectorEditPage: FunctionComponent<ConnectorEditPageInterface> = (
                 </>);
             case ServerConfigurationsConstants.ADMIN_FORCE_PASSWORD_RESET_CONNECTOR_ID:
                 return (<>
-                    Enable administrators to initiate password reset process for users.
+                    { t("governanceConnectors:connectorCategories.accountManagement.connectors." +
+                        "adminForcedPasswordReset.description") }
                     <DocumentationLink
                         link={ getLink("manage.accountRecovery.adminInitiatedPasswordReset.learnMore") }
                     >

--- a/features/admin.server-configurations.v1/pages/internal-notification-sending-page.tsx
+++ b/features/admin.server-configurations.v1/pages/internal-notification-sending-page.tsx
@@ -23,7 +23,15 @@ import { AlertLevels, IdentifiableComponentInterface,
     HttpErrorResponseDataInterface
 } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { DangerZone, DangerZoneGroup, EmphasizedSegment, Hint, PageLayout } from "@wso2is/react-components";
+import {
+    DangerZone,
+    DangerZoneGroup,
+    DocumentationLink,
+    EmphasizedSegment,
+    Hint,
+    PageLayout,
+    useDocumentation
+} from "@wso2is/react-components";
 import { AxiosError } from "axios";
 import React, { FC, FormEvent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -60,6 +68,7 @@ const InternalNotificationSendingPage: FC<InternalNotificationSendingPageInterfa
     const { [ "data-componentid" ]: componentId = "internal-notification-sending" } = props;
 
     const { t } = useTranslation();
+    const { getLink } = useDocumentation();
     const dispatch: Dispatch = useDispatch();
 
     const [ isLoading, setIsLoading ] = useState<boolean>(false);
@@ -458,8 +467,17 @@ const InternalNotificationSendingPage: FC<InternalNotificationSendingPageInterfa
 
     return (
         <PageLayout
-            title={ "Internal Notification Sending" }
-            pageTitle={ "Internal Notification Sending" }
+            title={ t("governanceConnectors:connectorCategories.internalNotificationSending.connector.title") }
+            pageTitle={ t("governanceConnectors:connectorCategories.internalNotificationSending.connector.title") }
+            description={ (
+                <>
+                    { t("governanceConnectors:connectorCategories.internalNotificationSending" +
+                        ".connector.description") }
+                    <DocumentationLink link={ getLink("manage.internalNotificationSending.learnMore") }>
+                        { t("common:learnMore") }
+                    </DocumentationLink>
+                </>
+            ) }
             data-componentid={ `${ componentId }-page-layout` }
             backButton={ {
                 "data-testid": `${ componentId }-page-back-button`,

--- a/features/admin.session-management.v1/pages/session-management.tsx
+++ b/features/admin.session-management.v1/pages/session-management.tsx
@@ -26,7 +26,14 @@ import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { Field, Form } from "@wso2is/forms";
-import { DangerZone, DangerZoneGroup, EmphasizedSegment, PageLayout } from "@wso2is/react-components";
+import {
+    DangerZone,
+    DangerZoneGroup,
+    DocumentationLink,
+    EmphasizedSegment,
+    PageLayout,
+    useDocumentation
+} from "@wso2is/react-components";
 import { FormValidation } from "@wso2is/validation";
 import React, { FunctionComponent, MutableRefObject, ReactElement, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -65,6 +72,7 @@ const SessionManagementSettingsPage: FunctionComponent<SessionManagementSettings
     const dispatch : Dispatch<any> = useDispatch();
 
     const { t } = useTranslation();
+    const { getLink } = useDocumentation();
 
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
     const [ isReverting, setIsReverting ] = useState<boolean>(false);
@@ -337,7 +345,16 @@ const SessionManagementSettingsPage: FunctionComponent<SessionManagementSettings
         <PageLayout
             title={ t("sessionManagement:title") }
             pageTitle={ t("sessionManagement:title") }
-            description={ t("sessionManagement:description") }
+            description={ (
+                <>
+                    { t("sessionManagement:description") }
+                    <DocumentationLink
+                        link={ getLink("manage.loginSecurity.sessionManagement.learnMore") }
+                    >
+                        { t("common:learnMore") }
+                    </DocumentationLink>
+                </>
+            ) }
             backButton={ {
                 onClick: () => onBackButtonClick(),
                 text: t("governanceConnectors:goBackLoginAndRegistration")

--- a/features/admin.username-validation.v1/pages/username-validation-page.tsx
+++ b/features/admin.username-validation.v1/pages/username-validation-page.tsx
@@ -38,10 +38,12 @@ import { Field, Form } from "@wso2is/forms";
 import { ContentLoader,
     DangerZone,
     DangerZoneGroup,
+    DocumentationLink,
     EmphasizedSegment,
     Hint,
     PageLayout,
-    Text
+    Text,
+    useDocumentation
 } from "@wso2is/react-components";
 import { AxiosError } from "axios";
 import React, { FunctionComponent, MutableRefObject, ReactElement, useEffect, useRef, useState } from "react";
@@ -73,6 +75,7 @@ const UsernameValidationPage: FunctionComponent<UsernameValidationPageInterface>
     const dispatch: Dispatch = useDispatch();
     const pageContextRef: MutableRefObject<HTMLElement> = useRef(null);
     const { t } = useTranslation();
+    const { getLink } = useDocumentation();
     const [ isSubmitting, setSubmitting ] = useState<boolean>(false);
     const [ isReverting, setReverting ] = useState<boolean>(false);
     const [ initialFormValues, setInitialFormValues ] = useState<ValidationFormInterface>(undefined);
@@ -367,6 +370,11 @@ const UsernameValidationPage: FunctionComponent<UsernameValidationPageInterface>
             description={ (
                 <>
                     { t("extensions:manage.accountLogin.editPage.description") }
+                    <DocumentationLink
+                        link={ getLink("manage.accountLogin.usernameValidation.learnMore") }
+                    >
+                        { t("common:learnMore") }
+                    </DocumentationLink>
                 </>
             ) }
             data-componentid={ `${componentId}-page-layout` }

--- a/modules/i18n/src/models/namespaces/governance-connectors-ns.ts
+++ b/modules/i18n/src/models/namespaces/governance-connectors-ns.ts
@@ -464,6 +464,7 @@ export interface governanceConnectorsNS {
                 };
                 multiattributeLoginHandler: {
                     friendlyName: string;
+                    description: string;
                     properties: {
                         accountMultiattributeloginHandlerEnable: {
                             hint: string;
@@ -552,6 +553,7 @@ export interface governanceConnectorsNS {
                 };
                 adminForcedPasswordReset: {
                     friendlyName: string;
+                    description: string;
                     properties: {
                         recoveryAdminPasswordResetRecoveryLink: {
                             hint: string;

--- a/modules/i18n/src/translations/en-US/portals/governance-connectors.ts
+++ b/modules/i18n/src/translations/en-US/portals/governance-connectors.ts
@@ -420,6 +420,7 @@ export const governanceConnectors: governanceConnectorsNS = {
                 },
                 multiattributeLoginHandler: {
                     friendlyName: "Multi Attribute Login",
+                    description: "Configure alternative login identifiers and allow users to use username or configured login identifier in login and recovery flows.",
                     properties: {
                         accountMultiattributeloginHandlerEnable: {
                             hint: "Enable using multiple attributes as login identifier",
@@ -508,6 +509,7 @@ export const governanceConnectors: governanceConnectorsNS = {
                 },
                 adminForcedPasswordReset: {
                     friendlyName: "Password Reset",
+                    description: "Enable administrators to initiate password reset process for users.",
                     properties: {
                         recoveryAdminPasswordResetRecoveryLink: {
                             hint: "User gets notified with a link to reset password",


### PR DESCRIPTION
### Purpose

Several tiles shipped without the "Learn More" link that most other tiles provide, leaving admins with no in-context path to the docs.

Two distinct causes:

- The Email Provider and SMS Provider pages already rendered a DocumentationLink, but the keys they read (develop.emailProviders.learnMore and develop.smsProviders.learnMore) were absent from the documentation link config, so getLink returned undefined and the link never rendered.
- The remaining pages passed a plain string as the PageLayout description with no DocumentationLink at all.

Adds the link keys and wires up the pages for: Alternative Login Identifiers (both the governance connector and the beta page), Username Validation, Session Management, Policy Management, Preference Management, Admin Initiated Password Reset, SAML2 Web SSO Configuration, Organization Discovery, Impersonation, Issuer Usage Scope, Outbound Provisioning Configuration, Internal Notification Sending, Email Provider, SMS Provider and Push Provider.

The Internal Notification Sending page also had its hardcoded title replaced with the existing i18n key and gained the description it was missing.
