### PR TITLE
Fix the custom layout resolution for inherited application level branding

### DIFF
--- a/.changeset/fix-app-level-custom-layout-inheritance.md
+++ b/.changeset/fix-app-level-custom-layout-inheritance.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix the custom layout resolution for inherited application level branding

--- a/identity-apps-core/apps/accounts/src/main/webapp/includes/branding-preferences.jsp
+++ b/identity-apps-core/apps/accounts/src/main/webapp/includes/branding-preferences.jsp
@@ -278,6 +278,8 @@
     String applicationRequestingPreferences = spAppId;
     String preferenceResolvedFromOrganization = tenantRequestingPreferences;
     String preferenceResolvedFromApplication = applicationRequestingPreferences;
+    String customLayoutOrganization = tenantRequestingPreferences;
+    String customLayoutApplication = applicationRequestingPreferences;
     String locale = userLocale != null ? userLocale.getLanguage() + "-" + userLocale.getCountry() : DEFAULT_RESOURCE_LOCALE;
     String resolutionStrategy = "DEFAULT";
     String uiThemeParam = request.getParameter(UI_THEME);

--- a/identity-apps-core/apps/accounts/src/main/webapp/includes/branding-preferences.jsp
+++ b/identity-apps-core/apps/accounts/src/main/webapp/includes/branding-preferences.jsp
@@ -265,12 +265,19 @@
     String APP_PREFERENCE_RESOURCE_TYPE = "APP";
     String RESOURCE_TYPE_KEY = "type";
     String RESOURCE_NAME_KEY = "name";
+    String RESOURCE_ORGANIZATION_KEY = "organization";
+    String RESOURCE_APPLICATION_KEY = "application";
     String UI_THEME = "ui_theme";
     String preferenceResourceType = ORG_PREFERENCE_RESOURCE_TYPE;
     String tenantRequestingPreferences = tenantForTheming;
     JSONObject preferenceResolvedFrom = null;
+    /* `preferenceResolvedFromResourceName` is deprecated. It is retained since the custom JSP files
+       may refer to it. Use `preferenceResolvedFromOrganization` & `preferenceResolvedFromApplication`
+       instead. */
     String preferenceResolvedFromResourceName = tenantRequestingPreferences;
     String applicationRequestingPreferences = spAppId;
+    String preferenceResolvedFromOrganization = tenantRequestingPreferences;
+    String preferenceResolvedFromApplication = applicationRequestingPreferences;
     String locale = userLocale != null ? userLocale.getLanguage() + "-" + userLocale.getCountry() : DEFAULT_RESOURCE_LOCALE;
     String resolutionStrategy = "DEFAULT";
     String uiThemeParam = request.getParameter(UI_THEME);
@@ -318,6 +325,8 @@
             preferenceResolvedFrom = brandingPreferenceResponse.getJSONObject(RESOLVED_FROM_KEY);
             preferenceResourceType = preferenceResolvedFrom.getString(RESOURCE_TYPE_KEY);
             preferenceResolvedFromResourceName = preferenceResolvedFrom.getString(RESOURCE_NAME_KEY);
+            preferenceResolvedFromOrganization = preferenceResolvedFrom.getString(RESOURCE_ORGANIZATION_KEY);
+            preferenceResolvedFromApplication = preferenceResolvedFrom.optString(RESOURCE_APPLICATION_KEY, null);
         }
 
 %>

--- a/identity-apps-core/apps/accounts/src/main/webapp/includes/header.jsp
+++ b/identity-apps-core/apps/accounts/src/main/webapp/includes/header.jsp
@@ -139,9 +139,9 @@
 <style type="text/css"><%= cssContent %></style>
 <%
         } else {
-            styleFilePath = layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromOrganization);
+            styleFilePath = layoutStoreURL.replace("${tenantDomain}", customLayoutOrganization);
             if (StringUtils.equals(preferenceResourceType, APP_PREFERENCE_RESOURCE_TYPE)) {
-                styleFilePath += "/apps/" + convertApplicationName(preferenceResolvedFromApplication);
+                styleFilePath += "/apps/" + convertApplicationName(customLayoutApplication);
             }
             styleFilePath += "/styles.css";
         }

--- a/identity-apps-core/apps/accounts/src/main/webapp/includes/header.jsp
+++ b/identity-apps-core/apps/accounts/src/main/webapp/includes/header.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+  ~ Copyright (c) 2025-2026, WSO2 LLC. (https://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -139,13 +139,11 @@
 <style type="text/css"><%= cssContent %></style>
 <%
         } else {
-            if (StringUtils.equals(layout, PREFIX_FOR_CUSTOM_LAYOUT_NAME + CUSTOM_LAYOUT_NAME_SEPERATOR
-                + preferenceResolvedFromResourceName)) {
-                styleFilePath = layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromResourceName) + "/styles.css";
-            } else if (StringUtils.equals(layout, PREFIX_FOR_CUSTOM_LAYOUT_NAME + CUSTOM_LAYOUT_NAME_SEPERATOR
-                + tenantRequestingPreferences + CUSTOM_LAYOUT_NAME_SEPERATOR + convertApplicationName(applicationRequestingPreferences))) {
-                styleFilePath = layoutStoreURL.replace("${tenantDomain}", tenantRequestingPreferences) + "/apps/" + convertApplicationName(applicationRequestingPreferences) + "/styles.css";
+            styleFilePath = layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromOrganization);
+            if (StringUtils.equals(preferenceResourceType, APP_PREFERENCE_RESOURCE_TYPE)) {
+                styleFilePath += "/apps/" + convertApplicationName(preferenceResolvedFromApplication);
             }
+            styleFilePath += "/styles.css";
         }
     } else {
         styleFilePath = "includes/layouts/" + layout + "/styles.css";

--- a/identity-apps-core/apps/accounts/src/main/webapp/includes/layout-resolver.jsp
+++ b/identity-apps-core/apps/accounts/src/main/webapp/includes/layout-resolver.jsp
@@ -88,6 +88,19 @@
         layoutStoreURL = tempLayoutStoreURL;
     }
 
