### PR TITLE
Fix API Authorization tab missing for multi-protocol applications

### DIFF
--- a/.changeset/fix-issue-8385-api-authorization-tab.md
+++ b/.changeset/fix-issue-8385-api-authorization-tab.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.applications.v1": patch
+---
+
+Fix the API Authorization tab not rendering for multi-protocol applications when the OIDC protocol is not first in the inbound protocol list.

--- a/.changeset/fix-issue-8385-api-authorization-tab.md
+++ b/.changeset/fix-issue-8385-api-authorization-tab.md
@@ -1,4 +1,5 @@
 ---
+"@wso2is/console": patch
 "@wso2is/admin.applications.v1": patch
 ---
 

--- a/features/admin.applications.v1/pages/application-edit.tsx
+++ b/features/admin.applications.v1/pages/application-edit.tsx
@@ -87,6 +87,7 @@ import {
     ApplicationAccessTypes,
     ApplicationInterface,
     ApplicationTemplateListItemInterface,
+    InboundProtocolListItemInterface,
     idpInfoTypeInterface
 } from "../models/application";
 import {
@@ -327,8 +328,15 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
          */
         if (!clonedApplication?.advancedConfigurations?.fragment && !clonedApplication?.templateId) {
             if (clonedApplication?.inboundProtocols?.length > 0) {
+                const fallbackProtocolType: string = clonedApplication.inboundProtocols.some(
+                    (protocol: InboundProtocolListItemInterface) =>
+                        protocol?.type === SupportedAuthProtocolTypes.OAUTH2
+                )
+                    ? SupportedAuthProtocolTypes.OAUTH2
+                    : clonedApplication.inboundProtocols[ 0 ]?.type;
+
                 clonedApplication.templateId = InboundProtocolDefaultFallbackTemplates.get(
-                    clonedApplication?.inboundProtocols?.[ 0 /*We pick the first*/ ]?.type
+                    fallbackProtocolType
                 ) ?? ApplicationManagementConstants.CUSTOM_APPLICATION_OIDC;
 
                 return determineApplicationTemplate(clonedApplication);


### PR DESCRIPTION
## Purpose

Fixes the API Authorization tab not being rendered for multi-protocol applications (SAML + OIDC) when the OIDC protocol is not first in the inbound protocol list.

Related internal issue: https://github.com/wso2/product-is/issues/28378

## Root cause

Applications with an empty `templateId` (e.g. apps created via the API or migrated from older IS versions) have their fallback template synthesized in `application-edit.tsx` from the application's inbound protocols — but only the **first** element of `inboundProtocols` was used. The protocol order returned by the API is non-deterministic, so:

- `samlsso`-first → resolves to the SAML template → API Authorization tab **not** rendered
- `oauth2`-first → resolves to the OIDC template → API Authorization tab rendered

## Approach

In the `moderatedApplicationData` no-`templateId` branch, prefer `oauth2` when it is present anywhere in the protocol list instead of taking index `0`. This resolves the fallback template — and therefore the API Authorization tab — consistently regardless of protocol order.