### PR TITLE
Add an option to route custom claim dialect applications that rename attributes to the local dialect selector

### DIFF
--- a/.changeset/quiet-donkeys-repeat.md
+++ b/.changeset/quiet-donkeys-repeat.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.applications.v1": patch
+"@wso2is/console": patch
+---
+
+Route applications with a custom claim dialect to the local dialect attribute selector

--- a/.changeset/quiet-donkeys-repeat.md
+++ b/.changeset/quiet-donkeys-repeat.md
@@ -1,6 +1,7 @@
 ---
 "@wso2is/admin.applications.v1": patch
+"@wso2is/admin.core.v1": patch
 "@wso2is/console": patch
 ---
 
-Route applications with a custom claim dialect to the local dialect attribute selector
+Add an opt in option to route applications with a custom claim dialect to the local dialect attribute selector

--- a/.changeset/quiet-donkeys-repeat.md
+++ b/.changeset/quiet-donkeys-repeat.md
@@ -4,4 +4,4 @@
 "@wso2is/console": patch
 ---
 
-Add an opt in option to route applications with a custom claim dialect to the local dialect attribute selector
+Add an opt in option to route applications that rename attributes through a custom claim dialect to the local dialect attribute selector

--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -3038,6 +3038,9 @@
         {% if oauth.hash_tokens_and_secrets is defined %}
         "isClientSecretHashEnabled": {{ (oauth.hash_client_secret | default(false)) or (oauth.hash_tokens_and_secrets) }},
         {% endif %}
+        {% if console.ui.is_custom_claim_dialect_routing_enabled is defined %}
+        "isCustomClaimDialectRoutingEnabled": {{ console.ui.is_custom_claim_dialect_routing_enabled }},
+        {% endif %}
         {% if authentication.endpoint.enable_custom_claim_mappings is defined %}
         "isCustomClaimMappingEnabled": {{ authentication.endpoint.enable_custom_claim_mappings }},
         {% endif %}

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -2324,6 +2324,7 @@
         "isClaimUniquenessValidationEnabled": false,
         "isClientSecretHashEnabled": false,
         "isCookieConsentBannerEnabled": true,
+        "isCustomClaimDialectRoutingEnabled": false,
         "isCustomClaimMappingEnabled": true,
         "isCustomClaimMappingMergeEnabled": true,
         "isDefaultDialectEditingEnabled": false,