+    /* The app level custom layout is read from the organization & the application the branding preference was
+       resolved from. When the inheritance is turned off, it is read from the requesting organization &
+       application instead. The org level custom layout is always read from the resolved organization. */
+    boolean inheritAppLevelCustomLayout =
+            Boolean.parseBoolean(application.getInitParameter("inheritAppLevelCustomLayout"));
+    customLayoutOrganization = preferenceResolvedFromOrganization;
+    customLayoutApplication = preferenceResolvedFromApplication;
+    if (StringUtils.equals(preferenceResourceType, APP_PREFERENCE_RESOURCE_TYPE)
+            && !inheritAppLevelCustomLayout) {
+        customLayoutOrganization = tenantRequestingPreferences;
+        customLayoutApplication = applicationRequestingPreferences;
+    }
+
     // Common data for the layout file.
     layoutData.put("BASE_URL", "includes/layouts/" + layout);
 
@@ -154,13 +167,11 @@
                                     }
                                 }
                             } else {
-                                /* App-wise and tenant-wise custom layout resolving logic. Both path segments are
-                                   taken from the resolved branding preference, so that an organization inheriting
-                                   branding renders the layout of the organization the preference was resolved from. */
-                                String customLayoutName = temp + CUSTOM_LAYOUT_NAME_SEPERATOR + preferenceResolvedFromOrganization;
-                                String customLayoutBaseURL = layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromOrganization);
+                                // App-wise and tenant-wise custom layout resolving logic.
+                                String customLayoutName = temp + CUSTOM_LAYOUT_NAME_SEPERATOR + customLayoutOrganization;
+                                String customLayoutBaseURL = layoutStoreURL.replace("${tenantDomain}", customLayoutOrganization);
                                 if (StringUtils.equals(preferenceResourceType, APP_PREFERENCE_RESOURCE_TYPE)) {
-                                    String resolvedApplicationName = convertApplicationName(preferenceResolvedFromApplication);
+                                    String resolvedApplicationName = convertApplicationName(customLayoutApplication);
                                     customLayoutName += CUSTOM_LAYOUT_NAME_SEPERATOR + resolvedApplicationName;
                                     customLayoutBaseURL += "/apps/" + resolvedApplicationName;
                                 }

