### PR TITLE
Handle missing forwarded query string on the login page

### DIFF
--- a/.changeset/fix-login-jsp-npe-missing-forward-query-string.md
+++ b/.changeset/fix-login-jsp-npe-missing-forward-query-string.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix unhandled NullPointerException on the login page when the forwarded query string is absent

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
@@ -112,7 +112,8 @@
         idpAuthenticatorMapping = (Map<String, String>) request.getAttribute(Constants.IDP_AUTHENTICATOR_MAP);
     }
 
-    String forwardedQueryString = (String) request.getAttribute(JAVAX_SERVLET_FORWARD_QUERY_STRING);
+    String forwardedQueryString =
+            StringUtils.defaultString((String) request.getAttribute(JAVAX_SERVLET_FORWARD_QUERY_STRING));
     String appName = Encode.forUriComponent(request.getParameter("sp"));
     String userType = request.getParameter("utype");
     String consoleURL = application.getInitParameter("ConsoleURL");
@@ -414,14 +415,7 @@
         } else {
             srURI = ServiceURLBuilder.create().addPath(AUTHENTICATION_ENDPOINT_LOGIN).build().getAbsolutePublicURL();
         }
-        /* This page can be reached without a servlet forward -- a direct request, or a dispatch that
-           carries no query string -- in which case the forwarded query string attribute is absent.
-           Decoding null throws and fails the whole login page, so treat a missing value as no
-           parameters and build the sign-up callback without a query component. */
-        String srForwardedQueryString = (String) request.getAttribute(JAVAX_SERVLET_FORWARD_QUERY_STRING);
-        String srprmstr = StringUtils.isNotBlank(srForwardedQueryString)
-                ? URLDecoder.decode(srForwardedQueryString, UTF_8)
-                : StringUtils.EMPTY;
+        String srprmstr = URLDecoder.decode(forwardedQueryString, UTF_8);
         String srURLWithoutEncoding = StringUtils.isNotBlank(srprmstr) ? srURI + "?" + srprmstr : srURI;
         srURLEncodedURL = URLEncoder.encode(srURLWithoutEncoding, UTF_8);
     }
@@ -1278,7 +1272,7 @@
                                     String serverName = request.getServerName();
                                     int serverPort = request.getServerPort();
                                     String uri = (String) request.getAttribute(JAVAX_SERVLET_FORWARD_REQUEST_URI);
-                                    String prmstr = (String) request.getAttribute(JAVAX_SERVLET_FORWARD_QUERY_STRING);
+                                    String prmstr = forwardedQueryString;
                                     String urlWithoutEncoding = scheme + "://" +serverName + ":" + serverPort + uri + "?" + prmstr;
                                     if ((scheme == "http" && serverPort == HttpURL.DEFAULT_PORT) || (scheme == "https" && serverPort == HttpsURL.DEFAULT_PORT)) {
                                         urlWithoutEncoding = scheme + "://" + serverName + uri + "?" + prmstr;
@@ -1316,7 +1310,7 @@
                             ((isSelfSignUpEnabledInTenant && isSelfSignUpEnabledInTenantPreferences)
                                 || dynamicPortalSREnabled)
                         ) {
-                                urlParameters = (String) request.getAttribute(JAVAX_SERVLET_FORWARD_QUERY_STRING);
+                                urlParameters = forwardedQueryString;
                         %>
                                 <div class="ui horizontal divider">
                                     <%=AuthenticationEndpointUtil.i18n(resourceBundle, "or")%>
@@ -1375,7 +1369,7 @@
 
         <% if (Boolean.parseBoolean(request.getParameter("isSelfRegistration"))) { %>
                 $(".ui.segment").hide();
-                window.location = "<%=getRegistrationPortalUrl(accountRegistrationEndpointContextURL, srURLEncodedURL, (String) request.getAttribute(JAVAX_SERVLET_FORWARD_QUERY_STRING))%>";
+                window.location = "<%=getRegistrationPortalUrl(accountRegistrationEndpointContextURL, srURLEncodedURL, forwardedQueryString)%>";
         <% } %>
 
         function handleCredentialResponse(response) {

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
@@ -415,7 +415,7 @@
             srURI = ServiceURLBuilder.create().addPath(AUTHENTICATION_ENDPOINT_LOGIN).build().getAbsolutePublicURL();
         }
         String srprmstr = URLDecoder.decode(StringUtils.defaultString(forwardedQueryString), UTF_8);
-        String srURLWithoutEncoding = srURI + "?" + srprmstr;
+        String srURLWithoutEncoding = StringUtils.isNotBlank(srprmstr) ? srURI + "?" + srprmstr : srURI;
         srURLEncodedURL= URLEncoder.encode(srURLWithoutEncoding, UTF_8);
     }
 %>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
@@ -414,9 +414,16 @@
         } else {
             srURI = ServiceURLBuilder.create().addPath(AUTHENTICATION_ENDPOINT_LOGIN).build().getAbsolutePublicURL();
         }
