### PR TITLE
Support URN and non-URL absolute URI values for SAML audiences

### DIFF
--- a/.changeset/saml-audience-absolute-uri.md
+++ b/.changeset/saml-audience-absolute-uri.md
@@ -1,0 +1,13 @@
+---
+"@wso2is/admin.applications.v1": patch
+"@wso2is/console": patch
+"@wso2is/core": patch
+"@wso2is/react-components": patch
+---
+
+Accept any absolute URI as a SAML assertion audience, and stop hiding stored audiences that are not
+conventional URLs. Audience entry previously required a `<scheme>://<authority>` shape, which rejected
+URNs such as `urn:amazon:webservices`, and values failing the URL check were dropped at render, so a
+non-compliant audience already present in the assertion could be neither seen nor removed. The non-TLS
+warning on URL chips is also narrowed to plain `http`, so schemes with no transport of their own — such
+as mobile deep links — are no longer flagged as insecure.

--- a/features/admin.applications.v1/components/forms/inbound-saml-form.tsx
+++ b/features/admin.applications.v1/components/forms/inbound-saml-form.tsx
@@ -1214,7 +1214,7 @@ export const InboundSAMLForm: FunctionComponent<InboundSAMLFormPropsInterface> =
                                                 );
                                             }
 
-                                            if (!URLUtils.isMobileDeepLink(value)) {
+                                            if (!URLUtils.isAbsoluteURI(value)) {
                                                 return false;
                                             }
 
@@ -1224,6 +1224,7 @@ export const InboundSAMLForm: FunctionComponent<InboundSAMLFormPropsInterface> =
                                         } }
                                         showError={ showAudienceError }
                                         setShowError={ setAudienceError }
+                                        skipInternalValidation
                                         hint={
                                             t("applications:forms.inboundSAML.sections" +
                                                 ".assertion.fields.audience.hint")

--- a/modules/core/src/utils/__tests__/url-utils.test.ts
+++ b/modules/core/src/utils/__tests__/url-utils.test.ts
@@ -175,6 +175,46 @@ describe("URLUtils", (): void => {
         });
     });
 