--- a/identity-apps-core/apps/accounts/src/main/webapp/includes/layout-resolver.jsp
+++ b/identity-apps-core/apps/accounts/src/main/webapp/includes/layout-resolver.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+  ~ Copyright (c) 2025-2026, WSO2 LLC. (https://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -154,15 +154,23 @@
                                     }
                                 }
                             } else {
-                                // App-wise and tenant-wise custom layout resolving logic.
+                                /* App-wise and tenant-wise custom layout resolving logic. Both path segments are
+                                   taken from the resolved branding preference, so that an organization inheriting
+                                   branding renders the layout of the organization the preference was resolved from. */
+                                String customLayoutName = temp + CUSTOM_LAYOUT_NAME_SEPERATOR + preferenceResolvedFromOrganization;
+                                String customLayoutBaseURL = layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromOrganization);
                                 if (StringUtils.equals(preferenceResourceType, APP_PREFERENCE_RESOURCE_TYPE)) {
-                                    layout = temp + CUSTOM_LAYOUT_NAME_SEPERATOR + tenantRequestingPreferences + CUSTOM_LAYOUT_NAME_SEPERATOR + convertApplicationName(applicationRequestingPreferences);
-                                    layoutFileRelativePath = layoutStoreURL.replace("${tenantDomain}", tenantRequestingPreferences) + "/apps/" + convertApplicationName(applicationRequestingPreferences) + "/body.ser";
-                                    layoutData.put("BASE_URL", layoutStoreURL.replace("${tenantDomain}", tenantRequestingPreferences) + "/apps/" + convertApplicationName(applicationRequestingPreferences));
-                                } else if (StringUtils.equals(preferenceResourceType, ORG_PREFERENCE_RESOURCE_TYPE)) {
-                                    layout = temp + CUSTOM_LAYOUT_NAME_SEPERATOR + preferenceResolvedFromResourceName;
-                                    layoutFileRelativePath = layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromResourceName) + "/body.ser";
-                                    layoutData.put("BASE_URL", layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromResourceName));
+                                    String resolvedApplicationName = convertApplicationName(preferenceResolvedFromApplication);
+                                    customLayoutName += CUSTOM_LAYOUT_NAME_SEPERATOR + resolvedApplicationName;
+                                    customLayoutBaseURL += "/apps/" + resolvedApplicationName;
+                                }
+                                String customLayoutFilePath = customLayoutBaseURL + "/body.ser";
+                                // Keep the default layout when the custom layout file is not deployed.
+                                if (customLayoutFilePath.startsWith("http")
+                                        || config.getServletContext().getResource(customLayoutFilePath) != null) {
+                                    layout = customLayoutName;
+                                    layoutFileRelativePath = customLayoutFilePath;
+                                    layoutData.put("BASE_URL", customLayoutBaseURL);
                                 }
                             }
                         } else {

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/branding-preferences.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/branding-preferences.jsp
@@ -278,6 +278,8 @@
     String applicationRequestingPreferences = spAppId;
     String preferenceResolvedFromOrganization = tenantRequestingPreferences;
     String preferenceResolvedFromApplication = applicationRequestingPreferences;
+    String customLayoutOrganization = tenantRequestingPreferences;
+    String customLayoutApplication = applicationRequestingPreferences;
     String locale = userLocale != null ? userLocale.getLanguage() + "-" + userLocale.getCountry() : DEFAULT_RESOURCE_LOCALE;
     String resolutionStrategy = "DEFAULT";
     String uiThemeParam = request.getParameter(UI_THEME);

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/branding-preferences.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/branding-preferences.jsp
@@ -265,12 +265,19 @@
     String APP_PREFERENCE_RESOURCE_TYPE = "APP";
     String RESOURCE_TYPE_KEY = "type";
     String RESOURCE_NAME_KEY = "name";
+    String RESOURCE_ORGANIZATION_KEY = "organization";
+    String RESOURCE_APPLICATION_KEY = "application";
     String UI_THEME = "ui_theme";
     String preferenceResourceType = ORG_PREFERENCE_RESOURCE_TYPE;
     String tenantRequestingPreferences = tenantForTheming;
     JSONObject preferenceResolvedFrom = null;
+    /* `preferenceResolvedFromResourceName` is deprecated. It is retained since the custom JSP files
+       may refer to it. Use `preferenceResolvedFromOrganization` & `preferenceResolvedFromApplication`
+       instead. */
     String preferenceResolvedFromResourceName = tenantRequestingPreferences;
     String applicationRequestingPreferences = spAppId;
+    String preferenceResolvedFromOrganization = tenantRequestingPreferences;
+    String preferenceResolvedFromApplication = applicationRequestingPreferences;
     String locale = userLocale != null ? userLocale.getLanguage() + "-" + userLocale.getCountry() : DEFAULT_RESOURCE_LOCALE;
     String resolutionStrategy = "DEFAULT";
     String uiThemeParam = request.getParameter(UI_THEME);
@@ -318,6 +325,8 @@
             preferenceResolvedFrom = brandingPreferenceResponse.getJSONObject(RESOLVED_FROM_KEY);
             preferenceResourceType = preferenceResolvedFrom.getString(RESOURCE_TYPE_KEY);
             preferenceResolvedFromResourceName = preferenceResolvedFrom.getString(RESOURCE_NAME_KEY);
+            preferenceResolvedFromOrganization = preferenceResolvedFrom.getString(RESOURCE_ORGANIZATION_KEY);
+            preferenceResolvedFromApplication = preferenceResolvedFrom.optString(RESOURCE_APPLICATION_KEY, null);
         }
 
 %>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/header.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/header.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright (c) 2019-2025, WSO2 LLC. (https://www.wso2.com).
+  ~ Copyright (c) 2019-2026, WSO2 LLC. (https://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -45,7 +45,7 @@
             for (Cookie cookie : userCookies) {
                 if ("ui_lang".equals(cookie.getName())) {
                     language = cookie.getValue();
-    
+
                     break;
                 }
             }
@@ -55,7 +55,7 @@
             for (Cookie cookie : userCookies) {
                 if ("ui_lang".equals(cookie.getName())) {
                     language = cookie.getValue();
-    
+
                     break;
                 }
             }
@@ -156,13 +156,11 @@
 <style type="text/css"><%= cssContent %></style>
 <%
         } else {
-            if (StringUtils.equals(layout, PREFIX_FOR_CUSTOM_LAYOUT_NAME + CUSTOM_LAYOUT_NAME_SEPERATOR
-                + preferenceResolvedFromResourceName)) {
-                styleFilePath = layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromResourceName) + "/styles.css";
-            } else if (StringUtils.equals(layout, PREFIX_FOR_CUSTOM_LAYOUT_NAME + CUSTOM_LAYOUT_NAME_SEPERATOR
-                + tenantRequestingPreferences + CUSTOM_LAYOUT_NAME_SEPERATOR + convertApplicationName(applicationRequestingPreferences))) {
-                styleFilePath = layoutStoreURL.replace("${tenantDomain}", tenantRequestingPreferences) + "/apps/" + convertApplicationName(applicationRequestingPreferences) + "/styles.css";
+            styleFilePath = layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromOrganization);
+            if (StringUtils.equals(preferenceResourceType, APP_PREFERENCE_RESOURCE_TYPE)) {
+                styleFilePath += "/apps/" + convertApplicationName(preferenceResolvedFromApplication);
             }
+            styleFilePath += "/styles.css";
         }
     } else {
         styleFilePath = "includes/layouts/" + layout + "/styles.css";

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/header.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/header.jsp
@@ -156,9 +156,9 @@
 <style type="text/css"><%= cssContent %></style>
 <%
         } else {
-            styleFilePath = layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromOrganization);
+            styleFilePath = layoutStoreURL.replace("${tenantDomain}", customLayoutOrganization);
             if (StringUtils.equals(preferenceResourceType, APP_PREFERENCE_RESOURCE_TYPE)) {
-                styleFilePath += "/apps/" + convertApplicationName(preferenceResolvedFromApplication);
+                styleFilePath += "/apps/" + convertApplicationName(customLayoutApplication);
             }
             styleFilePath += "/styles.css";
         }

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/layout-resolver.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/layout-resolver.jsp
@@ -88,6 +88,19 @@
         layoutStoreURL = tempLayoutStoreURL;
     }
 
+    /* The app level custom layout is read from the organization & the application the branding preference was
+       resolved from. When the inheritance is turned off, it is read from the requesting organization &
+       application instead. The org level custom layout is always read from the resolved organization. */
+    boolean inheritAppLevelCustomLayout =
+            Boolean.parseBoolean(application.getInitParameter("inheritAppLevelCustomLayout"));
+    customLayoutOrganization = preferenceResolvedFromOrganization;
+    customLayoutApplication = preferenceResolvedFromApplication;
+    if (StringUtils.equals(preferenceResourceType, APP_PREFERENCE_RESOURCE_TYPE)
+            && !inheritAppLevelCustomLayout) {
+        customLayoutOrganization = tenantRequestingPreferences;
+        customLayoutApplication = applicationRequestingPreferences;
+    }
+
     // Common data for the layout file.
     layoutData.put("BASE_URL", "includes/layouts/" + layout);
 
