### PR TITLE
Add application level token exchange scope restriction configuration to Console

### DIFF
--- a/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
+++ b/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
@@ -388,6 +388,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
     const notificationChannels: MutableRefObject<HTMLDivElement> = useRef<HTMLDivElement>();
     const cibaSkipUserValidation: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
     const cibaAllowFederatedUsers: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
+    const tokenExchangeRestrictScopeIssuanceForFederatedTokens: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
 
     const [ isSPAApplication, setSPAApplication ] = useState<boolean>(false);
     const [ isOIDCWebApplication, setOIDCWebApplication ] = useState<boolean>(false);
@@ -407,6 +408,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
     const [ sharedOrganizationsList, setSharedOrganizationsList ] = useState<Array<OrganizationInterface>>(undefined);
     const [ enableHybridFlowResponseTypeField , setEnableHybridFlowResponseTypeField ] = useState<boolean>(undefined);
     const [ showCibaFields, setShowCibaFields ] = useState<boolean>(false);
+    const [ showTokenExchangeFields, setShowTokenExchangeFields ] = useState<boolean>(false);
     const [ isSkipUserValidationEnabled, setIsSkipUserValidationEnabled ] = useState<boolean>(
         initialValues?.cibaAuthenticationRequest?.skipUserValidation ?? false
     );
@@ -784,6 +786,12 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
     useEffect(() => {
         setShowCibaFields(
             selectedGrantTypes?.includes(ApplicationManagementConstants.CIBA_GRANT) ?? false
+        );
+    }, [ selectedGrantTypes, isGrantChanged ]);
+
+    useEffect(() => {
+        setShowTokenExchangeFields(
+            selectedGrantTypes?.includes(ApplicationManagementConstants.OAUTH2_TOKEN_EXCHANGE) ?? false
         );
     }, [ selectedGrantTypes, isGrantChanged ]);
 
@@ -1769,6 +1777,16 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                         authReqExpiryTime: undefined,
                         notificationChannels: [],
                         skipUserValidation: false
+                    }
+                };
+            }
+
+            if (showTokenExchangeFields) {
+                inboundConfigFormValues = {
+                    ...inboundConfigFormValues,
+                    tokenExchange: {
+                        restrictScopeIssuanceForFederatedTokens:
+                            values.get("tokenExchangeRestrictScopeIssuanceForFederatedTokens")?.length > 0
                     }
                 };
             }
@@ -3076,6 +3094,46 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                         showEmptyLinkText
                                     > hybrid flow </DocumentationLink> response type.
                                 </Trans>
+                            </Hint>
+                        </Grid.Column>
+                    </Grid.Row>
+                )
+            }
+
+            {
+                showTokenExchangeFields && (
+                    <Grid.Row columns={ 2 }>
+                        <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
+                            <Divider />
+                            <Divider hidden />
+                        </Grid.Column>
+                        <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
+                            <Heading as="h4">
+                                { t("applications:forms.inboundOIDC.fields.tokenExchange.heading") }
+                            </Heading>
+                            <Field
+                                ref={ tokenExchangeRestrictScopeIssuanceForFederatedTokens }
+                                name="tokenExchangeRestrictScopeIssuanceForFederatedTokens"
+                                required={ false }
+                                type="checkbox"
+                                value={
+                                    initialValues?.tokenExchange?.restrictScopeIssuanceForFederatedTokens
+                                        ? [ "tokenExchangeRestrictScopeIssuanceForFederatedTokens" ]
+                                        : []
+                                }
+                                children={ [
+                                    {
+                                        label: t("applications:forms.inboundOIDC.fields." +
+                                            "tokenExchange.restrictScopeIssuanceForFederatedTokens.label"),
+                                        value: "tokenExchangeRestrictScopeIssuanceForFederatedTokens"
+                                    }
+                                ] }
+                                readOnly={ readOnly }
+                                data-componentid={ `${ testId }-token-exchange-restrict-scopes-checkbox` }
+                            />
+                            <Hint>
+                                { t("applications:forms.inboundOIDC.fields." +
+                                    "tokenExchange.restrictScopeIssuanceForFederatedTokens.hint") }
                             </Hint>
                         </Grid.Column>
                     </Grid.Row>

--- a/features/admin.applications.v1/models/application-inbound.ts
+++ b/features/admin.applications.v1/models/application-inbound.ts
@@ -210,6 +210,13 @@ interface CIBAAuthenticationConfigurationInterface {
     skipUserValidation?: boolean;
 }
 
+/**
+ * Token exchange related properties.
+ */
+interface TokenExchangeConfigurationInterface {
+    restrictScopeIssuanceForFederatedTokens?: boolean;
+}
+
 interface OIDCLogoutConfigurationInterface {
     backChannelLogoutUrl?: string;
     frontChannelLogoutUrl?: string;
@@ -244,6 +251,7 @@ export interface OIDCDataInterface {
     fapiProfile?: FapiProfile;
     hybridFlow?: HybridFlowConfigurationInterface;
     cibaAuthenticationRequest?: CIBAAuthenticationConfigurationInterface;
+    tokenExchange?: TokenExchangeConfigurationInterface;
     issuer?: AllowedIssuerInterface;
 }
 

--- a/modules/i18n/src/models/namespaces/applications-ns.ts
+++ b/modules/i18n/src/models/namespaces/applications-ns.ts
@@ -1679,6 +1679,13 @@ export interface ApplicationsNS {
                         label: string;
                     };
                     heading: string;
+                };
+                tokenExchange: {
+                    restrictScopeIssuanceForFederatedTokens: {
+                        hint: string;
+                        label: string;
+                    };
+                    heading: string;
                 }
             };
             mobileApp: {

--- a/modules/i18n/src/translations/en-US/portals/applications.ts
+++ b/modules/i18n/src/translations/en-US/portals/applications.ts
@@ -1971,6 +1971,14 @@ export const applications: ApplicationsNS = {
                         label: "Allow federated users"
                     },
                     heading: "Client Initiated Backchannel Authentication"
+                },
+                tokenExchange: {
+                    heading: "Token Exchange",
+                    restrictScopeIssuanceForFederatedTokens: {
+                        hint: "When enabled, the server does not issue scopes for tokens obtained " +
+                            "by exchanging a federated token.",
+                        label: "Restrict scope issuance for federated tokens"
+                    }
                 }
             },
             messages: {


### PR DESCRIPTION
## Purpose

Let administrators configure the token exchange scope restriction for federated subject tokens from the Console.

Related issue: https://github.com/wso2/product-is/issues/28406

## Description

Adds a Token Exchange section to the OIDC protocol settings, rendered only when the token exchange grant is selected.

- `showTokenExchangeFields` is derived from the selected grant types and keeps the section hidden otherwise.
- The `tokenExchangeRestrictScopeIssuanceForFederatedTokens` checkbox is unchecked by default and is only included in the submit payload while the section is visible.
- Adds the field to the OIDC inbound model, and the label and hint copy to the i18n namespace and `en-US` translations.

Existing applications show the checkbox unchecked, matching the permissive backend default.