--- a/features/admin.applications.v1/components/settings/attribute-management/attribute-settings.tsx
+++ b/features/admin.applications.v1/components/settings/attribute-management/attribute-settings.tsx
@@ -278,6 +278,17 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
     }, [ externalClaims ]);
 
     /**
+     * Applications that define their own claim dialect carry per application attribute names. The OIDC scope
+     * grouped selector has no way to display or edit those names, and saving from it drops them. Route such
+     * applications to the local dialect selector, which supports them, and leave every other application on
+     * the scope grouped selector.
+     *
+     * `onlyOIDCConfigured` is intentionally left untouched. It also drives subject claim handling, and these
+     * applications are still OIDC applications.
+     */
+    const useScopeGroupedSelector: boolean = onlyOIDCConfigured && claimConfigurations?.dialect !== "CUSTOM";
+
+    /**
      * Set the dialects for inbound protocols
      */
     useEffect(() => {
@@ -287,7 +298,7 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
         //TODO  move this logic to backend
         setIsClaimRequestLoading(true);
 
-        if (onlyOIDCConfigured) {
+        if (useScopeGroupedSelector) {
             changeSelectedDialect("http://wso2.org/oidc/claim");
 
             return;
@@ -295,7 +306,7 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
 
         setIsClaimRequestLoading(false);
         changeSelectedDialect(localDialectURI);
-    }, [ onlyOIDCConfigured, dialect ]);
+    }, [ useScopeGroupedSelector, dialect ]);
 
     useEffect(() => {
         if (advanceSettingValues) {
@@ -1140,7 +1151,7 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
         const RequestedClaims: RequestedClaimConfigurationInterface[] = [];
         const subjectClaim: AppClaimInterface = advanceSettingValues?.subject?.claim;
 
-        const isSubjectClaimOmitted: boolean = !onlyOIDCConfigured
+        const isSubjectClaimOmitted: boolean = !useScopeGroupedSelector
             && !claimConfigurations?.subject?.claim?.uri
             && !advanceSettingValues?.isSubjectClaimExplicit;
 
@@ -1341,7 +1352,7 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
                         <div className="form-container with-max-width">
                             <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 12 }>
                                 {
-                                    onlyOIDCConfigured
+                                    useScopeGroupedSelector
                                         ? (
                                             <AttributeSelectionOIDC
                                                 claims={ claims }

--- a/features/admin.applications.v1/components/settings/attribute-management/attribute-settings.tsx
+++ b/features/admin.applications.v1/components/settings/attribute-management/attribute-settings.tsx
@@ -278,15 +278,18 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
     }, [ externalClaims ]);
 
     /**
-     * Applications that define their own claim dialect carry per application attribute names. The OIDC scope
-     * grouped selector has no way to display or edit those names, and saving from it drops them. Route such
-     * applications to the local dialect selector, which supports them, and leave every other application on
-     * the scope grouped selector.
+     * Whether this tab operates on the tenant wide OIDC claim dialect rather than the local claim dialect.
      *
-     * `onlyOIDCConfigured` is intentionally left untouched. It also drives subject claim handling, and these
-     * applications are still OIDC applications.
+     * Applications that define their own claim dialect carry per application attribute names. Those names only
+     * exist in the local dialect, and the OIDC scope grouped selector has no field for them, so saving from it
+     * drops them. Such applications therefore work in the local dialect, like every application that is not
+     * OIDC only.
+     *
+     * This drives the dialect the tab loads, which selector renders, and whether an unset subject claim is
+     * sent on save. `onlyOIDCConfigured` is intentionally left untouched; those applications are still OIDC
+     * applications for every other purpose.
      */
-    const useScopeGroupedSelector: boolean = onlyOIDCConfigured && claimConfigurations?.dialect !== "CUSTOM";
+    const usesOIDCClaimDialect: boolean = onlyOIDCConfigured && claimConfigurations?.dialect !== "CUSTOM";
 
     /**
      * Set the dialects for inbound protocols
@@ -298,7 +301,7 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
         //TODO  move this logic to backend
         setIsClaimRequestLoading(true);
 
-        if (useScopeGroupedSelector) {
+        if (usesOIDCClaimDialect) {
             changeSelectedDialect("http://wso2.org/oidc/claim");
 
             return;
@@ -306,7 +309,7 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
 
         setIsClaimRequestLoading(false);
         changeSelectedDialect(localDialectURI);
-    }, [ useScopeGroupedSelector, dialect ]);
+    }, [ usesOIDCClaimDialect, dialect ]);
 
     useEffect(() => {
         if (advanceSettingValues) {
@@ -1151,7 +1154,7 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
         const RequestedClaims: RequestedClaimConfigurationInterface[] = [];
         const subjectClaim: AppClaimInterface = advanceSettingValues?.subject?.claim;
 
-        const isSubjectClaimOmitted: boolean = !useScopeGroupedSelector
+        const isSubjectClaimOmitted: boolean = !usesOIDCClaimDialect
             && !claimConfigurations?.subject?.claim?.uri
             && !advanceSettingValues?.isSubjectClaimExplicit;
 
@@ -1352,7 +1355,7 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
                         <div className="form-container with-max-width">
                             <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 12 }>
                                 {
-                                    useScopeGroupedSelector
+                                    usesOIDCClaimDialect
                                         ? (
                                             <AttributeSelectionOIDC
                                                 claims={ claims }

--- a/features/admin.applications.v1/components/settings/attribute-management/attribute-settings.tsx
+++ b/features/admin.applications.v1/components/settings/attribute-management/attribute-settings.tsx
@@ -285,17 +285,25 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
      * It drives the dialect the tab loads, which selector renders, and whether an unset subject claim is
      * sent on save.
      *
-     * Applications that define their own claim dialect carry per application attribute names. Those names
-     * only exist in the local dialect, and the OIDC scope grouped selector has no field for them, so saving
-     * from it drops them. Sending such applications to the local dialect instead is a behaviour change for
-     * screens that work today, so it is opt in through `isCustomClaimDialectRoutingEnabled`. With the option
-     * off this is exactly `onlyOIDCConfigured`, which is what the tab used before the option existed.
+     * Applications that give attributes their own names keep those names in a custom claim dialect. The
+     * names only exist in the local dialect, and the OIDC scope grouped selector has no field for them, so it
+     * shows those attributes as unselected and saving from it drops the names. Such applications work in the
+     * local dialect instead, but only when at least one attribute is actually renamed. A custom dialect whose
+     * mappings all keep the local claim URI displays correctly on the scope grouped selector, so it stays.
+     *
+     * This changes screens that work today, so it is opt in through `isCustomClaimDialectRoutingEnabled`.
+     * With the option off this is exactly `onlyOIDCConfigured`, which is what the tab used before the option
+     * existed.
      *
      * `onlyOIDCConfigured` is intentionally left untouched; these are still OIDC applications for every
      * other purpose.
      */
+    const hasRenamedAttributes: boolean = claimConfigurations?.dialect === "CUSTOM"
+        && (claimConfigurations?.claimMappings ?? []).some((mapping: ClaimMappingInterface) =>
+            !!mapping?.applicationClaim && mapping.applicationClaim !== mapping?.localClaim?.uri);
+
     const usesOIDCClaimDialect: boolean = UIConfig?.isCustomClaimDialectRoutingEnabled
-        ? onlyOIDCConfigured && claimConfigurations?.dialect !== "CUSTOM"
+        ? onlyOIDCConfigured && !hasRenamedAttributes
         : onlyOIDCConfigured;
 
     /**

--- a/features/admin.applications.v1/components/settings/attribute-management/attribute-settings.tsx
+++ b/features/admin.applications.v1/components/settings/attribute-management/attribute-settings.tsx
@@ -18,6 +18,7 @@
 
 import { Show, useRequiredScopes } from "@wso2is/access-control";
 import { getAllExternalClaims, getAllLocalClaims, getDialects } from "@wso2is/admin.claims.v1/api";
+import useUIConfig from "@wso2is/admin.core.v1/hooks/use-ui-configs";
 import { FeatureConfigInterface } from "@wso2is/admin.core.v1/models/config";
 import { EventPublisher } from "@wso2is/admin.core.v1/utils/event-publisher";
 import { applicationConfig } from "@wso2is/admin.extensions.v1";
@@ -183,6 +184,8 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
 
     const hasApplicationUpdatePermissions: boolean = useRequiredScopes(featureConfig?.applications?.scopes?.update);
 
+    const { UIConfig } = useUIConfig();
+
     const [ localDialectURI, setLocalDialectURI ] = useState("");
 
     const [ dialect, setDialect ] = useState<ClaimDialect[]>([]);
@@ -279,17 +282,21 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
 
     /**
      * Whether this tab operates on the tenant wide OIDC claim dialect rather than the local claim dialect.
+     * It drives the dialect the tab loads, which selector renders, and whether an unset subject claim is
+     * sent on save.
      *
-     * Applications that define their own claim dialect carry per application attribute names. Those names only
-     * exist in the local dialect, and the OIDC scope grouped selector has no field for them, so saving from it
-     * drops them. Such applications therefore work in the local dialect, like every application that is not
-     * OIDC only.
+     * Applications that define their own claim dialect carry per application attribute names. Those names
+     * only exist in the local dialect, and the OIDC scope grouped selector has no field for them, so saving
+     * from it drops them. Sending such applications to the local dialect instead is a behaviour change for
+     * screens that work today, so it is opt in through `isCustomClaimDialectRoutingEnabled`. With the option
+     * off this is exactly `onlyOIDCConfigured`, which is what the tab used before the option existed.
      *
-     * This drives the dialect the tab loads, which selector renders, and whether an unset subject claim is
-     * sent on save. `onlyOIDCConfigured` is intentionally left untouched; those applications are still OIDC
-     * applications for every other purpose.
+     * `onlyOIDCConfigured` is intentionally left untouched; these are still OIDC applications for every
+     * other purpose.
      */
-    const usesOIDCClaimDialect: boolean = onlyOIDCConfigured && claimConfigurations?.dialect !== "CUSTOM";
+    const usesOIDCClaimDialect: boolean = UIConfig?.isCustomClaimDialectRoutingEnabled
+        ? onlyOIDCConfigured && claimConfigurations?.dialect !== "CUSTOM"
+        : onlyOIDCConfigured;
 
     /**
      * Set the dialects for inbound protocols

--- a/features/admin.core.v1/configs/app.ts
+++ b/features/admin.core.v1/configs/app.ts
@@ -526,6 +526,8 @@ export class Config {
                 window[ "AppUtils" ]?.getConfig()?.ui?.isClaimUniquenessValidationEnabled ?? false,
             isClientSecretHashEnabled: window[ "AppUtils" ]?.getConfig()?.ui?.isClientSecretHashEnabled,
             isCookieConsentBannerEnabled: window[ "AppUtils" ]?.getConfig()?.ui?.isCookieConsentBannerEnabled,
+            isCustomClaimDialectRoutingEnabled:
+                window[ "AppUtils" ]?.getConfig()?.ui?.isCustomClaimDialectRoutingEnabled,
             isCustomClaimMappingEnabled: window[ "AppUtils" ]?.getConfig()?.ui?.isCustomClaimMappingEnabled,
             isCustomClaimMappingMergeEnabled: window[ "AppUtils" ]?.getConfig()?.ui?.isCustomClaimMappingMergeEnabled,
             isDefaultDialectEditingEnabled: window[ "AppUtils" ]?.getConfig()?.ui?.isDefaultDialectEditingEnabled,

--- a/features/admin.core.v1/models/config.ts
+++ b/features/admin.core.v1/models/config.ts
@@ -674,6 +674,11 @@ export interface UIConfigInterface extends CommonUIConfigInterface<FeatureConfig
      */
     isSignatureValidationCertificateAliasEnabled?: boolean;
     /**
+     * Send applications that define their own claim dialect to the local dialect attribute selector.
+     * Off by default; the scope grouped selector keeps handling them unless this is switched on.
+     */
+    isCustomClaimDialectRoutingEnabled?: boolean;
+    /**
      * Enable/Disable the custom claim mapping feature.
      */
     isCustomClaimMappingEnabled?: boolean;

--- a/features/admin.core.v1/models/config.ts
+++ b/features/admin.core.v1/models/config.ts
@@ -674,8 +674,8 @@ export interface UIConfigInterface extends CommonUIConfigInterface<FeatureConfig
      */
     isSignatureValidationCertificateAliasEnabled?: boolean;
     /**
-     * Send applications that define their own claim dialect to the local dialect attribute selector.
-     * Off by default; the scope grouped selector keeps handling them unless this is switched on.
+     * Send applications whose custom claim dialect renames at least one attribute to the local dialect
+     * attribute selector. Off by default; the scope grouped selector keeps handling them unless this is on.
      */
     isCustomClaimDialectRoutingEnabled?: boolean;
     /**

--- a/features/admin.core.v1/store/reducers/config.ts
+++ b/features/admin.core.v1/store/reducers/config.ts
@@ -322,6 +322,7 @@ export const commonConfigReducerInitialState: CommonConfigReducerStateInterface<
             isClaimUniquenessValidationEnabled: undefined,
             isClientSecretHashEnabled: undefined,
             isCookieConsentBannerEnabled: undefined,
+            isCustomClaimDialectRoutingEnabled: undefined,
             isCustomClaimMappingEnabled: undefined,
             isCustomClaimMappingMergeEnabled: undefined,
             isDefaultDialectEditingEnabled: undefined,

--- a/features/admin.extensions.v1/test-configs/__mocks__/window.ts
+++ b/features/admin.extensions.v1/test-configs/__mocks__/window.ts
@@ -542,6 +542,7 @@ interface CustomExtendedWindow extends Window {
                 isCookieConsentBannerEnabled: true,
                 isGroupAndRoleSeparationEnabled: true,
                 isSignatureValidationCertificateAliasEnabled: false,
+                isCustomClaimDialectRoutingEnabled: false,
                 isCustomClaimMappingEnabled: true,
                 isCustomClaimMappingMergeEnabled: true,
                 isClientSecretHashEnabled: false,

--- a/modules/core/src/helpers/__mocks__/deployment.config.json
+++ b/modules/core/src/helpers/__mocks__/deployment.config.json
@@ -1270,6 +1270,7 @@
         "isClaimUniquenessValidationEnabled": false,
         "isClientSecretHashEnabled": false,
         "isCookieConsentBannerEnabled": true,
+        "isCustomClaimDialectRoutingEnabled": false,
         "isCustomClaimMappingEnabled": true,
         "isCustomClaimMappingMergeEnabled": true,
         "isDefaultDialectEditingEnabled": false,


### PR DESCRIPTION
### Purpose

Applications that use a custom claim dialect show every user attribute as unselected on the **User Attributes** tab, and pressing **Update** with no edits deletes their claim mappings.

**Cause.** A custom dialect stores the application's own name in `requestedClaims[].claim.uri` and keeps the pairing to the local attribute in `claimMappings`. The OIDC scope grouped selector compares that field directly against the local claim URI:

```ts
requestedClaims.find(r => r?.claim?.uri === externalClaim.mappedLocalClaimURI)
```

`email` never equals `http://wso2.org/claims/emailaddress`, so nothing matches. On save the scope grouped selector has no mapping state, so `claimMappingFinal` is empty, which forces `dialect: "LOCAL"` and drops the mappings.

The local dialect selector resolves the mapping before matching and handles these applications correctly. Every SAML, WS-Federation and multi protocol application already uses it.

**Fix.** A new option routes applications whose custom claim dialect renames at least one attribute to the local dialect selector. **It is off by default.**

```toml
[console.ui]
is_custom_claim_dialect_routing_enabled = true
```

The behaviour is one value in `attribute-settings.tsx`:

```ts
const hasRenamedAttributes: boolean = claimConfigurations?.dialect === "CUSTOM"
    && (claimConfigurations?.claimMappings ?? []).some((mapping: ClaimMappingInterface) =>
        !!mapping?.applicationClaim && mapping.applicationClaim !== mapping?.localClaim?.uri);

const usesOIDCClaimDialect: boolean = UIConfig?.isCustomClaimDialectRoutingEnabled
    ? onlyOIDCConfigured && !hasRenamedAttributes
    : onlyOIDCConfigured;
```

A custom claim dialect whose mappings all keep the local claim URI, or that has no mappings, displays correctly on the scope grouped selector today, so it is not moved.

It decides which dialect the tab loads, which selector renders, and whether an unset subject claim is sent on save. With the option off it is exactly `onlyOIDCConfigured`, the value the tab used before this change.

The `isSubjectClaimOmitted` guard from #10650 used `!onlyOIDCConfigured` to mean "this tab works in the local dialect". It now uses `!usesOIDCClaimDialect`. With the option off the two are identical. With it on, the new condition is a strict superset of the old one, so no application loses protection.

The option follows the existing pattern for Console UI flags: `UIConfigInterface`, `configs/app.ts`, the config reducer, and a `{% if … is defined %}` block in `deployment.config.json.j2`, so the key is absent from the rendered config unless it is set.

### Related Issues
- https://github.com/wso2/product-is/issues/28327

### Related PRs
- N/A

### Verification

**Routing applied.** Tested before the option was added, when every custom dialect application was routed. Every application below renames attributes, so the option on routes them the same way. Covered IS 7.4.0-SNAPSHOT and IS 7.2.0 with a database migrated from 5.11.0.

| Application | Screen | Selected | Update with no edits |
| --- | --- | --- | --- |
| custom dialect, no protocol | scope grouped → **local dialect** | 0 → **2** | **deleted → unchanged** |
| custom dialect, renamed | scope grouped → **local dialect** | 0 → **2** | **deleted → unchanged** |
| standard names, no protocol / OIDC | scope grouped (unchanged) | 5 | unchanged |
| custom dialect, SAML | local dialect (unchanged) | 2 | unchanged |

On both versions the OIDC `id_token` and the SAML assertion carried the same attributes before and after Update, renaming an attribute through the restored screen persisted, and the subject identifier was unchanged on every application.

**Option off and on.** IS 7.2.0 with a database migrated from 5.11.0, 16 applications. They include a custom dialect with no mappings, one whose mappings all keep the local claim URI, and one whose only renamed attribute is not requested. The Console was built twice, with this change and without it. Every run started from the same database snapshot and recorded, for each application, which selector rendered, the checkbox counts, the requests sent when pressing Update (method, status and body), and the stored configuration afterwards.

| Run | Result |
| --- | --- |
| Option not set | identical to the Console without this change, on all 16 applications |
| Option `false` | identical to the Console without this change, on all 16 applications |
| Option `true` | exactly the 6 applications predicted from their stored configuration move to the local dialect selector, and Update keeps their mappings, requested claims and dialect. The other 10 are identical to option off. Reopening every application after Update shows the same selector. |

The two applications whose custom claim dialect renames nothing, one with no mappings and one whose mappings all keep the local claim URI, stay on the scope grouped selector with the option on. That is the effect of requiring a renamed attribute, and both display correctly there today.

IS 7.4.0-SNAPSHOT, same method with Consoles built from `master` with and without this change, 12 applications. Option not set and option `false` are identical to the Console without this change on all 12. Option `true` moves exactly the 4 predicted applications, and Update keeps their configuration. The other 8 are identical to option off, and reopening every application after Update shows the same selector.

ESLint and `tsc` pass. As a control, a deliberately wrong property name on `UIConfig` is rejected, so the new field is type checked.

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.

> **Behavioural change.** None by default. With the option enabled, applications that rename attributes through a custom claim dialect and rendered the scope grouped selector render the local dialect selector instead. They gain the attribute name mapping toggle and see their real per application names, and lose the scope grouping. Applications whose custom dialect renames no attribute are not moved, since they display correctly today. If the last renamed attribute is removed while other mappings remain, the application returns to the scope grouped selector the next time it is opened.