@@ -154,13 +167,11 @@
                                     }
                                 }
                             } else {
-                                /* App-wise and tenant-wise custom layout resolving logic. Both path segments are
-                                   taken from the resolved branding preference, so that an organization inheriting
-                                   branding renders the layout of the organization the preference was resolved from. */
-                                String customLayoutName = temp + CUSTOM_LAYOUT_NAME_SEPERATOR + preferenceResolvedFromOrganization;
-                                String customLayoutBaseURL = layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromOrganization);
+                                // App-wise and tenant-wise custom layout resolving logic.
+                                String customLayoutName = temp + CUSTOM_LAYOUT_NAME_SEPERATOR + customLayoutOrganization;
+                                String customLayoutBaseURL = layoutStoreURL.replace("${tenantDomain}", customLayoutOrganization);
                                 if (StringUtils.equals(preferenceResourceType, APP_PREFERENCE_RESOURCE_TYPE)) {
-                                    String resolvedApplicationName = convertApplicationName(preferenceResolvedFromApplication);
+                                    String resolvedApplicationName = convertApplicationName(customLayoutApplication);
                                     customLayoutName += CUSTOM_LAYOUT_NAME_SEPERATOR + resolvedApplicationName;
                                     customLayoutBaseURL += "/apps/" + resolvedApplicationName;
                                 }

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/layout-resolver.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/layout-resolver.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright (c) 2022-2025, WSO2 LLC. (https://www.wso2.com).
+  ~ Copyright (c) 2022-2026, WSO2 LLC. (https://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -154,15 +154,23 @@
                                     }
                                 }
                             } else {
-                                // App-wise and tenant-wise custom layout resolving logic.
+                                /* App-wise and tenant-wise custom layout resolving logic. Both path segments are
+                                   taken from the resolved branding preference, so that an organization inheriting
+                                   branding renders the layout of the organization the preference was resolved from. */
+                                String customLayoutName = temp + CUSTOM_LAYOUT_NAME_SEPERATOR + preferenceResolvedFromOrganization;
+                                String customLayoutBaseURL = layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromOrganization);
                                 if (StringUtils.equals(preferenceResourceType, APP_PREFERENCE_RESOURCE_TYPE)) {
-                                    layout = temp + CUSTOM_LAYOUT_NAME_SEPERATOR + tenantRequestingPreferences + CUSTOM_LAYOUT_NAME_SEPERATOR + convertApplicationName(applicationRequestingPreferences);
-                                    layoutFileRelativePath = layoutStoreURL.replace("${tenantDomain}", tenantRequestingPreferences) + "/apps/" + convertApplicationName(applicationRequestingPreferences) + "/body.ser";
-                                    layoutData.put("BASE_URL", layoutStoreURL.replace("${tenantDomain}", tenantRequestingPreferences) + "/apps/" + convertApplicationName(applicationRequestingPreferences));
-                                } else if (StringUtils.equals(preferenceResourceType, ORG_PREFERENCE_RESOURCE_TYPE)) {
-                                    layout = temp + CUSTOM_LAYOUT_NAME_SEPERATOR + preferenceResolvedFromResourceName;
-                                    layoutFileRelativePath = layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromResourceName) + "/body.ser";
-                                    layoutData.put("BASE_URL", layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromResourceName));
+                                    String resolvedApplicationName = convertApplicationName(preferenceResolvedFromApplication);
+                                    customLayoutName += CUSTOM_LAYOUT_NAME_SEPERATOR + resolvedApplicationName;
+                                    customLayoutBaseURL += "/apps/" + resolvedApplicationName;
+                                }
+                                String customLayoutFilePath = customLayoutBaseURL + "/body.ser";
+                                // Keep the default layout when the custom layout file is not deployed.
+                                if (customLayoutFilePath.startsWith("http")
+                                        || config.getServletContext().getResource(customLayoutFilePath) != null) {
+                                    layout = customLayoutName;
+                                    layoutFileRelativePath = customLayoutFilePath;
+                                    layoutData.put("BASE_URL", customLayoutBaseURL);
                                 }
                             }
                         } else {

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/branding-preferences.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/branding-preferences.jsp
@@ -271,6 +271,8 @@
     String applicationRequestingPreferences = spAppId;
     String preferenceResolvedFromOrganization = tenantRequestingPreferences;
     String preferenceResolvedFromApplication = applicationRequestingPreferences;
+    String customLayoutOrganization = tenantRequestingPreferences;
+    String customLayoutApplication = applicationRequestingPreferences;
     String locale = userLocale != null ? userLocale.getLanguage() + "-" + userLocale.getCountry() : DEFAULT_RESOURCE_LOCALE;
     String resolutionStrategy = "DEFAULT";
     String uiThemeParam = request.getParameter(UI_THEME);

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/branding-preferences.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/branding-preferences.jsp
@@ -258,12 +258,19 @@
     String APP_PREFERENCE_RESOURCE_TYPE = "APP";
     String RESOURCE_TYPE_KEY = "type";
     String RESOURCE_NAME_KEY = "name";
+    String RESOURCE_ORGANIZATION_KEY = "organization";
+    String RESOURCE_APPLICATION_KEY = "application";
     String UI_THEME = "ui_theme";
     String preferenceResourceType = ORG_PREFERENCE_RESOURCE_TYPE;
     String tenantRequestingPreferences = tenantForTheming;
     JSONObject preferenceResolvedFrom = null;
+    /* `preferenceResolvedFromResourceName` is deprecated. It is retained since the custom JSP files
+       may refer to it. Use `preferenceResolvedFromOrganization` & `preferenceResolvedFromApplication`
+       instead. */
     String preferenceResolvedFromResourceName = tenantRequestingPreferences;
     String applicationRequestingPreferences = spAppId;
+    String preferenceResolvedFromOrganization = tenantRequestingPreferences;
+    String preferenceResolvedFromApplication = applicationRequestingPreferences;
     String locale = userLocale != null ? userLocale.getLanguage() + "-" + userLocale.getCountry() : DEFAULT_RESOURCE_LOCALE;
     String resolutionStrategy = "DEFAULT";
     String uiThemeParam = request.getParameter(UI_THEME);
@@ -311,6 +318,8 @@
             preferenceResolvedFrom = brandingPreferenceResponse.getJSONObject(RESOLVED_FROM_KEY);
             preferenceResourceType = preferenceResolvedFrom.getString(RESOURCE_TYPE_KEY);
             preferenceResolvedFromResourceName = preferenceResolvedFrom.getString(RESOURCE_NAME_KEY);
+            preferenceResolvedFromOrganization = preferenceResolvedFrom.getString(RESOURCE_ORGANIZATION_KEY);
+            preferenceResolvedFromApplication = preferenceResolvedFrom.optString(RESOURCE_APPLICATION_KEY, null);
         }
 
 %>

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/header.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/header.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright (c) 2019-2025, WSO2 LLC. (https://www.wso2.com).
+  ~ Copyright (c) 2019-2026, WSO2 LLC. (https://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -46,7 +46,7 @@
             for (Cookie cookie : userCookies) {
                 if ("ui_lang".equals(cookie.getName())) {
                     language = cookie.getValue();
-    
+
                     break;
                 }
             }
@@ -56,7 +56,7 @@
             for (Cookie cookie : userCookies) {
                 if ("ui_lang".equals(cookie.getName())) {
                     language = cookie.getValue();
-    
+
                     break;
                 }
             }
@@ -157,13 +157,11 @@
 <style type="text/css"><%= cssContent %></style>
 <%
         } else {
-            if (StringUtils.equals(layout, PREFIX_FOR_CUSTOM_LAYOUT_NAME + CUSTOM_LAYOUT_NAME_SEPERATOR
-                    + preferenceResolvedFromResourceName)) {
-                styleFilePath = layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromResourceName) + "/styles.css";
-            } else if (StringUtils.equals(layout, PREFIX_FOR_CUSTOM_LAYOUT_NAME + CUSTOM_LAYOUT_NAME_SEPERATOR
-                    + tenantRequestingPreferences + CUSTOM_LAYOUT_NAME_SEPERATOR + convertApplicationName(applicationRequestingPreferences))) {
-                styleFilePath = layoutStoreURL.replace("${tenantDomain}", tenantRequestingPreferences) + "/apps/" + convertApplicationName(applicationRequestingPreferences) + "/styles.css";
+            styleFilePath = layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromOrganization);
+            if (StringUtils.equals(preferenceResourceType, APP_PREFERENCE_RESOURCE_TYPE)) {
+                styleFilePath += "/apps/" + convertApplicationName(preferenceResolvedFromApplication);
             }
+            styleFilePath += "/styles.css";
         }
     } else {
         styleFilePath = "includes/layouts/" + layout + "/styles.css";

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/header.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/header.jsp
@@ -157,9 +157,9 @@
 <style type="text/css"><%= cssContent %></style>
 <%
         } else {
-            styleFilePath = layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromOrganization);
+            styleFilePath = layoutStoreURL.replace("${tenantDomain}", customLayoutOrganization);
             if (StringUtils.equals(preferenceResourceType, APP_PREFERENCE_RESOURCE_TYPE)) {
-                styleFilePath += "/apps/" + convertApplicationName(preferenceResolvedFromApplication);
+                styleFilePath += "/apps/" + convertApplicationName(customLayoutApplication);
             }
             styleFilePath += "/styles.css";
         }

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/layout-resolver.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/layout-resolver.jsp
@@ -88,6 +88,19 @@
         layoutStoreURL = tempLayoutStoreURL;
     }
 