+    describe("isAbsoluteURI", (): void => {
+        it("should return true for absolute URIs of any scheme", (): void => {
+            expect(URLUtils.isAbsoluteURI("https://app.example.com/saml")).toBe(true);
+            expect(URLUtils.isAbsoluteURI("http://app.example.com/saml")).toBe(true);
+            expect(URLUtils.isAbsoluteURI("ftp://files.example.com")).toBe(true);
+            expect(URLUtils.isAbsoluteURI("myapp://open")).toBe(true);
+        });
+
+        it("should return true for URN audiences, which have no authority component", (): void => {
+            expect(URLUtils.isAbsoluteURI("urn:example:sp:audience")).toBe(true);
+            expect(URLUtils.isAbsoluteURI("urn:amazon:webservices")).toBe(true);
+        });
+
+        it("should return false for bare tokens that are not absolute", (): void => {
+            expect(URLUtils.isAbsoluteURI("PlainNonUrlAudience")).toBe(false);
+            expect(URLUtils.isAbsoluteURI("ABC-123")).toBe(false);
+            expect(URLUtils.isAbsoluteURI("app.example.com/saml")).toBe(false);
+        });
+
+        it("should return false for values containing whitespace", (): void => {
+            expect(URLUtils.isAbsoluteURI("my audience with spaces")).toBe(false);
+            expect(URLUtils.isAbsoluteURI("urn:my audience")).toBe(false);
+        });
+
+        it("should return false for empty and blank values", (): void => {
+            expect(URLUtils.isAbsoluteURI("")).toBe(false);
+            expect(URLUtils.isAbsoluteURI("   ")).toBe(false);
+            expect(URLUtils.isAbsoluteURI(undefined)).toBe(false);
+            expect(URLUtils.isAbsoluteURI(null)).toBe(false);
+        });
+
+        it("should reject unsafe schemes via the sanitization check", (): void => {
+            expect(URLUtils.isAbsoluteURI("javascript:alert(1)")).toBe(false);
+        });
+
+        it("should tolerate surrounding whitespace", (): void => {
+            expect(URLUtils.isAbsoluteURI("  https://app.example.com/saml  ")).toBe(true);
+        });
+    });
+
     describe("getDomain", (): void => {
         it("should extract domain correctly", (): void => {
             expect(URLUtils.getDomain("https://www.example.com/path")).toBe("example.com");

--- a/modules/core/src/utils/url-utils.ts
+++ b/modules/core/src/utils/url-utils.ts
@@ -100,6 +100,31 @@ export class URLUtils {
     }
 
     /**
+     * Determines whether a value is a valid absolute URI.
+     *
+     * Validates that the input contains no whitespace and forms an absolute URI of any scheme
+     * (including URNs like `urn:`). Whitespace is explicitly checked beforehand because standard
+     * URL parsers may tolerate spaces within opaque paths (e.g., `urn:my audience`), which
+     * is considered invalid.
+     *
+     * @param uri - The URI string to evaluate.
+     * @returns `true` if the string is a non-empty, whitespace-free absolute URI; otherwise, `false`.
+     */
+    public static isAbsoluteURI(uri: string): boolean {
+        if (!uri) {
+            return false;
+        }
+
+        const trimmedURI: string = uri.trim();
+
+        if (trimmedURI === "" || /\s/.test(trimmedURI)) {
+            return false;
+        }
+
+        return URLUtils.isURLValid(trimmedURI, true);
+    }
+
+    /**
      * Checks if the the provided URL is a loop back call.
      *
      * @param url - The URL to evaluate.

--- a/modules/react-components/src/components/input/url-input.tsx
+++ b/modules/react-components/src/components/input/url-input.tsx
@@ -18,7 +18,11 @@
 
 import IconButton from "@oxygen-ui/react/IconButton";
 import { PlusIcon, XMarkIcon } from "@oxygen-ui/react-icons";
-import { IdentifiableComponentInterface, TestableComponentInterface } from "@wso2is/core/models";
+import {
+    IdentifiableComponentInterface,
+    TestableComponentInterface,
+    URLComponentsInterface
+} from "@wso2is/core/models";
 import { URLUtils } from "@wso2is/core/utils";
 import classNames from "classnames";
 import React, { FunctionComponent, ReactElement, ReactNode, useCallback, useEffect, useState } from "react";
@@ -757,8 +761,14 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
      */
     const urlTextWidget = (url: string): ReactElement => {
 
-        const { protocol, host } = URLUtils.urlComponents(url);
-        let { pathWithoutProtocol } = URLUtils.urlComponents(url);
+        const components: URLComponentsInterface = URLUtils.urlComponents(url);
+
+        if (!components || !components.pathWithoutProtocol) {
+            return <span className="decoded-path">{ url }</span>;
+        }
+
+        const { protocol, host } = components;
+        let { pathWithoutProtocol } = components;
 
         // `pathWithoutProtocol` is taken from the `href` attribute returned when parsed using URL constructor.
         // It always appends a `/` if the URL doesn't have it. Need to get rid of this additional `/`.
@@ -768,7 +778,7 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
 
         return (
             <span>
-                { (!URLUtils.isHTTPS(url) && !onlyOrigin && !isCustom) ? (
+                { (protocol === "http" && !onlyOrigin && !isCustom) ? (
                     <Popup
                         trigger={
                             <span style={ { color: "red", textDecoration: "line-through" } }>{ protocol }</span>
@@ -967,7 +977,7 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
                                                 data-componentid={ `${ componentId }-${ url }` }
                                                 data-testid={ `${ testId }-${ url }` }
                                             >
-                                                <span>{ url }</span>
+                                                { urlTextWidget(url) }
                                                 { !readOnly && urlRemoveButtonWidget(url) }
                                             </Label>
                                         </p>


### PR DESCRIPTION
### Purpose

The SAML inbound configuration in the Console rejected audience values that are not conventional URLs, and hid stored audiences it could not parse.

Per the SAML 2.0 core specification (§1.3.2), an `<Audience>` is a URI reference — not necessarily an HTTP(S) URL. Audiences such as `urn:amazon:webservices` are valid absolute URIs, but the audience field validated entries with `URLUtils.isMobileDeepLink()`, which requires a `<scheme>://<authority>` shape. URNs have no authority component, so they were rejected outright.

Separately, any stored audience failing the `URLInput` component's built-in URL check was dropped at render. Because such values are still emitted in the assertion, the Console misrepresented the runtime configuration: an administrator could neither see nor remove a non-compliant audience, and the only way to discover one was to decode an assertion. Applications migrated from earlier versions commonly hold such values, since the management API has accepted free-form audiences since 5.x.

Implementation notes:

- Added `URLUtils.isAbsoluteURI()` in `modules/core/src/utils/url-utils.ts`. It trims the input, rejects empty/blank values and anything containing whitespace, then delegates to `isURLValid(uri, true)` so absolute URIs of any scheme are accepted while unsafe schemes are still filtered out. The explicit whitespace check is required because the WHATWG URL parser percent-encodes spaces inside opaque paths, so `urn:my audience` would otherwise parse successfully.
- The audience field now validates with `isAbsoluteURI()` and passes `skipInternalValidation`, so every stored value is rendered. The existing "unrecognized URL" hint is retained as a soft warning for non-HTTP(S) schemes rather than a hard block.
- `urlTextWidget` destructured `URLUtils.urlComponents()` unconditionally and assumed every entry splits into protocol, host and path. Values with no authority component produced an undefined path and threw during render; it now falls back to rendering the raw value.
- The plain chip branch renders through `urlTextWidget` so values shown via `skipValidation`/`skipInternalValidation` keep protocol highlighting and percent-decoding instead of being printed as flat text.
- The non-TLS warning was driven by `!URLUtils.isHTTPS(url)`, true for *any* non-https scheme. With the above change that flagged mobile deep links (`myapp://callback`) as insecure transports, so it is narrowed to `protocol === "http"`.

No server-side validation is added. The management API and the SOAP admin service have accepted free-form audiences since 5.x and migrated tenants hold values that would now fail, so enforcing there would break migration and existing automation for no security gain — the audience is assertion payload, not a redirect target or other sink. This leaves a deliberate asymmetry: the Console accepts only absolute URIs while the API keeps accepting anything.

Unit tests cover `isAbsoluteURI` across schemes, URN audiences, bare tokens, whitespace, empty/blank/nullish input, unsafe schemes and surrounding whitespace.

### Related Issues

- https://github.com/wso2/product-is/issues/28264

### Related PRs

<!-- Support-branch counterparts are in a private repository; omitted here as the template asks for publicly accessible references only. -->
- N/A
