### PR TITLE
Paginate the user group assignment list and show the selection count

### DIFF
--- a/.changeset/brave-otters-scroll.md
+++ b/.changeset/brave-otters-scroll.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/console": patch
+"@wso2is/admin.users.v1": patch
+"@wso2is/i18n": patch
+---
+
+Paginate the group assignment list in the user Groups tab and show how many of the listed groups are selected

--- a/features/admin.users.v1/components/user-groups-edit.tsx
+++ b/features/admin.users.v1/components/user-groups-edit.tsx
@@ -34,6 +34,7 @@ import { addAlert } from "@wso2is/core/store";
 import { StringUtils } from "@wso2is/core/utils";
 import {
     Heading,
+    Hint,
     ItemTypeLabelPropsInterface,
     LinkButton,
     PrimaryButton,
@@ -53,6 +54,11 @@ import {
     Modal
 } from "semantic-ui-react";
 import { UserGroupsListTable } from "./user-groups-list";
+
+/**
+ * Number of groups fetched per page in the group assignment modal.
+ */
+const GROUPS_FETCH_LIMIT: number = 100;
 
 interface UserGroupsPropsInterface {
     /**
@@ -110,6 +116,14 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
     const [ searchQuery, setSearchQuery ] = useState<string>(null);
 
+    /**
+     * Groups are fetched a page at a time and accumulated here, so that the modal is not
+     * limited to the first page returned by the API.
+     */
+    const [ fetchedGroups, setFetchedGroups ] = useState<GroupsInterface[]>([]);
+    const [ groupsStartIndex, setGroupsStartIndex ] = useState<number>(1);
+    const [ hasMoreGroups, setHasMoreGroups ] = useState<boolean>(false);
+
     const domain: string = user?.userName?.split("/")?.length > 1
         ? user.userName.split("/")[0]
         : userstoresConfig.primaryUserstoreName;
@@ -121,18 +135,18 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
         isLoading: isGroupsListFetchRequestLoading,
         isValidating: isGroupsListFetchRequestValidating
     } = useGroupList(
-        null,
-        null,
+        GROUPS_FETCH_LIMIT,
+        groupsStartIndex,
         searchQuery,
         domain,
         excludedAttributes
     );
 
     const groupsList: GroupsInterface[] = useMemo(() => {
-        if (originalGroupsList?.Resources) {
+        if (fetchedGroups?.length > 0) {
             const filteredGroups: GroupsInterface[] = [];
 
-            originalGroupsList.Resources.map((group: GroupsInterface) => {
+            fetchedGroups.map((group: GroupsInterface) => {
                 let isGroupExistInUser: boolean = false;
 
                 if (user?.groups?.length > 0) {
@@ -153,11 +167,84 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
         }
 
         return [];
-    }, [ originalGroupsList ]);
+    }, [ fetchedGroups, user?.groups ]);
 
     const isLoading: boolean = useMemo(() => {
         return isGroupsListFetchRequestLoading || isGroupsListFetchRequestValidating;
     }, [ isGroupsListFetchRequestLoading, isGroupsListFetchRequestValidating ]);
+
+    /**
+     * Only the very first page should replace the list with a loading placeholder. Later
+     * pages are appended below the groups that are already rendered.
+     */
+    const isInitialGroupsLoading: boolean = isLoading && fetchedGroups.length === 0;
+
+    /**
+     * Accumulate each page returned by the API.
+     */
+    useEffect(() => {
+        if (!originalGroupsList) {
+            return;
+        }
+
+        const page: GroupsInterface[] = originalGroupsList.Resources ?? [];
+        const isPageFull: boolean = page.length === GROUPS_FETCH_LIMIT;
+
+        setFetchedGroups((previousGroups: GroupsInterface[]) => {
+            const merged: GroupsInterface[] = [ ...previousGroups ];
+
+            // Guard against the same page being appended twice on revalidation.
+            page.forEach((group: GroupsInterface) => {
+                if (!merged.some((item: GroupsInterface) => item.id === group.id)) {
+                    merged.push(group);
+                }
+            });
+
+            return merged;
+        });
+
+        // A page that is not full is the last one. The listing is capped by the server's
+        // maximum group list length, which is expected to be configured above the number
+        // of groups in the server, so reaching the end here means the whole list is loaded.
+        setHasMoreGroups(isPageFull);
+    }, [ originalGroupsList ]);
+
+    /**
+     * Loads the next page of groups when the list is scrolled to the bottom.
+     */
+    const loadMoreGroups: () => void = useCallback(() => {
+        if (!hasMoreGroups || isLoading) {
+            return;
+        }
+
+        // The scroll observer can fire again before the state of the page in flight has
+        // settled. Advance only once every group of the current page has been collected,
+        // so that a page is never skipped or requested twice.
+        if (fetchedGroups.length < groupsStartIndex - 1 + GROUPS_FETCH_LIMIT) {
+            return;
+        }
+
+        setGroupsStartIndex((previousStartIndex: number) => previousStartIndex + GROUPS_FETCH_LIMIT);
+    }, [ hasMoreGroups, isLoading, fetchedGroups.length, groupsStartIndex ]);
+
+    /**
+     * Restart pagination whenever the search query changes, so that results of the previous
+     * query are not mixed with the new one.
+     */
+    useEffect(() => {
+        setFetchedGroups([]);
+        setGroupsStartIndex(1);
+        setHasMoreGroups(false);
+    }, [ searchQuery ]);
+
+    /**
+     * A newly loaded page brings in groups that are not selected yet, so the header
+     * checkbox must stop claiming that everything in the list is selected.
+     */
+    useEffect(() => {
+        setIsSelectAllGroupsChecked(
+            groupsList.length > 0 && selectedGroupsList.length === groupsList.length);
+    }, [ groupsList ]);
 
     /**
      * Show error if group list fetch request failed.
@@ -407,7 +494,9 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
                     <TransferList
                         bordered={ false }
                         isListEmpty={ groupsList?.length === 0 }
-                        isLoading={ isLoading }
+                        isLoading={ isInitialGroupsLoading }
+                        hasMore={ hasMoreGroups }
+                        loadMore={ loadMoreGroups }
                         listType="unselected"
                         listHeaders={ [
                             t("transferList:list.headers.0"),
@@ -447,6 +536,35 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
             </Modal.Content>
             <Modal.Actions>
                 <Grid>
+                    { !isInitialGroupsLoading && groupsList.length > 0 && (
+                        <Grid.Row columns={ 1 }>
+                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
+                                <Hint
+                                    compact
+                                    data-componentid="user-mgt-update-groups-modal-selection-summary"
+                                >
+                                    { t("user:updateUser.groups.addGroupsModal.selectionSummary", {
+                                        selected: selectedGroupsList?.length ?? 0,
+                                        total: groupsList.length
+                                    }) }
+                                    {
+                                        // A full page means there are more groups still to load.
+                                        // Say so before the list is scrolled, so that selecting
+                                        // all is never mistaken for selecting every group. Once
+                                        // the last page has arrived the list is complete and
+                                        // nothing more needs to be said.
+                                        hasMoreGroups && (
+                                            <>
+                                                { " " }
+                                                { t("user:updateUser.groups.addGroupsModal" +
+                                                    ".listIncomplete") }
+                                            </>
+                                        )
+                                    }
+                                </Hint>
+                            </Grid.Column>
+                        </Grid.Row>
+                    ) }
                     <Grid.Row columns={ 2 }>
                         <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 8 }>
                             <LinkButton

--- a/features/admin.users.v1/components/user-groups-edit.tsx
+++ b/features/admin.users.v1/components/user-groups-edit.tsx
@@ -238,13 +238,33 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
     }, [ searchQuery ]);
 
     /**
+     * Whether every group currently listed is among the selected ones. The two lists are
+     * compared by id rather than by length, because a selection made before a search is
+     * kept while the listing narrows, and the counts can then match without the listed
+     * groups being the selected ones.
+     */
+    const countSelectedAmongListed = (
+        listed: GroupsInterface[],
+        selected: GroupsInterface[]
+    ): number =>
+        listed.filter((group: GroupsInterface) =>
+            selected.some((item: GroupsInterface) => item.id === group.id)).length;
+
+    const areAllListedGroupsSelected = (
+        listed: GroupsInterface[],
+        selected: GroupsInterface[]
+    ): boolean =>
+        listed.length > 0
+        && listed.every((group: GroupsInterface) =>
+            selected.some((item: GroupsInterface) => item.id === group.id));
+
+    /**
      * A newly loaded page brings in groups that are not selected yet, so the header
      * checkbox must stop claiming that everything in the list is selected.
      */
     useEffect(() => {
-        setIsSelectAllGroupsChecked(
-            groupsList.length > 0 && selectedGroupsList.length === groupsList.length);
-    }, [ groupsList ]);
+        setIsSelectAllGroupsChecked(areAllListedGroupsSelected(groupsList, selectedGroupsList));
+    }, [ groupsList, selectedGroupsList ]);
 
     /**
      * Show error if group list fetch request failed.
@@ -305,7 +325,7 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
         }
 
         setSelectedGroupList(checkedGroups);
-        setIsSelectAllGroupsChecked(checkedGroups.length === groupsList.length);
+        setIsSelectAllGroupsChecked(areAllListedGroupsSelected(groupsList, checkedGroups));
     };
 
     const handleOpenAddNewGroupModal = () => {
@@ -544,7 +564,8 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
                                     data-componentid="user-mgt-update-groups-modal-selection-summary"
                                 >
                                     { t("user:updateUser.groups.addGroupsModal.selectionSummary", {
-                                        selected: selectedGroupsList?.length ?? 0,
+                                        selected: countSelectedAmongListed(
+                                            groupsList, selectedGroupsList),
                                         total: groupsList.length
                                     }) }
                                     {

--- a/modules/i18n/src/models/namespaces/user-ns.ts
+++ b/modules/i18n/src/models/namespaces/user-ns.ts
@@ -796,6 +796,8 @@ export interface userNS {
         groups: {
             addGroupsModal: {
                 heading: string;
+                listIncomplete: string;
+                selectionSummary: string;
                 subHeading: string;
             };
             editGroups: {

--- a/modules/i18n/src/translations/en-US/portals/user.ts
+++ b/modules/i18n/src/translations/en-US/portals/user.ts
@@ -837,6 +837,9 @@ export const user: userNS = {
         groups: {
             addGroupsModal: {
                 heading: "Update User Groups",
+                listIncomplete: "More groups may be available. Scroll down to load them, or "
+                    + "search by name.",
+                selectionSummary: "{{selected}} of {{total}} listed groups selected.",
                 subHeading: "Add new groups or remove existing groups assigned to the user."
             },
             editGroups: {


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-is/issues/28294

The group assignment modal in the user Groups tab calls `useGroupList` with no
`count` and no `startIndex`, so it only ever holds the first page the API
returns. "Select all" then selects that page alone, and nothing on screen says
that more groups exist. On a server holding 151 groups, selecting all and saving
assigns 100 and reports success.

## Approach

1. Fetch groups a page at a time and append each page as the list is scrolled,
   so the modal is no longer limited to one page. This uses the `hasMore` /
   `loadMore` support that `TransferList` already has.
2. Show how many of the listed groups are selected, so that "select all" cannot
   be mistaken for selecting every group in the server.
3. While pages are still outstanding, say so, so that selecting all before the
   list has been scrolled is not mistaken for a complete selection. Once the last
   page has arrived the message goes away.

## Note on the server side listing limit

The SCIM2 Groups listing is capped by the user store's `MaxRoleNameListLength`,
which defaults to 100. When a listing is clipped by it, the endpoint reports the
clipped number as `totalResults`, so a capped listing and a complete listing of
exactly that many groups are indistinguishable from the client. `count`
variations, `sortBy`, a `gt` filter and the `.search` endpoint were all checked
and none reports the real total.

This change therefore assumes the server is configured with a
`MaxRoleNameListLength` above the number of groups it holds. Reaching the end of
the listing is then taken to mean the whole list has been loaded. Reporting the
true total regardless of that limit would be a server side change and is not
part of this PR.

## Testing

Verified against a WSO2 IS 7.4.0-SNAPSHOT pack holding 151 groups, with
`max_role_name_list_length` set above that.

| Case | Result |
| --- | --- |
| Open the modal | 100 rows, "0 of 100 listed groups selected" plus the message that more may be available |
| Scroll to the end | 151 rows, message gone |
| Select all, save | 151 assigned, 0 missing, confirmed from the group side past the first page |
| Close and reopen after scrolling | 151 rows kept, no message, no further requests |
| User already holding 3 of the groups | 148 rows, those 3 absent, the neighbouring group present |
| Search for a group beyond the first page | narrows to that group |
| Result set under one page | count shown, no message |

Behaviour with the server default limit of 100 was also checked: the listing
stops at 100, which is the server ceiling rather than a limit of this modal.

A support branch backport of the same change is at
https://github.com/wso2-support/identity-apps/pull/1463

## Demo 

https://github.com/user-attachments/assets/e2a1f5a9-34b2-406b-bc5b-251fe32f0617