+    /* The app level custom layout is read from the organization & the application the branding preference was
+       resolved from. When the inheritance is turned off, it is read from the requesting organization &
+       application instead. The org level custom layout is always read from the resolved organization. */
+    boolean inheritAppLevelCustomLayout =
+            Boolean.parseBoolean(application.getInitParameter("inheritAppLevelCustomLayout"));
+    customLayoutOrganization = preferenceResolvedFromOrganization;
+    customLayoutApplication = preferenceResolvedFromApplication;
+    if (StringUtils.equals(preferenceResourceType, APP_PREFERENCE_RESOURCE_TYPE)
+            && !inheritAppLevelCustomLayout) {
+        customLayoutOrganization = tenantRequestingPreferences;
+        customLayoutApplication = applicationRequestingPreferences;
+    }
+
     // Common data for the layout file.
     layoutData.put("BASE_URL", "includes/layouts/" + layout);
 
@@ -154,13 +167,11 @@
                                     }
                                 }
                             } else {
-                                /* App-wise and tenant-wise custom layout resolving logic. Both path segments are
-                                   taken from the resolved branding preference, so that an organization inheriting
-                                   branding renders the layout of the organization the preference was resolved from. */
-                                String customLayoutName = temp + CUSTOM_LAYOUT_NAME_SEPERATOR + preferenceResolvedFromOrganization;
-                                String customLayoutBaseURL = layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromOrganization);
+                                // App-wise and tenant-wise custom layout resolving logic.
+                                String customLayoutName = temp + CUSTOM_LAYOUT_NAME_SEPERATOR + customLayoutOrganization;
+                                String customLayoutBaseURL = layoutStoreURL.replace("${tenantDomain}", customLayoutOrganization);
                                 if (StringUtils.equals(preferenceResourceType, APP_PREFERENCE_RESOURCE_TYPE)) {
-                                    String resolvedApplicationName = convertApplicationName(preferenceResolvedFromApplication);
+                                    String resolvedApplicationName = convertApplicationName(customLayoutApplication);
                                     customLayoutName += CUSTOM_LAYOUT_NAME_SEPERATOR + resolvedApplicationName;
                                     customLayoutBaseURL += "/apps/" + resolvedApplicationName;
                                 }

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/layout-resolver.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/layout-resolver.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright (c) 2022-2025, WSO2 LLC. (https://www.wso2.com).
+  ~ Copyright (c) 2022-2026, WSO2 LLC. (https://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -154,15 +154,23 @@
                                     }
                                 }
                             } else {
-                                // App-wise and tenant-wise custom layout resolving logic.
+                                /* App-wise and tenant-wise custom layout resolving logic. Both path segments are
+                                   taken from the resolved branding preference, so that an organization inheriting
+                                   branding renders the layout of the organization the preference was resolved from. */
+                                String customLayoutName = temp + CUSTOM_LAYOUT_NAME_SEPERATOR + preferenceResolvedFromOrganization;
+                                String customLayoutBaseURL = layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromOrganization);
                                 if (StringUtils.equals(preferenceResourceType, APP_PREFERENCE_RESOURCE_TYPE)) {
-                                    layout = temp + CUSTOM_LAYOUT_NAME_SEPERATOR + tenantRequestingPreferences + CUSTOM_LAYOUT_NAME_SEPERATOR + convertApplicationName(applicationRequestingPreferences);
-                                    layoutFileRelativePath = layoutStoreURL.replace("${tenantDomain}", tenantRequestingPreferences) + "/apps/" + convertApplicationName(applicationRequestingPreferences) + "/body.ser";
-                                    layoutData.put("BASE_URL", layoutStoreURL.replace("${tenantDomain}", tenantRequestingPreferences) + "/apps/" + convertApplicationName(applicationRequestingPreferences));
-                                } else if (StringUtils.equals(preferenceResourceType, ORG_PREFERENCE_RESOURCE_TYPE)) {
-                                    layout = temp + CUSTOM_LAYOUT_NAME_SEPERATOR + preferenceResolvedFromResourceName;
-                                    layoutFileRelativePath = layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromResourceName) + "/body.ser";
-                                    layoutData.put("BASE_URL", layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromResourceName));
+                                    String resolvedApplicationName = convertApplicationName(preferenceResolvedFromApplication);
+                                    customLayoutName += CUSTOM_LAYOUT_NAME_SEPERATOR + resolvedApplicationName;
+                                    customLayoutBaseURL += "/apps/" + resolvedApplicationName;
+                                }
+                                String customLayoutFilePath = customLayoutBaseURL + "/body.ser";
+                                // Keep the default layout when the custom layout file is not deployed.
+                                if (customLayoutFilePath.startsWith("http")
+                                        || config.getServletContext().getResource(customLayoutFilePath) != null) {
+                                    layout = customLayoutName;
+                                    layoutFileRelativePath = customLayoutFilePath;
+                                    layoutData.put("BASE_URL", customLayoutBaseURL);
                                 }
                             }
                         } else {

--- a/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/branding-preferences.jsp
+++ b/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/branding-preferences.jsp
@@ -263,12 +263,19 @@
     String APP_PREFERENCE_RESOURCE_TYPE = "APP";
     String RESOURCE_TYPE_KEY = "type";
     String RESOURCE_NAME_KEY = "name";
+    String RESOURCE_ORGANIZATION_KEY = "organization";
+    String RESOURCE_APPLICATION_KEY = "application";
     String UI_THEME = "ui_theme";
     String preferenceResourceType = ORG_PREFERENCE_RESOURCE_TYPE;
     String tenantRequestingPreferences = tenantForTheming;
     JSONObject preferenceResolvedFrom = null;
+    /* `preferenceResolvedFromResourceName` is deprecated. It is retained since the custom JSP files
+       may refer to it. Use `preferenceResolvedFromOrganization` & `preferenceResolvedFromApplication`
+       instead. */
     String preferenceResolvedFromResourceName = tenantRequestingPreferences;
     String applicationRequestingPreferences = spAppId;
+    String preferenceResolvedFromOrganization = tenantRequestingPreferences;
+    String preferenceResolvedFromApplication = applicationRequestingPreferences;
     String locale = userLocale != null ? userLocale.getLanguage() + "-" + userLocale.getCountry() : DEFAULT_RESOURCE_LOCALE;
     String resolutionStrategy = "DEFAULT";
     String uiThemeParam = request.getParameter(UI_THEME);
@@ -316,6 +323,8 @@
             preferenceResolvedFrom = brandingPreferenceResponse.getJSONObject(RESOLVED_FROM_KEY);
             preferenceResourceType = preferenceResolvedFrom.getString(RESOURCE_TYPE_KEY);
             preferenceResolvedFromResourceName = preferenceResolvedFrom.getString(RESOURCE_NAME_KEY);
+            preferenceResolvedFromOrganization = preferenceResolvedFrom.getString(RESOURCE_ORGANIZATION_KEY);
+            preferenceResolvedFromApplication = preferenceResolvedFrom.optString(RESOURCE_APPLICATION_KEY, null);
         }
 
 %>

