### PR TITLE
Add i18n entry for the invalid authenticator error status

### DIFF
--- a/.changeset/olive-moons-listen.md
+++ b/.changeset/olive-moons-listen.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Add i18n entry for the invalid authenticator error status

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
@@ -276,6 +276,7 @@ authentication.flow.timeout=Sorry! Your sign-in attempt was taking too long
 authentication.flow.timeout.description=Looks like the sign-in process ended because of the delay. Let's start again. If this problem persists, please contact the administrator.
 authentication.flow.app.disabled=Sorry! Application is disabled.
 authentication.flow.app.disabled.description=Looks like the application is disabled and the access to the application is restricted. Please contact your administrator.
+authentication.invalid.authenticator=Sorry! Invalid authentication method.
 tracking.reference.id=Tracking Reference ID
 copied=Copied
 select.language=Select Language

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
@@ -264,6 +264,7 @@ authentication.flow.timeout=Es tut uns leid! Ihr Anmeldeversuch hat  zu lange ge
 authentication.flow.timeout.description=Anscheinend wurde der Anmeldevorgang aufgrund der Verzögerung beendet. Versuchen Sie es erneut. Wenn dieses Problem weiterhin besteht, wenden Sie sich bitte an den Administrator.
 authentication.flow.app.disabled=Entschuldigung! Die Anwendung ist deaktiviert.
 authentication.flow.app.disabled.description=Offenbar ist die Anwendung deaktiviert und der Zugriff auf die Anwendung ist eingeschränkt. Bitte wenden Sie sich an Ihren Administrator.
+authentication.invalid.authenticator=Entschuldigung! Ungültige Authentifizierungsmethode.
 tracking.reference.id=Verfolgungsreferenz-ID
 copied=Kopiert
 select.language=Sprache auswählen

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_es_ES.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_es_ES.properties
@@ -259,6 +259,7 @@ authentication.flow.timeout=¡Perdón! Su intento de inicio de sesión fue tarda
 authentication.flow.timeout.description=Parece que el proceso de inicio de sesión terminó debido a la demora. Vamos a empezar de nuevo. Si este problema persiste, comuníquese con el administrador.
 authentication.flow.app.disabled=¡Lo siento! La aplicación está deshabilitada.
 authentication.flow.app.disabled.description=Parece que la aplicación está deshabilitada y el acceso a la misma está restringido. Por favor contacte a su administrador.
+authentication.invalid.authenticator=¡Lo siento! Método de autenticación no válido.
 tracking.reference.id=ID de referencia de seguimiento
 copied=Copiado
 select.language=Seleccione el idioma

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
@@ -263,6 +263,7 @@ authentication.flow.timeout=Pardon! Votre tentative de connexion a pris trop de 
 authentication.flow.timeout.description=Il semble que le processus de connexion s'est terminé en raison du retard. Recommençons. Si ce problème persiste, veuillez contacter l'administrateur.
 authentication.flow.app.disabled=Désolé! L'application est désactivée.
 authentication.flow.app.disabled.description=Il semble que l'application soit désactivée et que l'accès à l'application soit restreint. Veuillez contacter votre administrateur.
+authentication.invalid.authenticator=Désolé! Méthode d'authentification non valide.
 tracking.reference.id=ID de référence de suivi
 copied=Copié
 select.language=Choisir la langue

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
@@ -263,6 +263,7 @@ authentication.flow.timeout=申し訳ございません！サインインに時�
 authentication.flow.timeout.description=遅延によりサインインプロセスが終了したようです。もう一度試してください。この問題が解決しない場合は、管理者にお問い合わせください。
 authentication.flow.app.disabled=ごめん！アプリケーションが無効になっています。
 authentication.flow.app.disabled.description=アプリケーションが無効になっており、アプリケーションへのアクセスが制限されているようです。管理者に連絡してください。
+authentication.invalid.authenticator=ごめん！無効な認証方法です。
 tracking.reference.id=トラッキングリファレンス ID
 copied=コピーされました
 select.language=言語選択

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_nl_NL.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_nl_NL.properties
@@ -273,6 +273,7 @@ authentication.flow.timeout=Sorry! Uw aanmeldpoging duurde te lang
 authentication.flow.timeout.description=Het lijkt erop dat het aanmeldingsproces is beëindigd vanwege de vertraging. Laten we opnieuw beginnen. Als dit probleem aanhoudt, neem dan contact op met de beheerder.
 authentication.flow.app.disabled=Sorry! Toepassing is uitgeschakeld.
 authentication.flow.app.disabled.description=Het lijkt erop dat de toepassing is uitgeschakeld en de toegang tot de toepassing is beperkt. Neem contact op met uw beheerder.
+authentication.invalid.authenticator=Sorry! Ongeldige authenticatiemethode.
 tracking.reference.id=Trackingreferentie-ID
 copied=Gekopieerd
 select.language=Taal selecteren

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_BR.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_BR.properties
@@ -261,6 +261,7 @@ authentication.flow.timeout=Desculpe-nos! Sua tentativa de login estava demorand
 authentication.flow.timeout.description=Parece que o processo de login terminou por causa da demora. Vamos começar novamente. Se esse problema persistir, entre em contato com o administrador.
 authentication.flow.app.disabled=Desculpe! O aplicativo está desativado.
 authentication.flow.app.disabled.description=Parece que o aplicativo está desabilitado e o acesso ao aplicativo é restrito. Entre em contato com seu administrador.
