### PR TITLE
Correct the option values of the SAML user ID location field

### DIFF
--- a/.changeset/saml-user-id-location-options.md
+++ b/.changeset/saml-user-id-location-options.md
@@ -1,0 +1,11 @@
+---
+"@wso2is/admin.identity-providers.v1": patch
+"@wso2is/admin.connections.v1": patch
+"@wso2is/console": patch
+---
+
+Fix the option values of the SAML connection's User ID Location field, which were wired to the inverse
+booleans of the `IsUserIdInClaims` property. `Use NameID as the User Identifier` mapped to `true` and
+`User Identifier found among claims` to `false`, while the authenticator reads `false` as NameID and
+`true` as claims. Every SAML connection was therefore rendered with the opposite user ID location to
+the one stored, and selecting an option persisted the opposite boolean.

--- a/features/admin.connections.v1/components/edit/forms/helpers/form-fields-helper.tsx
+++ b/features/admin.connections.v1/components/edit/forms/helpers/form-fields-helper.tsx
@@ -196,11 +196,11 @@ const getUserIdClaimRadioButtonField = (
     const options: StrictRadioChild[] = [
         {
             label: "Use NameID as the User Identifier",
-            value: "true"
+            value: "false"
         },
         {
             label: "User Identifier found among claims",
-            value: "false"
+            value: "true"
         }
     ];
 

--- a/features/admin.identity-providers.v1/components/forms/helpers/form-fields-helper.tsx
+++ b/features/admin.identity-providers.v1/components/forms/helpers/form-fields-helper.tsx
@@ -205,11 +205,11 @@ const getUserIdClaimRadioButtonField = (
     const options: StrictRadioChild[] = [
         {
             label: "Use NameID as the User Identifier",
-            value: "true"
+            value: "false"
         },
         {
             label: "User Identifier found among claims",
-            value: "false"
+            value: "true"
         }
     ];
 


### PR DESCRIPTION
### Purpose

On the SAML connection's federated authenticator settings, the **User ID Location** radio group had its two options wired to the inverse boolean values of the `IsUserIdInClaims` property.

The runtime authenticator semantics are:

- `IsUserIdInClaims = false` → the user identifier is taken from the SAML `NameID`.
- `IsUserIdInClaims = true` → the user identifier is found among the claims.

The Console mapped `Use NameID as the User Identifier` to `"true"` and `User Identifier found among claims` to `"false"`. As a result every SAML connection was rendered with the opposite user ID location to the one actually stored, and selecting an option persisted the opposite boolean.

Implementation notes:

- Swapped the `value` of the two radio options in `getUserIdClaimRadioButtonField` so each label maps to the boolean the authenticator expects. The value flows straight through to the property with no compensating inversion elsewhere in the field path, so the swap is the whole fix.
- Both copies of the helper are updated, since `admin.connections.v1` and the older `admin.identity-providers.v1` each carry their own version:
  - `features/admin.connections.v1/components/edit/forms/helpers/form-fields-helper.tsx`
  - `features/admin.identity-providers.v1/components/forms/helpers/form-fields-helper.tsx`

### Related Issues
- https://github.com/wso2/product-is/issues/28333

### Related PRs
<!-- The support-branch counterpart is in a private repository; omitted here as the template asks for publicly accessible references only. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