--- a/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/branding-preferences.jsp
+++ b/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/branding-preferences.jsp
@@ -276,6 +276,8 @@
     String applicationRequestingPreferences = spAppId;
     String preferenceResolvedFromOrganization = tenantRequestingPreferences;
     String preferenceResolvedFromApplication = applicationRequestingPreferences;
+    String customLayoutOrganization = tenantRequestingPreferences;
+    String customLayoutApplication = applicationRequestingPreferences;
     String locale = userLocale != null ? userLocale.getLanguage() + "-" + userLocale.getCountry() : DEFAULT_RESOURCE_LOCALE;
     String resolutionStrategy = "DEFAULT";
     String uiThemeParam = request.getParameter(UI_THEME);

--- a/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/header.jsp
+++ b/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/header.jsp
@@ -71,9 +71,9 @@
 <style type="text/css"><%= cssContent %></style>
 <%
         } else {
-            styleFilePath = layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromOrganization);
+            styleFilePath = layoutStoreURL.replace("${tenantDomain}", customLayoutOrganization);
             if (StringUtils.equals(preferenceResourceType, APP_PREFERENCE_RESOURCE_TYPE)) {
-                styleFilePath += "/apps/" + convertApplicationName(preferenceResolvedFromApplication);
+                styleFilePath += "/apps/" + convertApplicationName(customLayoutApplication);
             }
             styleFilePath += "/styles.css";
         }