-        String srprmstr = URLDecoder.decode(((String) request.getAttribute(JAVAX_SERVLET_FORWARD_QUERY_STRING)), UTF_8);
-        String srURLWithoutEncoding = srURI + "?" + srprmstr;
-        srURLEncodedURL= URLEncoder.encode(srURLWithoutEncoding, UTF_8);
+        /* This page can be reached without a servlet forward -- a direct request, or a dispatch that
+           carries no query string -- in which case the forwarded query string attribute is absent.
+           Decoding null throws and fails the whole login page, so treat a missing value as no
+           parameters and build the sign-up callback without a query component. */
+        String srForwardedQueryString = (String) request.getAttribute(JAVAX_SERVLET_FORWARD_QUERY_STRING);
+        String srprmstr = StringUtils.isNotBlank(srForwardedQueryString)
+                ? URLDecoder.decode(srForwardedQueryString, UTF_8)
+                : StringUtils.EMPTY;
+        String srURLWithoutEncoding = StringUtils.isNotBlank(srprmstr) ? srURI + "?" + srprmstr : srURI;
+        srURLEncodedURL = URLEncoder.encode(srURLWithoutEncoding, UTF_8);
     }
 %>
 

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
@@ -112,8 +112,7 @@
         idpAuthenticatorMapping = (Map<String, String>) request.getAttribute(Constants.IDP_AUTHENTICATOR_MAP);
     }
 
-    String forwardedQueryString =
-            StringUtils.defaultString((String) request.getAttribute(JAVAX_SERVLET_FORWARD_QUERY_STRING));
+    String forwardedQueryString = (String) request.getAttribute(JAVAX_SERVLET_FORWARD_QUERY_STRING);
     String appName = Encode.forUriComponent(request.getParameter("sp"));
     String userType = request.getParameter("utype");
     String consoleURL = application.getInitParameter("ConsoleURL");
@@ -415,9 +414,9 @@
         } else {
             srURI = ServiceURLBuilder.create().addPath(AUTHENTICATION_ENDPOINT_LOGIN).build().getAbsolutePublicURL();
         }
-        String srprmstr = URLDecoder.decode(forwardedQueryString, UTF_8);
-        String srURLWithoutEncoding = StringUtils.isNotBlank(srprmstr) ? srURI + "?" + srprmstr : srURI;
-        srURLEncodedURL = URLEncoder.encode(srURLWithoutEncoding, UTF_8);
+        String srprmstr = URLDecoder.decode(StringUtils.defaultString(forwardedQueryString), UTF_8);
+        String srURLWithoutEncoding = srURI + "?" + srprmstr;
+        srURLEncodedURL= URLEncoder.encode(srURLWithoutEncoding, UTF_8);
     }
 %>
 
@@ -1272,7 +1271,7 @@
                                     String serverName = request.getServerName();
                                     int serverPort = request.getServerPort();
                                     String uri = (String) request.getAttribute(JAVAX_SERVLET_FORWARD_REQUEST_URI);
-                                    String prmstr = forwardedQueryString;
+                                    String prmstr = (String) request.getAttribute(JAVAX_SERVLET_FORWARD_QUERY_STRING);
                                     String urlWithoutEncoding = scheme + "://" +serverName + ":" + serverPort + uri + "?" + prmstr;
                                     if ((scheme == "http" && serverPort == HttpURL.DEFAULT_PORT) || (scheme == "https" && serverPort == HttpsURL.DEFAULT_PORT)) {
                                         urlWithoutEncoding = scheme + "://" + serverName + uri + "?" + prmstr;
@@ -1310,7 +1309,7 @@
                             ((isSelfSignUpEnabledInTenant && isSelfSignUpEnabledInTenantPreferences)
                                 || dynamicPortalSREnabled)
                         ) {
-                                urlParameters = forwardedQueryString;
+                                urlParameters = (String) request.getAttribute(JAVAX_SERVLET_FORWARD_QUERY_STRING);
                         %>
                                 <div class="ui horizontal divider">
                                     <%=AuthenticationEndpointUtil.i18n(resourceBundle, "or")%>
@@ -1369,7 +1368,7 @@
 
         <% if (Boolean.parseBoolean(request.getParameter("isSelfRegistration"))) { %>
                 $(".ui.segment").hide();
-                window.location = "<%=getRegistrationPortalUrl(accountRegistrationEndpointContextURL, srURLEncodedURL, forwardedQueryString)%>";
+                window.location = "<%=getRegistrationPortalUrl(accountRegistrationEndpointContextURL, srURLEncodedURL, (String) request.getAttribute(JAVAX_SERVLET_FORWARD_QUERY_STRING))%>";
         <% } %>
 
         function handleCredentialResponse(response) {


### PR DESCRIPTION
## Issue

`login.jsp` fails to render with an unhandled `NullPointerException` when self sign-up is enabled for the tenant and the page is reached without a servlet forward — a direct request, or a dispatch carrying no query string. `javax.servlet.forward.query_string` is unset in that case, and `URLDecoder.decode(null, UTF_8)` throws:

```
java.lang.NullPointerException: Cannot invoke "String.length()" because "s" is null
    at java.base/java.net.URLDecoder.decode(URLDecoder.java:187)
    at org.apache.jsp.login_jsp._jspService(login_jsp.java:2629)
```

surfacing as `JasperException: An exception occurred processing [login.jsp] at line [417]`.

## Fix

Decode the value the page already holds in `forwardedQueryString`, defaulted to an empty string, and omit the query separator when there are no parameters — the self sign-up callback URL is regex-validated, so a dangling `?` should not be appended to it. Behaviour is unchanged when the attribute is present.

## Testing

On a local IS 7.4.0-SNAPSHOT pack with `SelfRegistration.Enable=true` on the super tenant, `GET /authenticationendpoint/login.jsp` failed with the trace above and now returns `200`, with and without a query string.
