### PR TITLE
Remove redundant authorization header from HYPR and iProov login pages

### DIFF
--- a/.changeset/quiet-pandas-shave.md
+++ b/.changeset/quiet-pandas-shave.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Remove redundant authorization header from HYPR and iProov login pages

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/hyprlogin.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/hyprlogin.jsp
@@ -21,7 +21,6 @@
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
 <%@ page import="org.wso2.carbon.identity.core.util.IdentityCoreConstants" %>
 <%@ page import="org.wso2.carbon.identity.core.util.IdentityUtil" %>
-<%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.EndpointConfigManager" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthenticationEndpointUtil" %>
 <%@ page import="static org.wso2.carbon.identity.application.authentication.endpoint.util.Constants.STATUS" %>
 <%@ page import="static org.wso2.carbon.identity.application.authentication.endpoint.util.Constants.STATUS_MSG" %>
@@ -29,8 +28,6 @@
 <%@ page import="static org.wso2.carbon.identity.application.authentication.endpoint.util.Constants.AUTHENTICATION_MECHANISM_NOT_CONFIGURED" %>
 <%@ page import="static org.wso2.carbon.identity.application.authentication.endpoint.util.Constants.ENABLE_AUTHENTICATION_WITH_REST_API" %>
 <%@ page import="static org.wso2.carbon.identity.application.authentication.endpoint.util.Constants.ERROR_WHILE_BUILDING_THE_ACCOUNT_RECOVERY_ENDPOINT_URL" %>
-<%@ page import="java.nio.charset.Charset" %>
-<%@ page import="org.apache.commons.codec.binary.Base64" %>
 <%@ page import="java.io.File" %>
 <%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.Arrays" %>
@@ -143,11 +140,6 @@
     <% } %>
 
     <%
-        String toEncode = EndpointConfigManager.getAppName() + ":" + String.valueOf(EndpointConfigManager.getAppPassword());
-        byte[] encoding = Base64.encodeBase64(toEncode.getBytes());
-        String authHeader = new String(encoding, Charset.defaultCharset());
-        String header = "Client " + authHeader;
-        
         // Handle error message with precedence for request parameter but fallback to generic message
         String errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "hypr.generic.error");
         String error = request.getParameter("message");
@@ -226,9 +218,6 @@
                 } else {
                     $.ajax("<%= Encode.forJavaScriptBlock(identityServerEndpointContextParam)%>" + authStatusCheckApiWithQueryParams + sessionDataKey, {
                     method: GET,
-                    headers: {
-                        "Authorization": "<%=header%>"
-                    },
                     success: function (res) {
                         handleStatusResponse(res);
                     },

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/iproovlogin.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/iproovlogin.jsp
@@ -21,7 +21,6 @@
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
 <%@ page import="org.wso2.carbon.identity.core.util.IdentityCoreConstants" %>
 <%@ page import="org.wso2.carbon.identity.core.util.IdentityUtil" %>
-<%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.EndpointConfigManager" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthenticationEndpointUtil" %>
 <%@ page import="static org.wso2.carbon.identity.application.authentication.endpoint.util.Constants.STATUS" %>
 <%@ page import="static org.wso2.carbon.identity.application.authentication.endpoint.util.Constants.STATUS_MSG" %>
@@ -29,8 +28,6 @@
 <%@ page import="static org.wso2.carbon.identity.application.authentication.endpoint.util.Constants.AUTHENTICATION_MECHANISM_NOT_CONFIGURED" %>
 <%@ page import="static org.wso2.carbon.identity.application.authentication.endpoint.util.Constants.ENABLE_AUTHENTICATION_WITH_REST_API" %>
 <%@ page import="static org.wso2.carbon.identity.application.authentication.endpoint.util.Constants.ERROR_WHILE_BUILDING_THE_ACCOUNT_RECOVERY_ENDPOINT_URL" %>
-<%@ page import="java.nio.charset.Charset" %>
-<%@ page import="org.apache.commons.codec.binary.Base64" %>
 <%@ page import="java.io.File" %>
 <%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.Arrays" %>
@@ -240,13 +237,6 @@
     <% } else { %>
         <jsp:include page="includes/footer.jsp"/>
     <% } %>
-
-    <%
-        String toEncode = EndpointConfigManager.getAppName() + ":" + String.valueOf(EndpointConfigManager.getAppPassword());
-        byte[] encoding = Base64.encodeBase64(toEncode.getBytes());
-        String authHeader = new String(encoding, Charset.defaultCharset());
-        String header = "Client " + authHeader;
-    %>
 
     <script type="text/javascript">
         var i = 0;


### PR DESCRIPTION
## Purpose

Removes code in the authentication portal that serves no purpose:

- `hyprlogin.jsp` builds a `Client <base64>` `Authorization` header and sends it on the HYPR authentication status `$.ajax` call. That endpoint does not require the header, so building and sending it is redundant.
- `iproovlogin.jsp` builds the same header in a scriptlet block that is never referenced anywhere in the page.

The imports that only those blocks used (`EndpointConfigManager`, `Base64`, `Charset`) are dropped along with them.

## Related Issues
N/A

## Related PRs
N/A

## Checklist
- [x] Deletion only — no behavioural change to the HYPR or iProov flows.
- [x] No new imports or dependencies.