--- a/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/header.jsp
+++ b/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/header.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright (c) 2020-2025, WSO2 LLC. (http://www.wso2.com).
+  ~ Copyright (c) 2020-2026, WSO2 LLC. (http://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -71,13 +71,11 @@
 <style type="text/css"><%= cssContent %></style>
 <%
         } else {
-            if (StringUtils.equals(layout, PREFIX_FOR_CUSTOM_LAYOUT_NAME + CUSTOM_LAYOUT_NAME_SEPERATOR
-                    + preferenceResolvedFromResourceName)) {
-                styleFilePath = layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromResourceName) + "/styles.css";
-            } else if (StringUtils.equals(layout, PREFIX_FOR_CUSTOM_LAYOUT_NAME + CUSTOM_LAYOUT_NAME_SEPERATOR
-                    + tenantRequestingPreferences + CUSTOM_LAYOUT_NAME_SEPERATOR + convertApplicationName(applicationRequestingPreferences))) {
-                styleFilePath = layoutStoreURL.replace("${tenantDomain}", tenantRequestingPreferences) + "/apps/" + convertApplicationName(applicationRequestingPreferences) + "/styles.css";
+            styleFilePath = layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromOrganization);
+            if (StringUtils.equals(preferenceResourceType, APP_PREFERENCE_RESOURCE_TYPE)) {
+                styleFilePath += "/apps/" + convertApplicationName(preferenceResolvedFromApplication);
             }
+            styleFilePath += "/styles.css";
         }
     } else {
         styleFilePath = "includes/layouts/" + layout + "/styles.css";

--- a/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/layout-resolver.jsp
+++ b/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/layout-resolver.jsp
@@ -88,6 +88,19 @@
         layoutStoreURL = tempLayoutStoreURL;
     }
 
+    /* The app level custom layout is read from the organization & the application the branding preference was
+       resolved from. When the inheritance is turned off, it is read from the requesting organization &
+       application instead. The org level custom layout is always read from the resolved organization. */
+    boolean inheritAppLevelCustomLayout =
+            Boolean.parseBoolean(application.getInitParameter("inheritAppLevelCustomLayout"));
+    customLayoutOrganization = preferenceResolvedFromOrganization;
+    customLayoutApplication = preferenceResolvedFromApplication;
+    if (StringUtils.equals(preferenceResourceType, APP_PREFERENCE_RESOURCE_TYPE)
+            && !inheritAppLevelCustomLayout) {
+        customLayoutOrganization = tenantRequestingPreferences;
+        customLayoutApplication = applicationRequestingPreferences;
+    }
+
     // Common data for the layout file.
     layoutData.put("BASE_URL", "includes/layouts/" + layout);
 
@@ -154,13 +167,11 @@
                                     }
                                 }
                             } else {
-                                /* App-wise and tenant-wise custom layout resolving logic. Both path segments are
-                                   taken from the resolved branding preference, so that an organization inheriting
-                                   branding renders the layout of the organization the preference was resolved from. */
-                                String customLayoutName = temp + CUSTOM_LAYOUT_NAME_SEPERATOR + preferenceResolvedFromOrganization;
-                                String customLayoutBaseURL = layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromOrganization);
+                                // App-wise and tenant-wise custom layout resolving logic.
+                                String customLayoutName = temp + CUSTOM_LAYOUT_NAME_SEPERATOR + customLayoutOrganization;
+                                String customLayoutBaseURL = layoutStoreURL.replace("${tenantDomain}", customLayoutOrganization);
                                 if (StringUtils.equals(preferenceResourceType, APP_PREFERENCE_RESOURCE_TYPE)) {
-                                    String resolvedApplicationName = convertApplicationName(preferenceResolvedFromApplication);
+                                    String resolvedApplicationName = convertApplicationName(customLayoutApplication);
                                     customLayoutName += CUSTOM_LAYOUT_NAME_SEPERATOR + resolvedApplicationName;
                                     customLayoutBaseURL += "/apps/" + resolvedApplicationName;
                                 }