+authentication.invalid.authenticator=Desculpe! Método de autenticação inválido.
 tracking.reference.id=ID de referência de rastreamento
 copied=Copiado
 select.language=Selecione o idioma

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_PT.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_PT.properties
@@ -264,6 +264,7 @@ authentication.flow.timeout=Desculpe-nos! Sua tentativa de login estava demorand
 authentication.flow.timeout.description=Parece que o processo de login terminou por causa do atraso. Vamos começar novamente. Se esse problema persistir, entre em contato com o administrador.
 authentication.flow.app.disabled=Desculpe! O aplicativo está desativado.
 authentication.flow.app.disabled.description=Parece que o aplicativo está desabilitado e o acesso ao aplicativo é restrito. Entre em contato com seu administrador.
+authentication.invalid.authenticator=Desculpe! Método de autenticação inválido.
 tracking.reference.id=ID de referência de rastreamento
 copied=Copiado
 select.language=Selecione o idioma

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_zh_CN.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_zh_CN.properties
@@ -263,6 +263,7 @@ authentication.flow.timeout=对不起！您的登录尝试花费太长
 authentication.flow.timeout.description=看起来由于延迟，登录过程结束了。我们重来。如果此问题持续存在，请联系管理员。
 authentication.flow.app.disabled=对不起！应用程序被禁用。
 authentication.flow.app.disabled.description=看起来该应用程序已被禁用并且对该应用程序的访问受到限制。请联系您的管理员。
+authentication.invalid.authenticator=对不起！无效的身份验证方式。
 tracking.reference.id=跟踪参考ID
 copied=复制
 select.language=选择语言


### PR DESCRIPTION
## Purpose

When a client requests an authenticator that is not configured in the current authentication
step, the framework fails the request with the retry-page status
`authentication.invalid.authenticator`, introduced by
https://github.com/wso2/carbon-identity-framework/pull/7655 and shipped in IS 7.3.0.

The `authenticationendpoint` resource bundle has no entry for that key, so `retry.do` renders the
**raw key** as the error heading instead of a message.

## Change

One line in the default `Resources.properties` of the `authentication-portal` component, beside
the existing `authentication.flow.app.disabled` sibling:

```properties
authentication.invalid.authenticator=Sorry! Invalid authentication method.
```

## Verification

Reproduced and verified on a stock **IS 7.3.0** pack (`authentication-framework 7.10.156.38`),
which carries this same bundle, driven with a real Chromium session — `POST /commonauth` with
`authenticator=email-otp-authenticator` against a `sessionDataKey` whose flow is still at step 1:

| | Heading | Body |
|---|---|---|
| **Before** | `authentication.invalid.authenticator` — the raw key | Invalid authenticator: email-otp-authenticator |
| **After** | Sorry! Invalid authentication method. | Invalid authenticator: email-otp-authenticator |

The API surface is untouched: `POST /oauth2/authn` returns
`HTTP 400 · ABA-60012 · Invalid authenticator.` in both states. This is purely the browser error
page. The normal 2-step login (Basic → Email OTP) is unaffected.

## Screenshots

Captured on a stock wso2is-7.3.0 pack, which carries this same bundle — no patch applied.

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/8d6c29a0-49d7-4867-bcd3-c85e55cd1412" width="440"> | <img src="https://github.com/user-attachments/assets/2529d8af-277e-4b06-867f-ad572f18bf87" width="440"> |

## Localisation

The English default plus all eight locale bundles are updated in this PR, matching how the
neighbouring `authentication.flow.app.disabled` key was added — translations land with the
English string rather than in a follow-up.

| Locale | Value |
|---|---|
| _(default)_ | Sorry! Invalid authentication method. |
| `de_DE` | Entschuldigung! Ungültige Authentifizierungsmethode. |
| `es_ES` | ¡Lo siento! Método de autenticación no válido. |
| `fr_FR` | Désolé! Méthode d'authentification non valide. |
| `ja_JP` | ごめん！無効な認証方法です。 |
| `nl_NL` | Sorry! Ongeldige authenticatiemethode. |
| `pt_BR` | Desculpe! Método de autenticação inválido. |
| `pt_PT` | Desculpe! Método de autenticação inválido. |
| `zh_CN` | 对不起！无效的身份验证方式。 |

Each reuses the opener already established in that bundle for the sibling key, so the tone stays
consistent with the rest of the page.

### Example — French (`Accept-Language: fr-FR`)

Verified at runtime. Note the page chrome was already localised (`Besoin d'aide?`), which is what
made the untranslated heading stand out.

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/f17eeacd-c246-462c-8ce6-cf54cef7cf99" width="440"> | <img src="https://github.com/user-attachments/assets/83b4bb9a-59e8-4e00-ae0e-699ab10f768f" width="440"> |

> **Translations need a native-speaker review.** The openers are copied verbatim from the
> existing bundles; the translated phrase itself was authored with this change and has not been
> reviewed by a native speaker of each language.

## Related Issue

- https://github.com/wso2/product-is/issues/28423