--- a/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/layout-resolver.jsp
+++ b/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/layout-resolver.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright (c) 2022-2025, WSO2 LLC. (http://www.wso2.com).
+  ~ Copyright (c) 2022-2026, WSO2 LLC. (http://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -154,15 +154,23 @@
                                     }
                                 }
                             } else {
-                                // App-wise and tenant-wise custom layout resolving logic.
+                                /* App-wise and tenant-wise custom layout resolving logic. Both path segments are
+                                   taken from the resolved branding preference, so that an organization inheriting
+                                   branding renders the layout of the organization the preference was resolved from. */
+                                String customLayoutName = temp + CUSTOM_LAYOUT_NAME_SEPERATOR + preferenceResolvedFromOrganization;
+                                String customLayoutBaseURL = layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromOrganization);
                                 if (StringUtils.equals(preferenceResourceType, APP_PREFERENCE_RESOURCE_TYPE)) {
-                                    layout = temp + CUSTOM_LAYOUT_NAME_SEPERATOR + tenantRequestingPreferences + CUSTOM_LAYOUT_NAME_SEPERATOR + convertApplicationName(applicationRequestingPreferences);
-                                    layoutFileRelativePath = layoutStoreURL.replace("${tenantDomain}", tenantRequestingPreferences) + "/apps/" + convertApplicationName(applicationRequestingPreferences) + "/body.ser";
-                                    layoutData.put("BASE_URL", layoutStoreURL.replace("${tenantDomain}", tenantRequestingPreferences) + "/apps/" + convertApplicationName(applicationRequestingPreferences));
-                                } else if (StringUtils.equals(preferenceResourceType, ORG_PREFERENCE_RESOURCE_TYPE)) {
-                                    layout = temp + CUSTOM_LAYOUT_NAME_SEPERATOR + preferenceResolvedFromResourceName;
-                                    layoutFileRelativePath = layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromResourceName) + "/body.ser";
-                                    layoutData.put("BASE_URL", layoutStoreURL.replace("${tenantDomain}", preferenceResolvedFromResourceName));
+                                    String resolvedApplicationName = convertApplicationName(preferenceResolvedFromApplication);
+                                    customLayoutName += CUSTOM_LAYOUT_NAME_SEPERATOR + resolvedApplicationName;
+                                    customLayoutBaseURL += "/apps/" + resolvedApplicationName;
+                                }
+                                String customLayoutFilePath = customLayoutBaseURL + "/body.ser";
+                                // Keep the default layout when the custom layout file is not deployed.
+                                if (customLayoutFilePath.startsWith("http")
+                                        || config.getServletContext().getResource(customLayoutFilePath) != null) {
+                                    layout = customLayoutName;
+                                    layoutFileRelativePath = customLayoutFilePath;
+                                    layoutData.put("BASE_URL", customLayoutBaseURL);
                                 }
                             }
                         } else {

--- a/identity-apps-core/features/org.wso2.identity.apps.accounts.portal.server.feature/resources/web.xml.j2
+++ b/identity-apps-core/features/org.wso2.identity.apps.accounts.portal.server.feature/resources/web.xml.j2
@@ -52,6 +52,18 @@
     {% endif %}
     <!-- *************** End of Layout Store URL Configuration ********************** -->
 
+    <!-- *************** App Level Custom Layout Inheritance Configuration ********************** -->
+    <!-- When an application inherits its branding from an ancestor organization, the custom layout is read
+         from the organization & the application the branding was resolved from. Set this to false to read it
+         from the requesting organization & application instead, which is how it behaved before this fix. -->
+    {% if webappscommon.inherit_app_level_custom_layout is defined %}
+    <context-param>
+        <param-name>inheritAppLevelCustomLayout</param-name>
+        <param-value>{{ webappscommon.inherit_app_level_custom_layout }}</param-value>
+    </context-param>
+    {% endif %}
+    <!-- *************** End of App Level Custom Layout Inheritance Configuration ********************** -->
+
     <!-- *************** Custom Error Page Configurations ********************** -->
     {% set all_error_pages = [] %}
     {% for error_page in accounts.error_pages %}

--- a/identity-apps-core/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
+++ b/identity-apps-core/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
@@ -209,6 +209,18 @@
     {% endif %}
     <!-- *************** End of Layout Store URL Configuration ********************** -->
 
+    <!-- *************** App Level Custom Layout Inheritance Configuration ********************** -->
+    <!-- When an application inherits its branding from an ancestor organization, the custom layout is read
+         from the organization & the application the branding was resolved from. Set this to false to read it
+         from the requesting organization & application instead, which is how it behaved before this fix. -->
+    {% if webappscommon.inherit_app_level_custom_layout is defined %}
+    <context-param>
+        <param-name>inheritAppLevelCustomLayout</param-name>
+        <param-value>{{ webappscommon.inherit_app_level_custom_layout }}</param-value>
+    </context-param>
+    {% endif %}
+    <!-- *************** End of App Level Custom Layout Inheritance Configuration ********************** -->
+
     <filter>
         <filter-name>HttpHeaderSecurityFilter</filter-name>
         <filter-class>org.apache.catalina.filters.HttpHeaderSecurityFilter</filter-class>

--- a/identity-apps-core/features/org.wso2.identity.apps.recovery.portal.server.feature/resources/web.xml.j2
+++ b/identity-apps-core/features/org.wso2.identity.apps.recovery.portal.server.feature/resources/web.xml.j2
@@ -122,6 +122,18 @@
     {% endif %}
     <!-- *************** End of Layout Store URL Configuration ********************** -->
 
+    <!-- *************** App Level Custom Layout Inheritance Configuration ********************** -->
+    <!-- When an application inherits its branding from an ancestor organization, the custom layout is read
+         from the organization & the application the branding was resolved from. Set this to false to read it
+         from the requesting organization & application instead, which is how it behaved before this fix. -->
+    {% if webappscommon.inherit_app_level_custom_layout is defined %}
+    <context-param>
+        <param-name>inheritAppLevelCustomLayout</param-name>
+        <param-value>{{ webappscommon.inherit_app_level_custom_layout }}</param-value>
+    </context-param>
+    {% endif %}
+    <!-- *************** End of App Level Custom Layout Inheritance Configuration ********************** -->
+
     <listener>
         <listener-class>org.wso2.carbon.identity.mgt.endpoint.util.listener.IdentityManagementEndpointContextListener</listener-class>
     </listener>

--- a/identity-apps-core/features/org.wso2.identity.apps.x509certificate.portal.server.feature/resources/web.xml.j2
+++ b/identity-apps-core/features/org.wso2.identity.apps.x509certificate.portal.server.feature/resources/web.xml.j2
@@ -38,4 +38,16 @@
     </context-param>
     {% endif %}
     <!-- *************** End of Layout Store URL Configuration ********************** -->
+
+    <!-- *************** App Level Custom Layout Inheritance Configuration ********************** -->
+    <!-- When an application inherits its branding from an ancestor organization, the custom layout is read
+         from the organization & the application the branding was resolved from. Set this to false to read it
+         from the requesting organization & application instead, which is how it behaved before this fix. -->
+    {% if webappscommon.inherit_app_level_custom_layout is defined %}
+    <context-param>
+        <param-name>inheritAppLevelCustomLayout</param-name>
+        <param-value>{{ webappscommon.inherit_app_level_custom_layout }}</param-value>
+    </context-param>
+    {% endif %}
+    <!-- *************** End of App Level Custom Layout Inheritance Configuration ********************** -->
 </web-app>


### PR DESCRIPTION
A sub-organization that inherits application level branding from a parent organization does not get the parent's custom layout. The login page reads the layout files from the sub-organization's own directory instead of the directory of the organization the branding came from.

If the sub-organization has no layout files there, the login page fails with a NullPointerException. If it has files left over from an earlier configuration, that old layout keeps rendering and there is no way to remove it from the Console.

The layout path is now built from the organization and the application the branding preference was resolved from, in the login, recovery, x509 certificate and account portals. A missing layout file falls back to the default layout instead of breaking the page.

`webappscommon.inherit_app_level_custom_layout` controls the application level custom layout inheritance only. Setting it to `false` reads the layout from the requesting organization and application instead, which is how it behaved before.

The config has no effect when the branding is resolved from an organization. In that case the custom layout is always read from the organization the branding was resolved from, which was already corrected earlier and stays as it is.

The default is `true`, and `infer.json` sets it to `false` for IS 7.0.0, 7.1.0, 7.2.0 and 7.3.0, so customers migrating from those versions keep their current behaviour.

Depends on https://github.com/wso2/identity-api-server/pull/1161 and https://github.com/wso2/carbon-identity-framework/pull/8272

Related to https://github.com/wso2/product-is/issues/28242
